### PR TITLE
Fix incomplete build published as 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 * `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [0.20.1]
+
+### Fixed
+- Corrects broken build published to npm
+
 ## [0.20.0]
 
 ### Added

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "author": "Getty Digital",
   "license": "J Paul Getty Trust",
   "bugs": {


### PR DESCRIPTION
Quire CLI v0.20.0 published a broken build to npm, this PR updates the version on `main` with the corrected and published v0.20.1