### PR TITLE
Fix `isWin32` import

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -14,7 +14,7 @@ const readline = require("readline");
 const fs = require("fs-extra");
 
 import Project from "@src/project";
-import { commandMissing, copy } from "@src/utils";
+import { commandMissing, copy, isWin32 } from "@src/utils";
 
 /**
  * CLI class.


### PR DESCRIPTION
Really need to finish the CI integration so we don't miss this stuff.