### PR TITLE
Fix/DEV-8524: Add Label to Popup Captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 ## [unreleased]
 
 ### Changed
-
 - Process IIIF images sequentially in `process --iiif` command.
+
+### Fixed
+- Include label in image modal caption/credit block
 
 <a name="0.19.1"></a>
 

--- a/themes/default/source/css/components/quire-popup.scss
+++ b/themes/default/source/css/components/quire-popup.scss
@@ -38,13 +38,17 @@ div {
       padding: 6px 10px;
       background: $off-black-semi-transparent;
       font-family: $font_0;
-      font-size: 0.75rem;
-      font-weight: bold;
+      font-size: 0.875rem;
 
       a {
         color: $accent-color;
         border-bottom: 1px dotted;
       }
+    }
+
+    .quire-figure__label-text {
+      margin-right: .5rem;
+      font-weight: bold;
     }
 
     a {

--- a/themes/default/source/js/popup.js
+++ b/themes/default/source/js/popup.js
@@ -63,13 +63,12 @@ export default function(gallerySelector, mapArr) {
       if (self) {
         $(".mfp-title").hide();
         const figureWrapper = $(self.currItem.el).closest('.q-figure__wrapper');
-        const caption =
-          $(figureWrapper).find(".quire-figure__caption-content").prop('outerHTML');
-        const credit =
-          $(figureWrapper).find(".quire-figure__credit").prop('outerHTML');
+        const captionParts = ['label-text', 'caption-content', 'credit'];
         const captionWrapper =$(`<span class="caption"></span>`);
-        caption ? captionWrapper.append(caption) : null;
-        credit ? captionWrapper.append(credit) : null;
+        captionParts.forEach((item) => {
+          const content = $(figureWrapper).find(`.quire-figure__${item}`).prop('outerHTML');
+          content ? captionWrapper.append(content) : null;
+        })
         if (captionWrapper.html()) {
           self.captionCont = `
             <div class="quire-caption-container">${captionWrapper.prop('outerHTML')}</div>`;


### PR DESCRIPTION
Previously, label text was not included in the caption/credit block in image modals. Changes to include label text and update styles to match the caption, credit, and label styling on inline images.

Note: It's expected that the `ci/circleci: build_install_test-win` job will fail