### PR TITLE
Feature/DEV-8398: Refactor imageslice messaging with process description, caveat, and summary

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -213,8 +213,7 @@ export default async function () {
         console.log(`::Summary::`);
         console.log(`Processed ${results.length} ${results.length === 1 ? 'image' : 'images'}${failures.length ? ` with ${failures.length} ${failures.length === 1 ? 'failure' : 'failures'}` : ''}.`);
         if (failures.length) {
-          console.log('\n');
-          console.log('Unable to process the following files.')
+          console.log('\nUnable to process the following files.');
           failures.forEach((result) => {
             spinner.fail(result.image+' - '+result.message);
           })

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -221,8 +221,7 @@ export default async function () {
           })
         }
         console.log('\n');
-        spinner.succeed("Completed processing images.");
-        console.log('\n');
+        spinner.succeed("Completed processing images.\n");
       }
       resolve(true);
     }

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -14,14 +14,14 @@ import { isWin32 } from "./utils";
  * If an existing processed image directory with the same name is found, it will be removed and re-written
  */
 export default async function () {
+  const spinner = ora();
+
   return new Promise((resolve) => {
-    let spinner = ora({
-      text: "Creating IIIF images..."
-    }).start();
     const iiifSeed = "static/img/iiif/images";
     const iiifProcessed = "static/img/iiif/processed";
     const originalImages = [];
     let imagesSliced = 0;
+    const results = [];
     const iiifTiler = isWin32()
       ? "/go-iiif/bin/iiif-tile-seed-win"
       : process.platform === "linux"
@@ -55,11 +55,9 @@ export default async function () {
       );
     }
 
-    // Log to spinner the process and then remove config file so only the template remains,
-    // Trigger done function
+    // Remove config file so only the template remains
     function resetConfigPath() {
       fs.unlink(__dirname + path.normalize("/go-iiif/config/config.json"));
-      done();
     }
 
     // function to execute the command to slice the images
@@ -115,7 +113,6 @@ export default async function () {
     // also check if any images have been processed and 
     // delete them so it can do a fresh slice
     function getAllImages() {
-      spinner.info("Finding images to process...");
       if (fs.existsSync(iiifSeed)) {
         const files = fs.readdirSync(iiifSeed);
         for (let i = 0; i < files.length; i++) {
@@ -129,14 +126,15 @@ export default async function () {
           if (supportedExts.some((supportedExt) => supportedExt === ext)) {
             originalImages.push(filePath);
           } else if (warnList.some((item) => item === ext)) {
-            spinner.fail(`Cannot process "${files[i]}" for IIIF. File type must be one of the following: ${supportedExts.join(', ')}.`);
+            results.push({ 
+              image: files[i],
+              status: 'error',
+              message: `File type must be one of the following: ${supportedExts.join(', ')}.` 
+            })
           }
           if (fs.existsSync(dest)) {
             const statProcessed = fs.lstatSync(dest);
             if (statProcessed.isDirectory()) {
-              spinner.info(
-                `IIIF image files already exist for ${base}. They will be removed and rewritten.`
-              );
               rimraf.sync(dest);
             }
           }
@@ -149,14 +147,22 @@ export default async function () {
 
     // Slice Images
     function sliceImages() {
-      spinner.start('Processing images. This may take a while depending on the image file sizes...');
+      console.log(`\nProcessing project image resources for IIIF.`);
       let imagesToSlice = originalImages.length;
       if (imagesToSlice === 0) {
+        console.log('\n');
         spinner.fail(`No images found in ${iiifSeed}`);
+        console.log('\n');
         resetConfigPath();
+        resolve(true);
+        return;
       }
+      console.log(`\nGenerating IIIF image tiles may take a while depending on the size of each image file.`);
+      console.log('\n');
+      spinner.start(`Processing images...`);
       for (let i = 0; i < originalImages.length; i++) {
         const image = originalImages[i];
+        // @todo output "processing <i> of <n> images"
         iiifSlice(image).then(() => {
           imagesSliced++;
           imagesToSlice--;
@@ -171,10 +177,10 @@ export default async function () {
     // Verify expected images were sliced
     // Log success
     async function imagesDone() {
-      spinner.succeed(`Done processing ${imagesSliced} images.`);
       await compareSlicedResults();
       getAllImagesAndRename(path.normalize("static/img/iiif/processed"));
       resetConfigPath();
+      done();
     }
 
     // compared the finished folders with the injested results to see which failed/passed
@@ -182,38 +188,47 @@ export default async function () {
     // in imagesDone()
     async function compareSlicedResults() {
       const processedImages = fs.readdirSync(iiifProcessed);
-      let failed = [];
-      let completed = [];
       for (let i = 0; i < originalImages.length; i++) {
         const originalImageFile = path.parse(originalImages[i]).base;
         const originalImageFileName = path.parse(originalImages[i]).name;
         if (processedImages.includes(originalImageFileName)) {
-          completed.push(originalImageFile);
+          results.push({
+            image: originalImageFile,
+            status: 'success'
+          })
         } else {
-          failed.push(originalImageFile);
+          results.push({
+            image: originalImageFile,
+            status: 'error',
+            message: 'Ensure file has proper exif headings'
+          })
         }
-      }
-      if (failed.length) {
-        spinner.fail(
-          `${failed.length}/${imagesSliced} failed. Ensure these files have proper exif headings: ${['', ...failed].join('\n - ')}`
-        )
-      }
-      if (completed.length) {
-        spinner.succeed(
-          `${completed.length}/${imagesSliced} succeeded:${['', ...completed].join('\n - ')}`
-        );
       }
     }
 
     // done function, trigger finish and resolve true to the Promise
     function done() {
-      spinner.succeed("IIIF Process Finished!");
+      if (results.length) {
+        const failures = results.filter((image) => image.status === "error");
+        spinner.clear();
+        console.log(`::Summary::`);
+        console.log(`Processed ${results.length} ${results.length === 1 ? 'image' : 'images'}${failures.length ? ` with ${failures.length} ${failures.length === 1 ? 'failure' : 'failures'}` : ''}.`);
+        if (failures.length) {
+          console.log('\n');
+          console.log('Unable to process the following files.')
+          failures.forEach((result) => {
+            spinner.fail(result.image+' - '+result.message);
+          })
+        }
+        console.log('\n');
+        spinner.succeed("Completed processing images.");
+        console.log('\n');
+      }
       resolve(true);
     }
 
     // startup process
     try {
-      spinner.info("Starting IIIF Process");
       updateConfigPath();
     } catch (error) {
       return new Promise((reject) => {

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -3,7 +3,7 @@ const fs = require("fs-extra");
 const ora = require("ora");
 const path = require("path");
 const rimraf = require("rimraf");
-import { isWin32 } from "./utils";
+import { isWin32, pluralize } from "./utils";
 
 /**
  * imageslice
@@ -151,8 +151,7 @@ export default async function () {
       let imagesToSlice = originalImages.length;
       if (imagesToSlice === 0) {
         console.log('\n');
-        spinner.fail(`No images found in ${iiifSeed}`);
-        console.log('\n');
+        spinner.fail(`No images found in ${iiifSeed}\n`);
         resetConfigPath();
         resolve(true);
         return;
@@ -211,11 +210,14 @@ export default async function () {
         const failures = results.filter((image) => image.status === "error");
         spinner.clear();
         console.log(`::Summary::`);
-        console.log(`Processed ${results.length} ${results.length === 1 ? 'image' : 'images'}${failures.length ? ` with ${failures.length} ${failures.length === 1 ? 'failure' : 'failures'}` : ''}.`);
+        let message = `Processed ${results.length} ${pluralize('item', results.length)}`;
+        const failureMessage = failures.length ? ` with ${failures.length} ${pluralize('failure', failures.length)}` : '';
+        message += failureMessage;
+        console.log(message);
         if (failures.length) {
-          console.log('\nUnable to process the following files.');
+          console.log('\nUnable to process the following files.')
           failures.forEach((result) => {
-            spinner.fail(result.image+' - '+result.message);
+            spinner.fail(`${result.image} - ${result.message}`);
           })
         }
         console.log('\n');

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -157,8 +157,7 @@ export default async function () {
         resolve(true);
         return;
       }
-      console.log(`\nGenerating IIIF image tiles may take a while depending on the size of each image file.`);
-      console.log('\n');
+      console.log(`\nGenerating IIIF image tiles may take a while depending on the size of each image file.\n`);
       spinner.start(`Processing images...`);
       for (let i = 0; i < originalImages.length; i++) {
         const image = originalImages[i];

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -104,3 +104,10 @@ export function copyDirRecursive(from, to, exclude) {
 export function isWin32() {
   return process.platform === "win32" ? true : false;
 }
+
+/**
+ * Very simple pluralize function that adds an s if n != 1
+ * @param {number} The number of things
+ * @param {string} The name of the things
+ */
+export function pluralize(word, n) { return n === 1 ? word : `${word}s` };


### PR DESCRIPTION
Changes:
- Update messaging to more closely match format in DEV-8398, to indicate the process being run, any caveats, and a results summary.
- Build `results` array with images, status, and error messages. 

These are the cases being covered so far. There is certainly room for expansion and improvement.
### No Images Found
- get images in iiif/images directory
- log "starting process" message
- if no images are found, log "no images found" message and stop process

### Images found
- get images in iiif/images directory
- log "starting process" message
- if images are found, log "generating images might take a long time..." message
- start spinner
- run tile command on each image
- when tiling process is complete, stop and clear spinner
- log summary with # of images processed and # of failures
- if there are failures, log each failed image path with any error messages
- log "completed" message

### No images found
![image](https://user-images.githubusercontent.com/13127674/112528586-910fad80-8d61-11eb-991d-f57db5208ea6.png)

### Processing
![image](https://user-images.githubusercontent.com/13127674/112528373-4aba4e80-8d61-11eb-8aae-ba04c1540fb6.png)

### Success
![image](https://user-images.githubusercontent.com/13127674/112528520-79d0c000-8d61-11eb-8039-d1b19b7718f7.png)

### Success & Failures
![image](https://user-images.githubusercontent.com/13127674/112528266-29f1f900-8d61-11eb-8ee4-2217e1f9470b.png)
