### PR TITLE
FIx/DEV-7773: Preserve content position when image modal is opened

### DIFF
--- a/themes/default/source/js/popup.js
+++ b/themes/default/source/js/popup.js
@@ -120,7 +120,7 @@ export default function(gallerySelector, mapArr) {
     type: "image",
     closeBtnInside: false,
     closeOnBgClick: false,
-    fixedContentPos: "auto",
+    fixedContentPos: false,
     fixedBgPos: "auto",
     overflowY: "hidden",
     image: {


### PR DESCRIPTION
Set `fixedContentPos` (see: [Magnific Popup Docs](https://dimsemenov.com/plugins/magnific-popup/documentation.html)) to `false`, which will preserve the content position while the modal is opened and closed. 