### PR TITLE
Fix/DEV-8262: Use os-specific npm command

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -257,9 +257,10 @@ export default class CLI extends EventEmitter {
   }
 
   npmInstall(cwd) {
+    const npmCmd = isWin32() ? "npm.cmd" : "npm";
     cwd = cwd || process.cwd();
     spawnSync(
-      "npm",
+      npmCmd,
       ["install"],
       {
         // cwd: cwd, stdio: 'inherit'


### PR DESCRIPTION
Quick fix for the issue where package dependencies were not being installed on windows from projects created with `quire new`, while we work on a more consistent approach to cross-platform support, including CI testing.