### PR TITLE
Fix / To include only pages within the section(s) where a contents list is rendered

### DIFF
--- a/themes/default/layouts/contents/single.html
+++ b/themes/default/layouts/contents/single.html
@@ -23,10 +23,10 @@
     <div class="container {{ if in $class "grid" }}is-fullhd{{ end }}">
       <div class="quire-contents-list {{ if in $class "grid" }} grid{{ else if in $class "abstract" }} abstract{{ else if in $class "brief" }} brief{{ else }} list{{ end }}">
         {{ if .Section }}
-          {{ $scope := where .Site.Pages "Section" .Section }}
+          {{ $scope := .File.Dir }}
           {{- partial "contents-list/contents-list.html" (dict "site" .Site "contentsScope" $scope "contentsLocation" ".Params.toc" "contentsPage" . ) -}}
         {{ else }}
-          {{ $scope := .Site.Pages }}
+          {{ $scope := "" }}
           {{- partial "contents-list/contents-list.html" (dict "site" .Site "contentsScope" $scope "contentsLocation" ".Params.toc" "contentsPage" . ) -}}
         {{ end }}
       </div>

--- a/themes/default/layouts/partials/contents-list/contents-list.html
+++ b/themes/default/layouts/partials/contents-list/contents-list.html
@@ -45,7 +45,7 @@
 {{/* List pages, but remove data pages, those hidden from toc/menu, and those hidden from specific output formats as needed
 --------------------------------------------------------------------------- */}}
 {{- $pages := "" -}}
-{{- $pages = where .contentsScope ".Kind" "page" -}}
+{{- $pages = where .site.Pages ".Kind" "page" -}}
 {{- $pages = where $pages ".Type" "!=" "data" -}}
 {{- $pages = where $pages .contentsLocation "!=" "false" -}}
 {{- if eq .site.Params.pdf true -}}
@@ -63,11 +63,14 @@
   {{- $pageOne = .Weight -}}
 {{- end -}}
 
-{{- $class := "" -}}
+{{- $contentsPageClass := "" -}}
+{{- $contentsPageID := "" -}}
 {{- if eq .contentsLocation ".Params.toc" -}}
-  {{- $class = .contentsPage.Params.class -}}
+  {{- $contentsPageClass = .contentsPage.Params.class -}}
+  {{- $contentsPageID = .contentsPage.File.UniqueID -}}
 {{- else -}}
-  {{- $class = .site.Params.menuClass -}}
+  {{- $contentsPageClass = .site.Params.menuClass -}}
+  {{- $contentsPageID = "" -}}
 {{- end -}}
 
 {{/* This contents list is built based on the number of section levels any given page is at, which is determined by looking at its File.Dir.
@@ -82,7 +85,9 @@ In order to properly close the /ul/li elements and nest sub-sections, the logic 
 
 {{- $lastSection := "/" -}}
 {{- $openSections := dict -}}
-{{- $renderedSections := "/" -}}
+{{- $renderedSections := .contentsScope -}}
+{{- $contentsScopePattern := printf "%s%s" "^" $renderedSections -}}
+{{- $contentsPageID := .contentsPage.File.UniqueID -}}
 
 <ul>
 {{- range $index, $page := $pages -}}
@@ -100,6 +105,11 @@ In order to properly close the /ul/li elements and nest sub-sections, the logic 
     {{- end -}}
   {{- end -}}
   {{- $openSections = merge $openSections (dict $sectionLevelKey $section) -}}
+
+  {{/* Check to make sure the page is within the section that the contents list is being rendederd in (the "contents scope"). If it is, and it’s not also the contents page itself, render the list item for it.
+  ------------------------------------------------------------------------- */}}
+  {{- $pageWithinThisScope := findRE $contentsScopePattern $section -}}
+  {{- if and $pageWithinThisScope (ne $contentsPageID .File.UniqueID) -}}
 
   {{- if and (ne $lastSection $section) (eq $sameAsOpenSection false) -}}
 
@@ -142,23 +152,25 @@ In order to properly close the /ul/li elements and nest sub-sections, the logic 
       ------------------------------------------------------------------- */}}
       {{- partial "contents-list/section-heading" (dict "Section" $section "Level" (sub $sectionLevel 1) ) -}}
 
