### PR TITLE
Add checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,7 +7,7 @@ assignees:
 body:
 - type: markdown
   attributes:
-    value: “## Thank you for opening a new issue!**“     
+    value: “## Thank you for opening a new issue!“     
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,10 +7,14 @@ assignees:
 body:
 - type: markdown
   attributes:
-    value: |
-      **Thank you for opening a new issue!**
-    
-      ⚠ Before submitting your bug report, please search [existing issues](https://github.com/thegetty/quire/issues) first to ensure the problem you've encountered hasn't already been reported. If you don't have a bug to report but still need help, please post your question on the [community forum](https://github.com/thegetty/quire/discussions) instead. 
+    value: “## Thank you for opening a new issue!**“     
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
 - type: textarea
   id: reproduce
   attributes:
@@ -60,6 +64,6 @@ body:
   id: supporting_info
   attributes:
     label: Supporting Information
-    description: If you have additional files that would be useful in describing the issue (Terminal output, screenshots, Quire output files) attach them by dragging and dropping in the comments below.
+    description: If you have additional files that would be useful in describing the issue (Terminal output, screenshots, Quire output files, related issue) attach them by dragging and dropping in the comments below.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -8,7 +8,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      ## Thank you for opening a new issue! 
+      # Thank you for opening a new issue! 
     
       ⚠ Before submitting your proposal, please review our [Contributing Guidelines](##).
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,8 +6,7 @@ assignees:
 - geealbers
 body:
 - type: markdown
-  attributes:
-    value: “## Thank you for opening a new issue!“     
+  value: “## Thank you for opening a new issue!“     
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -8,8 +8,7 @@ body:
 - type: markdown
   attributes:
     value: |
-   
-     ”## Thank you for opening a new issue!”
+      ## Thank you for opening a new issue! 
     
       ⚠ Before submitting your proposal, please review our [Contributing Guidelines](##).
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,7 +9,7 @@ body:
   attributes:
     value: |
    
-      **Thank you for opening a new issue!**
+     ”## Thank you for opening a new issue!”
     
       ⚠ Before submitting your proposal, please review our [Contributing Guidelines](##).
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ assignees:
 - geealbers
 body:
 - type: markdown
-  value: "## Thank you for opening a new issue!"     
+  value: **Thank you for opening a new issue!**     
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,17 +6,26 @@ assignees:
 - geealbers
 body:
 - type: markdown
-  attributes: 
+  attributes:
     value: |
-  
-      **Thank you for opening a new issue!**     
+   
+      **Thank you for opening a new issue!**
+    
+      ⚠ Before submitting your proposal, please review our [Contributing Guidelines](##).
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered.
+    description:
     options:
     - label: I have searched the existing issues
-      required: true
+      required: true    
+- type: input
+  id: number
+  attributes:
+    label: Issue number
+    description: If there is an existing issue, what is the number, please include it below.
+  validations:
+    required: false
 - type: textarea
   id: reproduce
   attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ assignees:
 - geealbers
 body:
 - type: markdown
-  value: “## Thank you for opening a new issue!“     
+  value: "## Thank you for opening a new issue!"     
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,10 @@ assignees:
 - geealbers
 body:
 - type: markdown
-  value: **Thank you for opening a new issue!**     
+  attributes: 
+    value: |
+  
+      **Thank you for opening a new issue!**     
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?


### PR DESCRIPTION
Just a suggestion based on GitHub's issue form documentation. Previously there was just a line in the introduction requesting that people search the issue tracker. Replacing that with this checkbox might help reduce dupes. 