### PR TITLE
Fix/dev 8375: Update file extension warning list

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -125,7 +125,7 @@ export default async function () {
 
           const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg"];
           // list of file extensions for common image types that can not be sliced into IIIF image tiles
-          const warnList = [".ai", ".bmp", ".gif", ".heif", ".ind", ".pdf", ".psd", ".raw", ".tiff", ".webp"];
+          const warnList = [".ai", ".bmp", ".gif", ".heif", ".ind", ".pdf", ".psd", ".raw", ".tif", ".tiff", ".webp"];
           if (supportedExts.some((item) => item === ext.toLowerCase())) {
             originalImages.push(filePath);
           } else if (warnList.some((item) => item === ext.toLowerCase())) {

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -126,9 +126,9 @@ export default async function () {
           const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg"];
           // list of file extensions for common image types that can not be sliced into IIIF image tiles
           const warnList = [".ai", ".bmp", ".gif", ".heif", ".ind", ".pdf", ".psd", ".raw", ".tiff", ".webp"];
-          if (supportedExts.some((supportedExt) => supportedExt === ext)) {
+          if (supportedExts.some((item) => item === ext.toLowerCase())) {
             originalImages.push(filePath);
-          } else if (warnList.some((item) => item === ext)) {
+          } else if (warnList.some((item) => item === ext.toLowerCase())) {
             spinner.fail(`Cannot process "${files[i]}" for IIIF. File type must be one of the following: ${supportedExts.join(', ')}.`);
           }
           if (fs.existsSync(dest)) {


### PR DESCRIPTION
Changes:
- Add '.tif' to warning list
- Lowercase extensions before comparing