### PR TITLE
DEV-11358: Fix missing fonts on catalogue item pages

### DIFF
--- a/packages/11ty/_includes/components/icon.js
+++ b/packages/11ty/_includes/components/icon.js
@@ -18,19 +18,20 @@ module.exports = function(eleventyConfig, globalData) {
   return function (params) {
     const { description, type } = params
     const iconPath = path.join(imageDir, 'icons', `${type}.png`)
+    const descriptionElement = description
+      ? `<span class="visually-hidden remove-from-epub">${description}</span>`
+      : ''
 
     return html`
-      <span class="remove-from-epub">
-        <svg>
-          <switch>
-            <use xlink:href="#${type}-icon"></use>
-            <foreignObject width="24" height="24">
-              <img src="${iconPath}" alt="${description}" />
-            </foreignObject>
-          </switch>
-        </svg>
-        <span class="visually-hidden">${description}</span>
-      </span>
+      <svg class="remove-from-epub">
+        <switch>
+          <use xlink:href="#${type}-icon"></use>
+          <foreignObject width="24" height="24">
+            <img src="${iconPath}" alt="${description}" />
+          </foreignObject>
+        </switch>
+      </svg>
+      ${descriptionElement}
     `
   }
 }

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -63,9 +63,11 @@ Entry content, including entry image and tombstone data
     <div class="quire-entry__content">
       {% if epub != true %}
         <header class="quire-entry__header">
-          <h1 class="quire-page__header__title" id="{{ title | url }}">
-            {% pageTitle label=label, title=title, subtitle=subtitle %}
-          </h1>
+          <div class="container">
+            <h1 class="quire-page__header__title" id="{{ title | url }}">
+              {% pageTitle label=label, title=title, subtitle=subtitle %}
+            </h1>
+          </div>
           {% contributorHeader
             contributor=contributor,
             contributor_as_it_appears=contributor_as_it_appears,

--- a/packages/11ty/content/_assets/styles/fonts.scss
+++ b/packages/11ty/content/_assets/styles/fonts.scss
@@ -2,7 +2,7 @@
 // Fonts.scss
 // -----------------------------------------------------------------------------
 // Custom font declarations (if any) can be imported here
-$assets-dir: "../_assets/" !default;
+$assets-dir: "/_assets/" !default;
 
 @function font($file) {
   @return url($assets-dir + 'fonts/' + $file);


### PR DESCRIPTION
- Add missing `div.container` wrapping `.quire-page__header__title` on catalogue entry pages
- Fix font asset path
- Fix catalogue item button link icon alignment; re-implement conditional description span in icon component