### PR TITLE
fix/issue-136: Properly wrap Prince pdf command in quotes for Windows users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 
 ### Fixed
 - Include label in image modal caption/credit block
+- Wrap Windows Prince command in quotes
 
 <a name="0.19.1"></a>
 

--- a/packages/cli/lib/project.js
+++ b/packages/cli/lib/project.js
@@ -335,7 +335,7 @@ class Project extends EventEmitter {
     );
 
     let princeCmd = isWin32()
-      ? "C:\\Program Files (x86)\\Prince\\engine\\bin\\prince.exe"
+      ? 'C:\\"Program Files (x86)"\\Prince\\engine\\bin\\prince.exe'
       : "prince";
     let spinner = ora("Building PDF").start();
     let start = performance.now();


### PR DESCRIPTION
For Windows users using PowerShell, which is now the default shell application on Windows, the Prince command needs to have the part of its path that includes spaces wrapped in double quotes. The following is the format that works (in PowerShell as well as in the older Command Prompt application), and is what's being done in this PR:

✅

```
$ C:\"Program Files (x86)"\Prince\engine\bin\prince.exe --version
```

FYI, these variations, wrapping the whole path in double quotes or wrapping the one part of the path in single quotes, have been tested and **do not work**:

🚫

```
$ "C:\Program Files (x86)\Prince\engine\bin\prince.exe" --version
```

```
$ C:\'Program Files (x86)'\Prince\engine\bin\prince.exe --version
```

---

This PR fixes issue #136, which was brought to our attention by Quire user @sophielamb. Thanks Sophie!