### PR TITLE
Feature/Issue-17: Add tests and suggested fixes for common user errors

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -245,7 +245,7 @@ export default class CLI extends EventEmitter {
   }
 
   error(msg) {
-    console.log(chalk.red(msg));
+    console.log(chalk.red(msg + "Run `quire preview --verbose` for details"));
     process.exitCode = 1;
   }
 

--- a/starters/default/config.yml
+++ b/starters/default/config.yml
@@ -32,6 +32,7 @@ markup:
 
 # These values can be accessed in templates via .Site.Params
 params:
+  runTests: true
   searchEnabled: true
   licenseIcons: true
   pageLabelDivider: ". "

--- a/themes/default/layouts/_default/baseof.html
+++ b/themes/default/layouts/_default/baseof.html
@@ -8,17 +8,19 @@
 {{- $js := "js/application.js" | relURL -}}
 {{- $figureModal := .Site.Params.figureModal -}}
 
+{{- partial "tests/run.html" . -}}
+
 <!DOCTYPE html>
 <html lang="{{ .Site.Data.publication.language }}">
   {{ partial "head.html" . }}
-  <body>        
+  <body>
     {{ partial "icons.html" . }}
     {{- if eq .Site.Params.licenseIcons true -}}
       {{ partial "icons-cc.html" . }}
     {{- end -}}
     {{- if eq .Site.Params.pdf true -}}
       {{ partial "pdf-info.html" . }}
-    {{- end -}} 
+    {{- end -}}
     <div class="quire no-js" id="container">
       <div class="quire__secondary remove-from-epub"
           id="site-menu"

--- a/themes/default/layouts/partials/tests/check-node-modules.html
+++ b/themes/default/layouts/partials/tests/check-node-modules.html
@@ -1,0 +1,9 @@
+{{ $themeDependencies := "themes/default/node_modules" }}
+
+{{ if fileExists $themeDependencies }}
+
+{{ else }}
+
+  {{ errorf "%q is missing! \n\nQUIRE FIX --> Run `quire install`. Running `quire install` will install missing theme node_modules dependencies. It only needs to be run once for this project. It is necessary when cloning/copying an existing Quire project from another source rather than starting it with `quire new`.\n"  $themeDependencies }}
+
+{{ end }}

--- a/themes/default/layouts/partials/tests/check-page-one-class.html
+++ b/themes/default/layouts/partials/tests/check-page-one-class.html
@@ -1,0 +1,21 @@
+{{ $pages := .Site.Pages }}
+{{ $pages = where $pages ".Type" "!=" "data" }}
+{{ $pageClassOne := slice }}
+
+{{ range $pages }}
+
+  {{ if in .Params.class "page-one" }}
+
+    {{ $pageClassOne = $pageClassOne | append .Path }}
+
+  {{ end }}
+
+{{ end }}
+
+{{ if gt $pageClassOne 1 }}
+
+  {{ $pageList := delimit $pageClassOne ", " }}
+
+  {{ errorf "More than one page with `class: page-one`! \n\nQUIRE FIX --> Remove `class: page-one` from all but one of these Markdown files: %s. Using `class: page-one` in the YAML of a page sets sets that page to be numbered as page 1 in the PDF output of your project. Pages before `page-one` will be numbered with lowercase Roman numerals (i, ii, iii, ix, etc.).\n" $pageList }}
+
+{{ end }}

--- a/themes/default/layouts/partials/tests/check-page-weights.html
+++ b/themes/default/layouts/partials/tests/check-page-weights.html
@@ -1,0 +1,49 @@
+{{ $pages := .Site.Pages }}
+{{ $pages = where $pages ".Type" "!=" "data" }}
+
+{{ $pageWeights := "" }}
+{{ $duplicatePageWeight := slice }}
+{{ $otherPageWeight := slice }}
+{{ $noPageWeight := slice }}
+
+{{ range $pages }}
+
+  {{ if .Weight }}
+
+    {{ if in (string $pageWeights) (string .Weight) }}
+
+      {{ $duplicatePageWeight = $duplicatePageWeight | append .Weight }}
+
+    {{ else }}
+
+      {{ $pageWeights = delimit (slice $pageWeights .Weight) ", " }}
+
+    {{ end }}
+
+  {{ else }}
+
+    {{ $noPageWeight = $noPageWeight | append .Path }}
+
+  {{ end }}
+
+{{ end }}
+
+{{ if gt $noPageWeight 0 }}
+
+  {{ $noPageWeightList := delimit $noPageWeight ", " }}
+
+  {{ errorf "One or more Markdown files with no page weight! \n\nQUIRE FIX --> Assign a unique weight that is greater than zero (0) to these Markdown files: %s. Having a valid weight on each page ensures your project pages are ordered correctly.\n" $noPageWeightList }}
+
+{{ end }}
+
+{{ if gt $duplicatePageWeight 0 }}
+
+  {{ $allDupes := slice }}
+  {{ range where $pages "Weight" "in" $duplicatePageWeight }}
+    {{ $allDupes = $allDupes | append .Path }}
+  {{ end }}
+  {{ $allDupesList := delimit $allDupes ", " }}
+
+  {{ errorf "Some Markdown files have duplicate page weights! \n\nQUIRE FIX --> Assign a unique weight to these Markdown files: %s. Having a unique weight ensures your project pages are ordered correctly.\n"   $allDupesList }}
+
+{{ end }}