-      <li class="page-item level-{{ $sectionLevel }}{{ if lt .Page.Weight $pageOne }} frontmatter-page{{ end }}">{{ partial "contents-list/list-item-type" (dict "Page" . "Class" $class) }}</li>
+      <li class="page-item level-{{ $sectionLevel }}{{ if lt .Page.Weight $pageOne }} frontmatter-page{{ end }}">{{ partial "contents-list/list-item-type" (dict "Page" . "Class" $contentsPageClass) }}</li>
       {{ partial "contents-list/closing-tags" (dict "Page" . "AllPages" $pages "PageIndex" $index "openSections" $openSections) -}}
 
     {{- else -}}
-      <li class="section-item level-{{ if eq .Slug "." }}{{ sub $sectionLevel 1 }}{{ else }}{{ $sectionLevel }}{{ end }}{{ if lt .Page.Weight $pageOne }} frontmatter-page{{ end }}">{{ partial "contents-list/list-item-type" (dict "Page" . "Class" $class) }}
+      <li class="section-item level-{{ if eq .Slug "." }}{{ sub $sectionLevel 1 }}{{ else }}{{ $sectionLevel }}{{ end }}{{ if lt .Page.Weight $pageOne }} frontmatter-page{{ end }}">{{ partial "contents-list/list-item-type" (dict "Page" . "Class" $contentsPageClass) }}
       <ul>
     {{- end -}}
 
   {{- else -}}
 
-    <li class="page-item level-{{ $sectionLevel }}{{ if lt .Page.Weight $pageOne }} frontmatter-page{{ end }}">{{ partial "contents-list/list-item-type" (dict "Page" . "Class" $class) }}</li>
+    <li class="page-item level-{{ $sectionLevel }}{{ if lt .Page.Weight $pageOne }} frontmatter-page{{ end }}">{{ partial "contents-list/list-item-type" (dict "Page" . "Class" $contentsPageClass) }}</li>
     {{ partial "contents-list/closing-tags" (dict "Page" . "AllPages" $pages "PageIndex" $index "openSections" $openSections) -}}
 
   {{- end -}}
 
   {{- $lastSection = $section -}}
   {{- $renderedSections = delimit (uniq (slice $renderedSections $section)) ", " -}}
+
+  {{- end -}}
 
 {{- end -}}
 </ul>

--- a/themes/default/layouts/partials/menu.html
+++ b/themes/default/layouts/partials/menu.html
@@ -4,7 +4,7 @@ available on all pages. For users with Javascript enabled, this menu is hidden
 by default. Users with JS disabled will alwasy see the menu in its expanded state.
 */}}
 
-{{- $contents := dict "site" .Site "contentsScope" .Site.Pages "contentsLocation" ".Params.menu" "contentsPage" . }}
+{{- $contents := dict "site" .Site "contentsScope" "" "contentsLocation" ".Params.menu" "contentsPage" . }}
 
 <div  class="quire-menu menu"
       role="banner"

--- a/themes/default/source/css/components/quire-contents-list.scss
+++ b/themes/default/source/css/components/quire-contents-list.scss
@@ -81,8 +81,9 @@
     fill: background-color-text-classic($secondary-background-color);
   }
   @media screen {
-    .level-0 > a,
-    .level-0 > .list-header {
+    // Special styling for top-level list items
+    ul:first-child > li > a,
+    ul:first-child > li > .list-header {
       font-size: 1.375em;
       padding-bottom: 0;
       border-bottom-width: 0;
@@ -160,26 +161,28 @@
     width: inherit;
   }
 
-  // Headers that aren't links
+  // Grid headers that aren't links
+  // Top-level headers
+  ul:first-child > li.section-item {
+    padding: 1.5rem 0;
+    margin-bottom: 1.5rem;
+    border-top: 1px solid;
+    border-bottom: 1px solid;
+    @if (lightness($secondary-background-color) > 50) {
+      border-color: darken($secondary-background-color, 20%);
+    } @else {
+      border-color: lighten($secondary-background-color, 20%);
+    }
+    > .list-header {
+      font-size: 1.75rem;
+    }
+  }
+  // All other headers
   .section-item {
     grid-column: 1/-1;
     font-size: 1.125rem;
     .list-header {
       text-align: center;
-    }
-    &.level-0 {
-      padding: 1.5rem 0;
-      margin-bottom: 1.5rem;
-      border-top: 1px solid;
-      border-bottom: 1px solid;
-      @if (lightness($secondary-background-color) > 50) {
-        border-color: darken($secondary-background-color, 20%);
-      } @else {
-        border-color: lighten($secondary-background-color, 20%);
-      }
-      > .list-header {
-        font-size: 1.75rem;
-      }
     }
   }
   // Headers that are links
@@ -318,7 +321,8 @@
         }
       }
     }
