### PR TITLE
Fix/DEV-8259: Replace starter project .gitignore

### DIFF
--- a/starters/default/.gitignore
+++ b/starters/default/.gitignore
@@ -1,0 +1,16 @@
+# Quire starter project ignored files
+
+.DS_Store
+.bundle
+.cache
+.sass-cache
+public
+site
+node_modules
+.tmp
+build
+Gemfile.lock
+themes/default/static/css/application.css
+themes/default/static/js/application.js
+themes/default/tests/e2e/
+themes/default/test-results/

--- a/starters/default/.gitignore
+++ b/starters/default/.gitignore
@@ -1,16 +1,14 @@
 # Quire starter project ignored files
-
 .DS_Store
 .bundle
 .cache
 .sass-cache
-public
-site
-node_modules
 .tmp
 build
-Gemfile.lock
+node_modules
+public
+site
 themes/default/static/css/application.css
 themes/default/static/js/application.js
-themes/default/tests/e2e/
 themes/default/test-results/
+themes/default/tests/e2e/


### PR DESCRIPTION
Moving to the monorepo we combined all the `.gitignore` files at the root, but new Quire projects still need a `.gitignore`. 