### PR TITLE
Fix/DEV-8383: Set zoom level from YAML

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -77,7 +77,7 @@ export default async function () {
         '-refresh',
         '-noextension',
         '-scale-factors',
-        '128,64,32,16,8,4,2,1,0',
+        '32,16,8,4,2,1',
         imageName
       ];
       return new Promise(function (resolve, reject) {

--- a/themes/default/layouts/entry/single.html
+++ b/themes/default/layouts/entry/single.html
@@ -222,7 +222,7 @@ a single image or object needs to be featured prominently.\
     aria-label="Zoomable image"
     data-catalogue-entry="true"
     {{ if .figure.iiif }} data-iiif="{{ .figure.iiif }}" {{ end }}
-    {{ if .figure.zoom_level }} data-zoom="{{ .figure.zoom_level }}" {{ end }}
+    {{ if .figure.zoom_max }} data-zoom-max="{{ .figure.zoom_max }}" {{ end }}
     {{ if .figure.caption }} data-caption='{{ .figure.caption | markdownify | safeHTML }}' {{ end }}
   >
   </div>

--- a/themes/default/layouts/shortcodes/q-figure-group.html
+++ b/themes/default/layouts/shortcodes/q-figure-group.html
@@ -139,7 +139,8 @@ the figure for each into a figure group
         class="quire-deepzoom inset leaflet-inner-wrapper " 
         aria-live="polite" 
         role="application"
-        aria-label="Zoomable image" 
+        aria-label="Zoomable image"
+        {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}
         src="{{ printf "%s/%s" ($.Scratch.Get "imageDir") .src | relURL }}">
         </div>
 

--- a/themes/default/layouts/shortcodes/q-figure-zoom.html
+++ b/themes/default/layouts/shortcodes/q-figure-zoom.html
@@ -78,7 +78,7 @@ document and render only the values given in the shortcode
         role="application" 
         aria-label="Zoomable image" 
         {{ if .Get "iiif" }} data-iiif="{{ .Get "iiif" }}" {{ end }}
-        {{ if .Get "zoom_level" }} data-zoom="{{ .Get "zoom_level" }}" {{ end }}
+        {{ if .Get "zoom_max" }} data-zoom-max="{{ .Get "zoom_max" }}" {{ end }}
         >
         </div>
         <span class="figure-caption visually-hidden">
@@ -118,6 +118,7 @@ document and render only the values given in the shortcode
     aria-live="polite" 
     role="application" 
     aria-label="Zoomable image" 
+    {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}
     src="{{ with .Get "src"}}{{ printf "%s/%s" ($.Scratch.Get "imageDir") . | relURL }}{{ end }}">
     </div>
     <span class="figure-caption visually-hidden">
@@ -169,7 +170,7 @@ document and render only the values given in the shortcode
  role="application" 
  aria-label="Zoomable image" 
  {{ if .Get "iiif" }} data-iiif="{{ .Get "iiif" }}" {{ end }}
- {{ if .Get "zoom_level" }} data-zoom="{{ .Get "zoom_level" }}" {{ end }}
+ {{ if .Get "zoom_max" }} data-zoom-max="{{ .Get "zoom_max" }}" {{ end }}
  >
 </div>
 
@@ -181,7 +182,9 @@ document and render only the values given in the shortcode
  aria-live="polite" 
  role="application" 
  aria-label="Zoomable image" 
- src='{{ with .Get "src"}}{{ printf "%s/%s" ($.Scratch.Get "imageDir") . | relURL }}{{ end }}'>
+ src='{{ with .Get "src"}}{{ printf "%s/%s" ($.Scratch.Get "imageDir") . | relURL }}{{ end }}'
+ {{ if .Get "zoom_max" }} data-zoom-max="{{ .Get "zoom_max" }}" {{ end }}
+ >
 </div>
     
 {{ end }}
@@ -349,7 +352,7 @@ alt='{{ with .Get "alt" }}{{ . }}{{ end }}' />
       role="application" 
       aria-label="Zoomable image" 
       data-iiif="{{ .iiif }}" 
-      data-zoom="{{ .zoom_level }}">
+      {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}>
       </div>
       <span class="figure-caption visually-hidden">
           {{ if $.Get "caption" }}
@@ -432,7 +435,7 @@ alt='{{ with .Get "alt" }}{{ . }}{{ end }}' />
     id="js-iiif-{{ now.UnixNano }}" 
     {{ if .caption }} title='{{ .caption | markdownify | safeHTML }}' {{ end }} 
     data-iiif="{{ .iiif }}" 
-    data-zoom="{{ .zoom_level }}"
+    {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}
     class="no-popup-quire-deepzoom quire-deepzoom inset" 
     aria-live="polite" 
     role="application" 
@@ -447,6 +450,7 @@ alt='{{ with .Get "alt" }}{{ . }}{{ end }}' />
     aria-live="polite" 
     role="application" 
     aria-label="Zoomable image" 
+    {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}
     src='{{ printf "%s/%s" ($.Scratch.Get "imageDir") .src | relURL }}'>
   </div>
 

--- a/themes/default/layouts/shortcodes/q-figure.html
+++ b/themes/default/layouts/shortcodes/q-figure.html
@@ -196,6 +196,7 @@ we start with media figures
     aria-live="polite" 
     role="application" 
     aria-label="Zoomable image" 
+    {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}
     src="{{ with .Get "src"}}{{ printf "%s/%s" ($.Scratch.Get "imageDir") . | relURL }}{{ end }}">
     </div>
     <span class="figure-caption visually-hidden">
@@ -477,6 +478,7 @@ render the figure from matching values found ther
           aria-live="polite" 
           role="application"
           aria-label="Zoomable image" 
+          {{ if .zoom_max }} data-zoom-max="{{ .zoom_max }}" {{ end }}
           src="{{ printf "%s/%s" ($.Scratch.Get "imageDir") .src | relURL }}">
           </div>
           <span class="figure-caption visually-hidden">

--- a/themes/default/source/js/deepzoom.js
+++ b/themes/default/source/js/deepzoom.js
@@ -28,8 +28,8 @@ class DeepZoom {
     this.iiif = this.el.getAttribute("data-iiif");
 
     const zoom = {
-      min: 1,
       default: 1,
+      min: 1,
       max: this.el.getAttribute('data-zoom-max') || 6
     };
 

--- a/themes/default/source/js/deepzoom.js
+++ b/themes/default/source/js/deepzoom.js
@@ -5,7 +5,8 @@ import "leaflet-iiif";
 class DeepZoom {
   // add map array to access map objects outside of Deepzoom class
   constructor(id, mapArr) {
-    this.el = id;
+    this.id = id;
+    this.el = document.querySelector(`#${this.id}`);
 
     // remove and refresh before init
     // @ts-ignore
@@ -22,8 +23,15 @@ class DeepZoom {
       }
     }
 
-    this.imageURL = $(`#${this.el}`).attr("src");
-    this.iiif = $(`#${this.el}`).data("iiif");
+    this.catalogueEntry = this.el.getAttribute("data-catalogue-entry");
+    this.imageURL = this.el.getAttribute("src");
+    this.iiif = this.el.getAttribute("data-iiif");
+
+    const zoom = {
+      min: 1,
+      default: 1,
+      max: this.el.getAttribute('data-zoom-max') || 6
+    };
 
     if (this.imageURL) {
       let image = new Image();
@@ -33,16 +41,10 @@ class DeepZoom {
           this.imgHeight = arr.height;
           this.imgWidth = arr.width;
           this.center = [0, 0];
-          this.defaultZoom = 0;
-          let zoom = {
-            min: 0,
-            default: 1,
-            max: 5
-          };
           this.map = this.createMap(zoom);
           // add leaflet objects to array
           mapArr.push(this.map);
-          if ($(`#${this.el}`).data("catalogue-entry") === undefined) {
+          if (this.catalogueEntry === undefined) {
             window["mapID"] = this.map;
           }
           this.southWest = this.map.unproject(
@@ -61,29 +63,16 @@ class DeepZoom {
         .catch(error => console.error(error));
     } else if (this.imageURL && this.iiif) {
       this.center = [0, 0];
-      this.defaultZoom = 0;
-      let zoom = {
-        min: 0.5,
-        default: 0,
-        max: 4
-      };
       this.map = this.createMap(zoom);
-      if ($(`#${this.el}`).data("catalogue-entry") === undefined) {
-        // @ts-ignore
+      if (this.catalogueEntry === undefined) {
         window["mapID"] = this.map;
       }
       this.addLayer(this.iiif, this.map);
       this.runMapTimeouts(this.map);
     } else {
       this.center = [0, 0];
-      this.defaultZoom = 0;
-      let zoom = {
-        min: 0.5,
-        default: 0,
-        max: 4
-      };
       this.map = this.createMap(zoom);
-      if ($(`#${this.el}`).data("catalogue-entry") === undefined) {
+      if (this.catalogueEntry === undefined) {
         window["mapID"] = this.map;
       }
       this.addLayer(this.iiif, this.map);
@@ -155,7 +144,7 @@ class DeepZoom {
 
   /** @param {object} zoom must be an object */
   createMap(zoom) {
-    return L.map(this.el, {
+    return L.map(this.id, {
       center: [0, 0],
       crs: L.CRS.Simple,
       zoom: zoom.default,


### PR DESCRIPTION
Changes:
- Rename `figures.yaml` image configuration `zoom_level` to `zoom_max` to be more explicit
- Set default max number of zoom levels in Leaflet to 6
- Set max number of scale factors generated by the image tiler to 6 
- Set `data-zoom-max` to a figure's `zoom_max` property, if one is present in `figures.yaml`
- Use `data-zoom-max` attribute in `deepzoom.js` to override leaflet default max zoom

Changes apply to all zoomable images, not just IIIF images.