-    .section-item.level-0 {
+    // Remove border for top-level items
+    ul:first-child > li.section-item {
       border-width: 0;
     }
   }

--- a/themes/default/static/css/application.css
+++ b/themes/default/static/css/application.css
@@ -9552,19 +9552,19 @@ html {
     margin-top: .375em;
     fill: #333333; }
   @media screen {
-    .quire-contents-list .level-0 > a,
-    .quire-contents-list .level-0 > .list-header {
+    .quire-contents-list ul:first-child > li > a,
+    .quire-contents-list ul:first-child > li > .list-header {
       font-size: 1.375em;
       padding-bottom: 0;
       border-bottom-width: 0; }
-      .quire-contents-list .level-0 > a .arrow svg,
-      .quire-contents-list .level-0 > .list-header .arrow svg {
+      .quire-contents-list ul:first-child > li > a .arrow svg,
+      .quire-contents-list ul:first-child > li > .list-header .arrow svg {
         display: inline-block; }
-      .quire-contents-list .level-0 > a:hover,
-      .quire-contents-list .level-0 > .list-header:hover {
+      .quire-contents-list ul:first-child > li > a:hover,
+      .quire-contents-list ul:first-child > li > .list-header:hover {
         border-bottom-width: 0; }
-        .quire-contents-list .level-0 > a:hover .arrow svg,
-        .quire-contents-list .level-0 > .list-header:hover .arrow svg {
+        .quire-contents-list ul:first-child > li > a:hover .arrow svg,
+        .quire-contents-list ul:first-child > li > .list-header:hover .arrow svg {
           margin-left: .75rem;
           fill: #CF4747;
           -webkit-transition: all .25s ease;
@@ -9610,19 +9610,20 @@ html {
 .quire-contents-list.grid .section-item > .list-header {
   width: inherit; }
 
+.quire-contents-list.grid ul:first-child > li.section-item {
+  padding: 1.5rem 0;
+  margin-bottom: 1.5rem;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: #b2c4c9; }
+  .quire-contents-list.grid ul:first-child > li.section-item > .list-header {
+    font-size: 1.75rem; }
+
 .quire-contents-list.grid .section-item {
   grid-column: 1/-1;
   font-size: 1.125rem; }
   .quire-contents-list.grid .section-item .list-header {
     text-align: center; }
-  .quire-contents-list.grid .section-item.level-0 {
-    padding: 1.5rem 0;
-    margin-bottom: 1.5rem;
-    border-top: 1px solid;
-    border-bottom: 1px solid;
-    border-color: #b2c4c9; }
-    .quire-contents-list.grid .section-item.level-0 > .list-header {
-      font-size: 1.75rem; }
 
 .quire-contents-list.grid .section-item > a {
   max-width: inherit;
@@ -9718,7 +9719,7 @@ html {
       font-weight: 400; }
     .quire-contents-list.grid .section-item > a::after {
       display: none; }
-  .quire-contents-list.grid .section-item.level-0 {
+  .quire-contents-list.grid ul:first-child > li.section-item {
     border-width: 0; } }
 
 .quire-figure {


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

No.

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

This fixes something I'd missed in PR #162 implementing sub-section support. When a contents-list is rendered within a sub-section of a project, it should only show the items within that sub-section and it's child sections. However, the way I had it before, there were circumstances when all the pages in the project were being listed.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Added checks to skip over pages not within the scope (.File.Dir) of the list where it is being rendered.

I also changed some CSS selectors so that the top-level list items are always styled the same, no matter where in the project they actually are. So, making the styling relative (`ul:first-child > li`) rather than fixed (`.level-0`).

### Does this pull request necessitate changes to Quire's documentation?

No.

### Include screenshots of before/after if applicable.



### Additional Comments

