### PR TITLE
Fix/DEV-7105: Load image sets with only IIIF images

### DIFF
--- a/themes/default/source/js/application.js
+++ b/themes/default/source/js/application.js
@@ -104,7 +104,7 @@ window["toggleSearch"] = () => {
  * @description Set up the simple image slider used on catalogue entry pages for
  * objects with multiple figure images. See also slideImage function below.
  */
-function sliderSetup() {
+async function sliderSetup() {
   toggleFullscreen(
     mapArr,
     document.getElementById("toggleFullscreen"),
@@ -132,17 +132,16 @@ function sliderSetup() {
     firstImage.css("display", "flex");
     lastImage.addClass("last-image");
   });
-  let images = [...document.querySelectorAll(".quire-deepzoom-entry")]
-    .filter(v => {
+  const images = [...document.querySelectorAll(".quire-deepzoom-entry")];
+  const imageSrcs = images.filter(v => {
       return v.getAttribute("src") !== null ? v : "";
     })
     .map(v => {
       return v.getAttribute("src");
     });
-  preloadImages(images, () => {
-    mapSetup(".quire-map-entry");
-    deepZoomSetup(".quire-deepzoom-entry", mapArr);
-  });
+  await preloadImages(imageSrcs);
+  mapSetup(".quire-map-entry");
+  deepZoomSetup(".quire-deepzoom-entry", mapArr);
 }
 
 /**

--- a/themes/default/source/js/helper.js
+++ b/themes/default/source/js/helper.js
@@ -107,19 +107,12 @@ export const enableScroll = element => {
  * @return {Promise}
  */
 export const preloadImages = (srcs) => {
-  return new Promise((resolve, reject) => {
-    if (!srcs.length) {
-      resolve();
-    }
-    let img;
-    let remaining = srcs.length;
-    for (let i = 0; i < srcs.length; i++) {
-      img = new Image();
+  return new Promise((resolve) => {
+    if (!srcs.length) resolve();
+    for (let i = srcs.length; i >= 0; --i) {
+      const img = new Image();
       img.onload = () => {
-        --remaining;
-        if (remaining <= 0) {
-          resolve();
-        }
+        if (i <= 0) resolve();
       };
       img.src = srcs[i];
     }

--- a/themes/default/source/js/helper.js
+++ b/themes/default/source/js/helper.js
@@ -102,8 +102,9 @@ export const enableScroll = element => {
 };
 
 /**
- * Preload
+ * Preload Images
  * @param  {Array} srcs array of images
+ * @return {Promise}
  */
 export const preloadImages = (srcs) => {
   return new Promise((resolve, reject) => {

--- a/themes/default/source/js/helper.js
+++ b/themes/default/source/js/helper.js
@@ -105,19 +105,24 @@ export const enableScroll = element => {
  * Preload
  * @param  {Array} srcs array of images
  */
-export const preloadImages = (srcs, callback) => {
-  let img;
-  let remaining = srcs.length;
-  for (let i = 0; i < srcs.length; i++) {
-    img = new Image();
-    img.onload = () => {
-      --remaining;
-      if (remaining <= 0) {
-        callback();
-      }
-    };
-    img.src = srcs[i];
-  }
+export const preloadImages = (srcs) => {
+  return new Promise((resolve, reject) => {
+    if (!srcs.length) {
+      resolve();
+    }
+    let img;
+    let remaining = srcs.length;
+    for (let i = 0; i < srcs.length; i++) {
+      img = new Image();
+      img.onload = () => {
+        --remaining;
+        if (remaining <= 0) {
+          resolve();
+        }
+      };
+      img.src = srcs[i];
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
Fixes: 
- Previously, `deepZoomSetup`  was a callback of `preloadImages` which is only called on images with a `src` attribute. Changing `preloadImages` to a function that returns a promise, and resolves when passed an empty array so that `deepZoomSetup` and `mapSetup` are called whether or not images with `src` attributes are present.