### PR TITLE
Fix: Replace q-figure-group closing anchor tag

### DIFF
--- a/themes/default/layouts/shortcodes/q-figure-group.html
+++ b/themes/default/layouts/shortcodes/q-figure-group.html
@@ -186,6 +186,8 @@ the figure for each into a figure group
     {{- partial "figures/label.html" $labelDict -}}
   {{ end }}
 
+  </a>
+
   {{/* -------------------- END LABEL BLOCK -------------------- */}}
 
 


### PR DESCRIPTION
This was accidentally removed in [d9fe8b8](https://github.com/thegetty/quire/commit/0d0380f45f1569f22e78bf695e5f2e76325d7e2b#diff-4ad3eec8d274d736e191b5cf805e22c79b8415f917ec3fb70d33416325a625d4L233). The problem it was causing was an extra (empty) <a class="inline popup"> tag was added to each figure in `q-figure-group`, causing the image item count (shown in the top right when the modal is open) to count two images for each `q-figure-group` image.