### PR TITLE
Fix/DEV-7773: Preserve scroll position when popups are opened

### DIFF
--- a/themes/default/layouts/shortcodes/q-figure-group.html
+++ b/themes/default/layouts/shortcodes/q-figure-group.html
@@ -129,9 +129,8 @@ the figure for each into a figure group
 
      {{ $Id := now.UnixNano }}
 
-  <div class="q-figure__wrapper">
+  <div id="deepzoom-{{ $Id }}" class="q-figure__wrapper">
     <figure 
-      id="deepzoom-{{ $Id }}"
       {{ if .caption }} title='{{ .caption | markdownify | safeHTML }}' {{ end }}  
       class="quire-figure leaflet-outer-wrapper mfp-hide">
         <div 

--- a/themes/default/layouts/shortcodes/q-figure-zoom.html
+++ b/themes/default/layouts/shortcodes/q-figure-zoom.html
@@ -23,14 +23,11 @@ document and render only the values given in the shortcode
 
 {{ if eq $.Site.Params.figureModal true }}
 
-<div class="q-figure__wrapper">
-
 {{ if eq (.Get "media_type") "map" }}
 
 {{ $Id := now.UnixNano }}
-
+  <div id="map-{{ $Id }}" class="q-figure__wrapper">
     <figure       
-      id="map-{{ $Id }}" 
       {{ if .Get "caption" }} title='{{ .Get "caption" | markdownify | safeHTML }}' {{ end }} 
       class="quire-figure leaflet-outer-wrapper mfp-hide">
         <div 
@@ -66,9 +63,8 @@ document and render only the values given in the shortcode
 {{ else if eq (.Get "media_type") "iiif" }}
 
 {{ $Id := now.UnixNano }}
-
+    <div id="iiif-{{ $Id }}" class="q-figure__wrapper">
       <figure    
-      id="iiif-{{ $Id }}" 
       {{ if .Get "caption" }}  title='{{ .Get "caption" | markdownify | safeHTML }}' {{ end }} 
       class="quire-figure leaflet-outer-wrapper mfp-hide">
         <div 
@@ -106,9 +102,8 @@ document and render only the values given in the shortcode
 {{ else }}
 
 {{ $Id := now.UnixNano }}
-
+<div id="deepzoom-{{ $Id }}" class="q-figure__wrapper">
   <figure   
-  id="deepzoom-{{ $Id }}" 
   {{ if .Get "caption" }}  
   title='{{ .Get "caption" | markdownify | safeHTML }}' {{ end }} 
   class="quire-figure leaflet-outer-wrapper mfp-hide">
@@ -296,14 +291,11 @@ alt='{{ with .Get "alt" }}{{ . }}{{ end }}' />
 
 {{ if eq $.Site.Params.figureModal true }}
 
-<div class="q-figure__wrapper">
-
 {{ if eq .media_type "map"  }}
 
 {{ $Id := now.UnixNano }}
-
+    <div id="map-{{ $Id }}" class="q-figure__wrapper">
       <figure 
-        id="map-{{ $Id }}" 
         {{ if .caption }} title='{{ .caption | markdownify | safeHTML }}' {{ end }} 
         class="quire-figure leaflet-outer-wrapper mfp-hide">
         <div 
@@ -337,9 +329,8 @@ alt='{{ with .Get "alt" }}{{ . }}{{ end }}' />
 {{ else if eq .media_type "iiif" }}
 
 {{ $Id := now.UnixNano }}
-
+  <div id="iiif-{{ $Id }}" class="q-figure__wrapper">
     <figure 
-    id="iiif-{{ $Id }}" 
     {{ if .caption }} title='{{ .caption | markdownify | safeHTML }}' {{ end }} 
     class="quire-figure leaflet-outer-wrapper mfp-hide">
       <div 
@@ -375,9 +366,8 @@ alt='{{ with .Get "alt" }}{{ . }}{{ end }}' />
 {{ else }}
 
 {{ $Id := now.UnixNano }}
-
+  <div id="deepzoom-{{ $Id }}" class="q-figure__wrapper">
     <figure 
-      id="deepzoom-{{ $Id }}"
       {{ if .caption }} title='{{ .caption | markdownify | safeHTML }}' {{ end }}  
       class="quire-figure leaflet-outer-wrapper mfp-hide hi">
         <div 

--- a/themes/default/layouts/shortcodes/q-figure.html
+++ b/themes/default/layouts/shortcodes/q-figure.html
@@ -178,15 +178,14 @@ we start with media figures
 
 
 {{/* -------------------- START q-figure__wrapper BLOCK -------------------- */}}
-<div class="q-figure__wrapper">
+<div id="deepzoom-{{ $Id }}" class="q-figure__wrapper">
 {{/* -------------------- START q-figure__wrapper BLOCK -------------------- */}}
 
   {{ if eq $.Site.Params.figureZoom true }}
 
   {{ $Id := now.UnixNano }}
 
-  <figure   
-  id="deepzoom-{{ $Id }}" 
+  <figure    
   {{ if .Get "caption" }}  
   title='{{ .Get "caption" | markdownify | safeHTML }}' {{ end }} 
   class="quire-figure leaflet-outer-wrapper mfp-hide Get">
@@ -455,9 +454,8 @@ render the figure from matching values found ther
 
   {{ $Id := now.UnixNano }}
 
-  <div class="q-figure__wrapper">
+  <div id="deepzoom-{{ $Id }}" class="q-figure__wrapper">
     <figure 
-      id="deepzoom-{{ $Id }}"
       {{ if .caption }} title='{{ .caption | markdownify | safeHTML }}' {{ end }}  
       class="quire-figure leaflet-outer-wrapper mfp-hide notGet">
         {{ if eq .media_type "table" }}

--- a/themes/default/source/js/application.js
+++ b/themes/default/source/js/application.js
@@ -193,6 +193,7 @@ function scrollToHash() {
     // Remove links that don't actually link to anything
     .not('[href="#"]')
     .not('[href="#0"]')
+    .not('.popup')
     .click(function(event) {
       // only override default link behavior if it points to the same page
       if (this.pathname.includes(window.location.pathname)) {


### PR DESCRIPTION
[Magnific popup inline images](https://dimsemenov.com/plugins/magnific-popup/documentation.html#inline-type) use the element with an id matching the clicked href as the popup content. So when you clicked the link,`scrollToHash` would scroll to the position of the pop up, which was positioned absolutely at the top of the page. This change excludes `.popup` from `scrollToHash`.