### PR TITLE
Refactor/DEV-8370: Change iiif seed directory

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -97,6 +97,10 @@ export default class CLI extends EventEmitter {
         // First Commit
         this.notice("Initializing git in the new project directory...");
         process.chdir(projectDir);
+
+        // Create empty IIIF image directory
+        fs.mkdirSync(path.join(localStarterDir, 'static', 'img', 'iiif'), { recursive: true });
+
         spawnSync("git", ["init"]);
         if (commandMissing("git-lfs")) {
           this.warn(`Warning: Git LFS (Large File Storage) is required to publish repositories with files over 100 MB to GitHub. See documentation for more info and install instructions: https://quire.getty.edu/documentation/github. This message will not impact initialization of new project directory.`);

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -17,7 +17,7 @@ export default async function () {
   const spinner = ora();
 
   return new Promise((resolve) => {
-    const iiifSeed = "static/img/iiif/images";
+    const iiifSeed = "static/img/iiif/";
     const iiifProcessed = "static/img/iiif/processed";
     const originalImages = [];
     let imagesSliced = 0;


### PR DESCRIPTION
Changes:
- Create empty `iiif` directory in new projects
- Search for images to tile for IIIF in `static/img/iiif` instead of `static/img/iiif/images`

IIIF Config in figures.yaml would look like this:
```
  - id: "fig-2"
    label: "Figure 2"
    src: iiif/cover.png
    iiif: /img/iiif/processed/cover/info.json
    media_type: iiif
    caption: "Walker Evans. *Sons of the American Legion, Bethlehem, Pennsylvania*, 1935."
    credit: "The J. Paul Getty Museum, Los Angeles"
```

This allows `iiif` to also be an external source.

Processed images are still output to `static/img/iiif/processed`