--- a/themes/default/layouts/partials/tests/run.html
+++ b/themes/default/layouts/partials/tests/run.html
@@ -1,4 +1,4 @@
-{{ if eq .Site.Params.runTests true }}
+{{ if ne .Site.Params.runTests false }}
 
   {{ partial "tests/check-node-modules.html" . }}
 

--- a/themes/default/layouts/partials/tests/run.html
+++ b/themes/default/layouts/partials/tests/run.html
@@ -1,5 +1,13 @@
-{{ partial "tests/check-node-modules.html" . }}
+{{ if eq .Site.Params.runTests true }}
 
-{{ partial "tests/check-page-weights.html" . }}
+  {{ partial "tests/check-node-modules.html" . }}
 
-{{ partial "tests/check-page-one-class.html" . }}
+  {{ partial "tests/check-page-weights.html" . }}
+
+  {{ partial "tests/check-page-one-class.html" . }}
+
+{{ else }}
+
+  {{ warnf "\n\nQuire tests are currently disabled. To enable them, set the `runTests` parameter to true in your projects’s config.yml file." }}
+
+{{ end }}

--- a/themes/default/layouts/partials/tests/run.html
+++ b/themes/default/layouts/partials/tests/run.html
@@ -1,0 +1,5 @@
+{{ partial "tests/check-node-modules.html" . }}
+
+{{ partial "tests/check-page-weights.html" . }}
+
+{{ partial "tests/check-page-one-class.html" . }}


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file.

- [x] I have made my changes in a new branch and not directly in the main branch

- [ ] I am requesting feedback on a draft pull request

### Is this pull request related to an open issue? If so, what is the issue number?

This expands a little on issue #17 "Add error messaging for page weight issues"

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

The goal is to catch common errors that Quire users make in projects and to give them fixes for them on the spot, rather than needing to go to the documentation, or the community forum, or us.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

This uses [Hugo’s built-in errorf and warnf functions](https://gohugo.io/functions/errorf/) in a series of individual partials that run particular tests. I've set it up so it's easy to add more, but so far they include three tests, and you can see sample outputs for each down below.

- Check that node_modules were installed in the default theme
- Check that all pages have a `weight` assigned and that the weights are unique
- Check that only one page has `class: page-one` which is used for page numbering in the PDF output.

I've also added a `runTests` configuration parameter that allows users to turn off testing.

Lastly, it should be noted that users who run `quire preview` will only see a message like `Error: Error building site: logged 1 error(s)`. To see the full error message(s) they need to run `--verbose`. So, to make this clear, I've also added to the output an additional line of text: `Run quire preview --verbose for details`. Ideally, this line would only show up if they weren't already running `--verbose` but I wasn't sure how to do that so currently they see it in either case.

### Does this pull request necessitate changes to Quire's documentation?

Yes. We'll need to document the `runTests` parameter and may also want to consider a section on troubleshooting / errors. I'll work on that with @Erin-Cecele. 

### Include screenshots of before/after if applicable.

Following are sample outputs as users would see them in their command line.

Check for node_modules:

```
ERROR 2021/08/25 17:08:03 "themes/default/node_modules" is missing! 

QUIRE FIX --> Run `quire install`. Running `quire install` will install missing theme node_modules dependencies. 
It only needs to be run once for this project. It is necessary when cloning/copying an existing Quire project 
from another source rather than starting it with `quire new`.
```

Check that all pages have a weight:

```
ERROR 2021/08/25 17:08:03 One or more Markdown files with no page weight! 

QUIRE FIX --> Assign a unique weight that is greater than zero (0) to these Markdown files: cover.md. 
Having a valid weight on each page ensures your project pages are ordered correctly.
```

Check that all page weights are unique:

```
ERROR 2021/08/25 17:08:03 Some Markdown files have duplicate page weights! 

QUIRE FIX --> Assign a unique weight to these Markdown files: catalogue/3.md, catalogue/2.md, about.md, 
bibliography.md, contributors.md. Having a unique weight ensures your project pages are ordered correctly.
```

Check that only one page uses `class: page-one`:

```
ERROR 2021/08/25 17:08:03 More than one page with `class: page-one`! 

QUIRE FIX --> Remove `class: page-one` from all but one of these Markdown files: intro.md, essay.md, 
catalogue/1.md. Using `class: page-one` in the YAML of a page sets sets that page to be numbered as page 1 
in the PDF output of your project. Pages before `page-one` will be numbered with lowercase Roman numerals 
(i, ii, iii, ix, etc.).
```

### Additional Comments
