### PR TITLE
Add tif to supported file types for imageslice

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -120,9 +120,9 @@ export default async function () {
           const filePath = path.join(iiifSeed, files[i]);
           const dest = path.join(iiifProcessed, name);
 
-          const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg"];
+          const supportedExts = [".jp2", ".jpg", ".jpeg", ".png", ".svg", ".tif", ".tiff"];
           // list of file extensions for common image types that can not be sliced into IIIF image tiles
-          const warnList = [".ai", ".bmp", ".gif", ".heif", ".ind", ".pdf", ".psd", ".raw", ".tif", ".tiff", ".webp"];
+          const warnList = [".ai", ".bmp", ".gif", ".heif", ".ind", ".pdf", ".psd", ".raw", ".webp"];
           if (supportedExts.some((item) => item === ext.toLowerCase())) {
             originalImages.push(filePath);
           } else if (warnList.some((item) => item === ext.toLowerCase())) {


### PR DESCRIPTION
I successfully tested slicing a `.tiff`, and I am unsure of why they were not originally included on the list of supported extensions, I haven't found anything in the `go-iiif` documentation that would indicate they aren't supported.