### PR TITLE
Fix/DEV-7773: Disable scrollToHash on popup links

### DIFF
--- a/themes/default/source/js/application.js
+++ b/themes/default/source/js/application.js
@@ -193,6 +193,7 @@ function scrollToHash() {
     // Remove links that don't actually link to anything
     .not('[href="#"]')
     .not('[href="#0"]')
+    .not('.popup')
     .click(function(event) {
       // only override default link behavior if it points to the same page
       if (this.pathname.includes(window.location.pathname)) {


### PR DESCRIPTION
[Magnific popup inline images](https://dimsemenov.com/plugins/magnific-popup/documentation.html#inline-type) use the element with an id matching the clicked href as the popup content. So when you clicked the link,scrollToHash would scroll to the position of the pop up, which was positioned absolutely at the top of the page. This change excludes .popup from scrollToHash.

