### PR TITLE
Fix/DEV-8433: Fix sequential slicing of images

### DIFF
--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -161,10 +161,8 @@ export default async function () {
         await iiifSlice(image).then(() => {
           imagesToSlice--;
           imagesSliced++;
-          if (imagesToSlice === 0) imagesDone();
         }).catch(() => {
           imagesToSlice--;
-          if (imagesToSlice === 0) imagesDone();
         }).finally(() => {
           spinner.start(`Processed ${imagesSliced}/${originalImages.length} ${pluralize('image', originalImages.length)}...`);
         });

--- a/packages/cli/lib/imageslice.js
+++ b/packages/cli/lib/imageslice.js
@@ -144,7 +144,7 @@ export default async function () {
     }
   }
 
-  // Slice Images
+  // Slice images sequentially
   async function sliceImages() {
     imagesToSlice = originalImages.length;
     console.log(`\nProcessing project image resources for IIIF.`);
@@ -155,18 +155,21 @@ export default async function () {
     }
     console.log(`\nGenerating IIIF image tiles may take a while depending on the size of each image file.\n`);
     spinner.start(`Processing ${imagesToSlice} ${pluralize('image', originalImages.length)}...`);
-    await Promise.all(
-      originalImages.map(async (image) => {
+
+    await (async () => {
+      for (const image of originalImages) {
         await iiifSlice(image).then(() => {
           imagesToSlice--;
           imagesSliced++;
+          if (imagesToSlice === 0) imagesDone();
         }).catch(() => {
           imagesToSlice--;
+          if (imagesToSlice === 0) imagesDone();
         }).finally(() => {
           spinner.start(`Processed ${imagesSliced}/${originalImages.length} ${pluralize('image', originalImages.length)}...`);
         });
-      })
-    );
+      }
+    })();
   }
 
   // Verify expected images were sliced


### PR DESCRIPTION
Replaces `Promise.all` with an anonymous async function with a for loop that `awaits` each image slice command's completion before proceeding to the next. Previously, I was using an await inside a `.map` which _does not wait for the function to resolve before moving to the next item_... all it does is allow you to execute a callback _after_ that item has completed.