### PR TITLE
Fix/DEV-11356: Nav titles

### DIFF
--- a/packages/11ty/_includes/components/navigation.js
+++ b/packages/11ty/_includes/components/navigation.js
@@ -14,7 +14,7 @@ const { html } = require('common-tags');
  */
 module.exports = function(eleventyConfig, globalData) {
   const eleventyNavigation = eleventyConfig.getFilter('eleventyNavigation')
-  const markdownify = eleventyConfig.getFilter('markdownify')
+  const pageTitle = eleventyConfig.getFilter('pageTitle')
   const { config } = globalData
 
   return function (params) {
@@ -26,6 +26,10 @@ module.exports = function(eleventyConfig, globalData) {
 
     // @TODO figure out js module-friendly filters -- this one should work though
     const truncate = (text, limit) => text.slice(0, limit)
+
+    const navBarLabel = ({ label, short_title, title }) => {
+      return pageTitle({ label, title: short_title || truncate(title, 34)})
+    }
 
     const navBarStartButton = () => {
       if (!isHomePage) return ''
@@ -51,8 +55,8 @@ module.exports = function(eleventyConfig, globalData) {
 
     const navBarPreviousButton = () => {
       if (!previousPage) return ''
-      const { data, label, url } = previousPage
-      const { short_title, title } = data
+      const { data, url } = previousPage
+      const { label, short_title, title } = data
       return html`
         <li class="quire-navbar-page-controls__item quire-previous-page">
           <a href="${url}" rel="previous">
@@ -65,7 +69,7 @@ module.exports = function(eleventyConfig, globalData) {
                 </foreignObject>
               </switch>
             </svg>
-            <span class="nav-label">${ label ? label + pageLabelDivider : ''}${short_title ? markdownify(short_title) : truncate(markdownify(title), 34)}</span>
+            ${navBarLabel({ label, short_title, title })}
           </a>
         </li>
       `
@@ -94,13 +98,13 @@ module.exports = function(eleventyConfig, globalData) {
 
     const navBarNextButton = () => {
       if (isHomePage || !nextPage) return ''
-      const { data, label, url } = nextPage
-      const { short_title, title } = data
+      const { data, url } = nextPage
+      const { label, short_title, title } = data
       return html`
         <li class="quire-navbar-page-controls__item quire-next-page">
           <a href="${url}" rel='next'>
             <span class="visually-hidden">Next Page: </span>
-            <span class="nav-label">${ label ? label + pageLabelDivider : ''}${short_title ? markdownify(short_title) : truncate(markdownify(title), 34)}</span>
+            ${navBarLabel({ label, short_title, title })}
             <svg class="remove-from-epub">
               <switch>
                 <use xlink:href="#right-arrow-icon"></use>

--- a/packages/11ty/_includes/components/page-title.js
+++ b/packages/11ty/_includes/components/page-title.js
@@ -12,7 +12,7 @@
  * @return {string} `page title: subtitle`
  */
 module.exports = function(eleventyConfig, globalData) {
-  const { config } = globalData
+  const markdownify = eleventyConfig.getFilter('markdownify')
   return function(params) {
 
     const { label, subtitle, title } = params
@@ -24,6 +24,6 @@ module.exports = function(eleventyConfig, globalData) {
       pageTitle = `${label}${config.params.pageLabelDivider} ${pageTitle}`
     }
 
-    return pageTitle;
+    return markdownify(pageTitle)
   }
 }

--- a/packages/11ty/_includes/components/page-title.js
+++ b/packages/11ty/_includes/components/page-title.js
@@ -13,6 +13,9 @@
  */
 module.exports = function(eleventyConfig, globalData) {
   const markdownify = eleventyConfig.getFilter('markdownify')
+
+  const { pageLabelDivider } = globalData.config.params
+
   return function(params) {
 
     const { label, subtitle, title } = params
@@ -21,7 +24,7 @@ module.exports = function(eleventyConfig, globalData) {
     let pageTitle = subtitle ? [title, subtitle].join(separator) : title
 
     if (label) {
-      pageTitle = `${label}${config.params.pageLabelDivider} ${pageTitle}`
+      pageTitle = `${[label, pageTitle].join(pageLabelDivider)}`
     }
 
     return markdownify(pageTitle)


### PR DESCRIPTION
Changes:
- Markdownifies `pageTitle`
- Removes extra space from `pageTitle` with `label`
- Fixes destructuring of `label` from `page`
- Refactors nav label to use `pageTitle` component