### PR TITLE
Refactor/DEV-8270: Remove file extension from iiif image output directory

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -76,7 +76,7 @@ export default async function () {
         iiifTiler
       )} -config-source file://${path.normalize(__dirname)}${path.normalize(
         iiifConfig
-      )} -quality default -verbose -refresh -scale-factors 128,64,32,16,8,4,2,1,0 ${imageName}`;
+      )} -quality default -verbose -refresh -noextension -scale-factors 128,64,32,16,8,4,2,1,0 ${imageName}`;
 
       return new Promise(function (resolve, reject) {
         // execSync(cmd); // alternative command, more console logs

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -123,14 +123,14 @@ export default async function () {
           let stat = fs.lstatSync(fullPath);
           let fullProcessPath = path.join(iiifProcessed, files[i]);
 
-          const params = [".jpg", ".jpeg", ".png", ".svg", ".jp2"];
+          const fileExtensions = [".jpg", ".jpeg", ".png", ".svg", ".jp2"];
           if (stat.isDirectory()) {
             spinner.fail(
               `Directories found! Please delete and move images you'd like to slice to ${iiifSeed}`
             );
             throw new error();
           } else {
-            if (params.some((el) => fullPath.includes(el))) {
+            if (fileExtensions.some((extension) => fullPath.toLowerCase().includes(extension))) {
               images.push(fullPath);
             } else {
               spinner.fail(`No images found! Add images in: ${iiifSeed}`);

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -6,11 +6,12 @@ const rimraf = require("rimraf");
 import { isWin } from "./utils";
 
 /**
- * imageslice - image slicing
- * @description Slice images to IIIF standard.  It determines has a few requirements.
- * It needs to have the images that need to be sliced, living in `static/img/iiif`, so
- * that the script will look for any images in there to slice and create the folders/zoom depth.
- * If it happens to detect folders are already there, it'll error out and tell you to remove them
+ * imageslice
+ *
+ * @description Tile images to IIIF Image API level 0 specification
+ *
+ * Images in `static/img/iiif/images` will be tiled and output to `static/img/iiif/processed/{image_filename}`
+ * If an existing processed image directory with the same name is found, it will be removed and re-written
  */
 export default async function () {
   return new Promise((resolve) => {


### PR DESCRIPTION
- Renames variables to more clearly indicate original vs destination paths
- Uses path.parse to derive filenames and extensions
- Adds `-noextension` option to go-iiif command to remove file extension from output directory name