### PR TITLE
Refactor/DEV-8375: Show warning in imageslice if file type belongs to warn list

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -127,9 +127,10 @@ export default async function () {
           const dest = path.join(iiifProcessed, name);
 
           const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg"];
+          const warnList = [".tiff", ".gif", ".bmp", ".webp", ".psd", ".heif", ".raw", ".pdf", ".ai", ".ind"];
           if (supportedExts.some((supportedExt) => supportedExt === ext)) {
             originalImages.push(filePath);
-          } else {
+          } else if (warnList.some((warnExt) => warnExt === ext)) {
             spinner.fail(`Cannot slice file ${files[i]}. File type must be: ${supportedExts.join(', ')}.`);
           }
           if (fs.existsSync(dest)) {

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -127,6 +127,7 @@ export default async function () {
           const dest = path.join(iiifProcessed, name);
 
           const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg"];
+          // list of file extensions for common image types that can not be sliced into IIIF image tiles
           const warnList = [".tiff", ".gif", ".bmp", ".webp", ".psd", ".heif", ".raw", ".pdf", ".ai", ".ind"];
           if (supportedExts.some((supportedExt) => supportedExt === ext)) {
             originalImages.push(filePath);

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -128,7 +128,7 @@ export default async function () {
 
           const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg"];
           // list of file extensions for common image types that can not be sliced into IIIF image tiles
-          const warnList = [".tiff", ".gif", ".bmp", ".webp", ".psd", ".heif", ".raw", ".pdf", ".ai", ".ind"];
+          const warnList = [".ai", ".bmp", ".gif", ".heif", ".ind", ".pdf", ".psd", ".raw", ".tiff", ".webp"];
           if (supportedExts.some((supportedExt) => supportedExt === ext)) {
             originalImages.push(filePath);
           } else if (warnList.some((item) => item === ext)) {

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -131,7 +131,7 @@ export default async function () {
           if (supportedExts.some((supportedExt) => supportedExt === ext)) {
             originalImages.push(filePath);
           } else if (warnList.some((warnExt) => warnExt === ext)) {
-            spinner.fail(`Cannot slice file ${files[i]}. File type must be: ${supportedExts.join(', ')}.`);
+            spinner.fail(`Cannot process "${files[i]}" for IIIF. File type must be one of the following: ${supportedExts.join(', ')}.`);
           }
           if (fs.existsSync(dest)) {
             const statProcessed = fs.lstatSync(dest);

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -130,7 +130,7 @@ export default async function () {
           const warnList = [".tiff", ".gif", ".bmp", ".webp", ".psd", ".heif", ".raw", ".pdf", ".ai", ".ind"];
           if (supportedExts.some((supportedExt) => supportedExt === ext)) {
             originalImages.push(filePath);
-          } else if (warnList.some((warnExt) => warnExt === ext)) {
+          } else if (warnList.some((item) => item === ext)) {
             spinner.fail(`Cannot process "${files[i]}" for IIIF. File type must be one of the following: ${supportedExts.join(', ')}.`);
           }
           if (fs.existsSync(dest)) {


### PR DESCRIPTION
Changes:
- Show warning message when `imageslice` is passed an unsupported file type in the `warnList` of file extensions

@geealbers @Erin-Cecele Any suggested edits to the warning message? When `imageslice` attempts to process an unsupported file type in the `warnList` it will show the warning message, but continue to process other images.