### PR TITLE
Feature/DEV-8372: Use git-lfs in new projects

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -101,7 +101,7 @@ export default class CLI extends EventEmitter {
         if (commandMissing("git-lfs")) {
           this.warn(`Warning: Please install "git-lfs". This is recommended for managing file storage, such as large images. Please see the Quire docs for instructions on how to install it: https://quire.netlify.app/`);
         } else {
-          spawnSync(`git-lfs track "img/**/*"`);
+          spawnSync(`git-lfs`, [`track`, `"img/**/*"`]);
         }
         this.notice("Committing starter files...");
         spawnSync("git", ["add", "-A"]);

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -98,6 +98,12 @@ export default class CLI extends EventEmitter {
         this.notice("Initializing git in the new project directory...");
         process.chdir(projectDir);
         spawnSync("git", ["init"]);
+        const lfsCmd = `git-lfs track "img/**/*"`;
+        if (commandMissing("git-lfs")) {
+          this.warn(`Warning: Please install "git-lfs". This is recommended for managing file storage, such as large images. Please see the Quire docs for instructions on how to install it: https://quire.netlify.app/`);
+        } else {
+          spawnSync(`lfsCmd`);
+        }
         this.notice("Committing starter files...");
         spawnSync("git", ["add", "-A"]);
         spawnSync("git", ["commit", "-m", `Add starter and theme to project`]);

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -98,11 +98,10 @@ export default class CLI extends EventEmitter {
         this.notice("Initializing git in the new project directory...");
         process.chdir(projectDir);
         spawnSync("git", ["init"]);
-        const lfsCmd = `git-lfs track "img/**/*"`;
         if (commandMissing("git-lfs")) {
           this.warn(`Warning: Please install "git-lfs". This is recommended for managing file storage, such as large images. Please see the Quire docs for instructions on how to install it: https://quire.netlify.app/`);
         } else {
-          spawnSync(`lfsCmd`);
+          spawnSync(`git-lfs track "img/**/*"`);
         }
         this.notice("Committing starter files...");
         spawnSync("git", ["add", "-A"]);

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -101,7 +101,7 @@ export default class CLI extends EventEmitter {
         if (commandMissing("git-lfs")) {
           this.warn(`Warning: Please install "git-lfs". This is recommended for managing file storage, such as large images. Please see the Quire docs for instructions on how to install it: https://quire.netlify.app/`);
         } else {
-          spawnSync(`git-lfs`, [`track`, `"img/**/*"`]);
+          spawnSync(`git-lfs`, [`track`, `"downloads/**/*"`, `"img/**/*"`]);
         }
         this.notice("Committing starter files...");
         spawnSync("git", ["add", "-A"]);

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -99,7 +99,7 @@ export default class CLI extends EventEmitter {
         process.chdir(projectDir);
         spawnSync("git", ["init"]);
         if (commandMissing("git-lfs")) {
-          this.warn(`Warning: Please install "git-lfs". This is recommended for managing file storage, such as large images. Please see the Quire docs for instructions on how to install it: https://quire.netlify.app/`);
+          this.warn(`Warning: Git LFS (Large File Storage) is required to publish repositories with files over 100 MB to GitHub. See documentation for more info and install instructions: https://quire.getty.edu/documentation/github. This message will not impact initialization of new project directory.`);
         } else {
           spawnSync(`git-lfs`, [`track`, `"downloads/**/*"`, `"img/**/*"`]);
         }

--- a/packages/cli/lib/project.js
+++ b/packages/cli/lib/project.js
@@ -670,7 +670,7 @@ class Project extends EventEmitter {
             ? "C:\\Program Files (x86)\\Kindle Previewer 3\\lib\\fc\\bin\\kindlegen"
             : "/Applications/Kindle Previewer 3.app/Contents/lib/fc/bin/kindlegen";
           if (!fs.existsSync(kindlegenCmd)) {
-            this.errorExit("The Kindle Previewer application is required to generate MOBI files. Please visit the Quire docs for download instructions: https://gettypubs.github.io/quire/", spinner);
+            this.errorExit("The Kindle Previewer application is required to generate MOBI files. Please visit the Quire docs for download instructions: https://quire.netlify.app/", spinner);
           }
           execSync(`"${kindlegenCmd}" ${fileNamePath}-mobi.epub -o ${fileName}.mobi`);
           spinner.succeed(`Filepath: ${filePath}.mobi`);

--- a/packages/cli/lib/project.js
+++ b/packages/cli/lib/project.js
@@ -670,7 +670,7 @@ class Project extends EventEmitter {
             ? "C:\\Program Files (x86)\\Kindle Previewer 3\\lib\\fc\\bin\\kindlegen"
             : "/Applications/Kindle Previewer 3.app/Contents/lib/fc/bin/kindlegen";
           if (!fs.existsSync(kindlegenCmd)) {
-            this.errorExit("The Kindle Previewer application is required to generate MOBI files. Please visit the Quire docs for download instructions: https://quire.netlify.app/", spinner);
+            this.errorExit("Warning: Kindle Previewer is required to generate MOBI files. Please visit https://kdp.amazon.com/en_US/help/topic/G202131170 for more info and install instructions.", spinner);
           }
           execSync(`"${kindlegenCmd}" ${fileNamePath}-mobi.epub -o ${fileName}.mobi`);
           spinner.succeed(`Filepath: ${filePath}.mobi`);


### PR DESCRIPTION
Changes:
- Run `git-lfs` command in new projects to track anything in the `/img` directory
- Log warning if user doesn't have `git-lfs` installed
- Update Quire docs link in kindle previewer warning

The Quire docs will also need to be updated to instruct users to install `git-lfs`:  https://github.com/git-lfs/git-lfs/wiki/Installation