### PR TITLE
fix/DEV 11340 remove jquery

### DIFF
--- a/packages/11ty/content/_assets/javascript/application/deepzoom.js
+++ b/packages/11ty/content/_assets/javascript/application/deepzoom.js
@@ -170,14 +170,19 @@ class DeepZoom {
     if (bounds) {
       this.map.setMaxBounds(bounds);
       this.map.fitBounds(bounds);
-      let imageOverlay = L.imageOverlay(this.imageURL, bounds, {
+      const imageOverlay = L.imageOverlay(this.imageURL, bounds, {
         opacity: 0.0
       });
       this.map.addLayer(imageOverlay);
-      imageOverlay.on("load", event => {
-        setTimeout(() => {
-          imageOverlay.setOpacity(1.0);
-        }, 250);
+      const loadEvent = new Promise((resolve) => {
+        imageOverlay.on("load", resolve);
+      });
+      const zoomEvent = new Promise((resolve) => {
+        this.map.on("zoomend", resolve);
+      });
+      // only make images opaque when finished loading, and after initial zoom transition
+      Promise.all([loadEvent, zoomEvent]).then(() => {
+        imageOverlay.setOpacity(1.0);
       });
     }
   }

--- a/packages/11ty/content/_assets/javascript/application/deepzoom.js
+++ b/packages/11ty/content/_assets/javascript/application/deepzoom.js
@@ -121,11 +121,13 @@ class DeepZoom {
     setTimeout(() => {
       this.validateSize(map);
     }, 100);
-    if ($(window)) {
-      $(window).on("resize", event => {
-        if (map) {
-          this.validateSize(map);
-        }
+    if (window) {
+      window.addEventListener('resize', (event) => {
+        window.requestAnimationFrame(() => {
+          if (map) {
+            this.validateSize(map);
+          }
+        });
       });
     }
   }

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -622,8 +622,8 @@ function pageTeardown() {
 // Run immediately
 globalSetup();
 
-// Run when document is ready
-$(window).ready(() => {
+// Run when DOM content has loaded
+window.addEventListener('DOMContentLoaded', () => {
   pageSetup();
   scrollToHashOnLoad();
-});
+})

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -16,7 +16,6 @@ import quicklink from "quicklink";
 
 // JS Libraries (add them to package.json with `npm install [library]`)
 import "babel-polyfill";
-import $ from "jquery";
 import "velocity-animate";
 import "./soundcloud-api";
 

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -441,10 +441,9 @@ function mlaDate(date) {
  *
  */
 function setDate() {
-  const $date = $(".cite-current-date");
+  const dateSpan = document.querySelector(".cite-current-date");
   const formattedDate = mlaDate(new Date());
-  $date.empty();
-  $date.text(formattedDate);
+  dateSpan.innerHTML(formattedDate);
 }
 
 /**

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -123,7 +123,6 @@ async function sliderSetup() {
     document.getElementById("quire-entry__image")
   );
 
-  let jqueryslider = $(".quire-entry__image__group-container");
   const slider = document.querySelector(".quire-entry__image__group-container");
   if (slider) {
     const sliderImages = slider.querySelectorAll("figure");

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -443,7 +443,7 @@ function mlaDate(date) {
 function setDate() {
   const dateSpan = document.querySelector(".cite-current-date");
   const formattedDate = mlaDate(new Date());
-  dateSpan.innerHTML(formattedDate);
+  dateSpan && dateSpan.innerHTML = formattedDate;
 }
 
 /**
@@ -457,6 +457,8 @@ function setDate() {
  */
 function slideImage(direction, event, mapArr) {
   event.stopPropagation();
+  const deepZoomImageContainer = document.querySelector(".leaflet-image-layer");
+  console.warn('DIRECTION, EVENT, MAPARR \n\n\n', direction, event, mapArr);
   let deepzoomCont = $(".leaflet-image-layer");
   deepzoomCont.hide();
   let slider = $(".quire-entry__image__group-container");

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -125,11 +125,11 @@ async function sliderSetup() {
 
   const slider = document.querySelector(".quire-entry__image__group-container");
   if (slider) {
-    const sliderImages = slider.querySelectorAll("figure");
-    const sliderImageCount = sliderImages.length
-    sliderImages.forEach((sliderImage, index) => {
-      if (sliderImageCount > 1) {
-        const counterDownloadContainer = sliderImage.querySelector(".quire-image-counter-download-container");
+    const slides = slider.querySelectorAll("figure");
+    const slidesCount = slides.length;
+    slides.forEach((slide, index) => {
+      if (slidesCount > 1) {
+        const counterDownloadContainer = slide.querySelector(".quire-image-counter-download-container");
         counterDownloadContainer && counterDownloadContainer.append(
           createHtml(
             "div",
@@ -137,19 +137,19 @@ async function sliderSetup() {
             createHtml(
               "span",
               { className: "counter" },
-              `${index + 1} of ${sliderImageCount}`
+              `${index + 1} of ${slidesCount}`
             )
           )
         );
         if (index > 0) {
-          sliderImage.classList.add("visually-hidden")
+          slide.classList.add("visually-hidden");
+          // slide.style.display = "none";
         }
       }
     });
-    const firstImage = sliderImages[0];
+    const firstImage = slides[0];
     firstImage.classList.add("current-image", "first-image");
-    firstImage.style.display = "flex";
-    const lastImage = sliderImages[sliderImageCount - 1];
+    const lastImage = slides[slidesCount - 1];
     lastImage.classList.add("last-image");
   }
   const images = [...document.querySelectorAll(".quire-deepzoom-entry")];
@@ -459,50 +459,57 @@ function setDate() {
  */
 function slideImage(direction, event, mapArr) {
   event.stopPropagation();
-  const deepZoomImageContainer = document.querySelector(".leaflet-image-layer");
-  console.warn('DIRECTION, EVENT, MAPARR \n\n\n', direction, event, mapArr);
-  let deepzoomCont = $(".leaflet-image-layer");
-  deepzoomCont.hide();
-  let slider = $(".quire-entry__image__group-container");
-  let firstImage = slider.children(".first-image");
-  let lastImage = slider.children(".last-image");
-  let currentImage = slider.children(".current-image");
-  let nextImage = currentImage.next("figure");
-  let prevImage = currentImage.prev("figure");
-  stopVideo(document.querySelector(".current-image"));
-  currentImage.hide();
-  currentImage.removeClass("current-image");
-  if (direction == "next") {
-    if (currentImage.hasClass("last-image")) {
-      firstImage.addClass("current-image");
-      firstImage.css("display", "flex");
-      firstImage.removeClass("visually-hidden");
-    } else {
-      nextImage.addClass("current-image");
-      nextImage.css("display", "flex");
-      nextImage.removeClass("visually-hidden");
-    }
-  } else if (direction == "prev") {
-    if (currentImage.hasClass("first-image")) {
-      lastImage.addClass("current-image");
-      lastImage.css("display", "flex");
-      lastImage.removeClass("visually-hidden");
-    } else {
-      prevImage.addClass("current-image");
-      prevImage.css("display", "flex");
-      prevImage.removeClass("visually-hidden");
-    }
-  }
 
-  mapArr.forEach(v => {
-    validateSize(v)
-      .then(() => {
-        deepzoomCont.fadeIn({
-          duration: "fast"
-        });
-      })
-      .catch(err => console.log(err));
-  });
+  const hideElement = (element) => {
+    element.style.display = "none";
+  };
+
+  const showElement = (element, displayValue) => {
+    element.style.display = displayValue;
+  };
+
+  const slider = document.querySelector(".quire-entry__image__group-container");
+  const leafletImages = Array.from(document.querySelector(".leaflet-image-layer"));
+  const slides = Array.from(slider.querySelectorAll("figure"));
+  const currentSlide = slider.querySelector(".current-image");
+  const currentSlideIndex = slides.findIndex((item) => item.classList.contains("current-image"));
+  const nextSlide = slides.slice((currentSlideIndex + 1) % slides.length)[0];
+  const prevSlide = slides.slice((currentSlideIndex - 1) % slides.length)[0];
+
+  const showSlide = (slide) => {
+    leafletImages.forEach((image) => {
+      hideElement(image);
+    });
+    stopVideo(currentSlide);
+    hideElement(currentSlide);
+    currentSlide.classList.remove("current-image");
+    slides.forEach((item) => {
+      item.classList.add("visually-hidden");
+    });
+    slide.classList.add("current-image");
+    showElement(slide, "flex")
+    slide.classList.remove("visually-hidden")
+    mapArr.forEach((map) => {
+      validateSize(map)
+        .then(() => {
+          leafletImages.forEach((image) => {
+            showElement(image, "block")
+          });
+        })
+        .catch((error) => console.error(error));
+    });
+  };
+
+  switch(direction) {
+    case "next":
+      showSlide(nextSlide);
+      break;
+    case "prev":
+      showSlide(prevSlide);
+      break;
+    default:
+      break;
+  }
 }
 
 /**
@@ -514,9 +521,7 @@ function slideImage(direction, event, mapArr) {
 function validateSize(map) {
   return new Promise((resolve, reject) => {
     if (!map) reject(new Error("No map!"));
-    setTimeout(() => {
-      resolve(map.invalidateSize());
-    }, 250);
+    resolve(map.invalidateSize());
   });
 }
 

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -312,15 +312,17 @@ function globalSetup() {
  */
 function loadSearchData() {
   // Grab search data
-  let dataURL = $("#js-search").data("search-index");
+  const dataURL = document.getElementById('js-search').dataset.searchIndex;
   if (!dataURL) {
-    console.warn('Search data url is undefined')
-    return
+    console.warn('Search data url is undefined');
+    return;
   }
-  $.get(dataURL, {
-    cache: true
-  }).done(data => {
-    data = typeof data === "string" ? JSON.parse(data) : data;
+  fetch(dataURL).then(async (response) => {
+    const { ok, statusText, url } = response
+    if (!ok) {
+      console.warn(`Search data ${statusText.toLowerCase()} at ${url}`)
+    }
+    const data = await response.json();
     window["QUIRE_SEARCH"] = new Search(data);
   });
 }

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -98,6 +98,20 @@ window["toggleSearch"] = () => {
 };
 
 /**
+ * Paul Frazee's easy templating function
+ * https://twitter.com/pfrazee/status/1223249561063477250?s=20
+ */
+function createHtml(tag, attributes, ...children) {
+  const element = document.createElement(tag);
+  for (let attribute in attributes) {
+    if (attribute === 'className') element.className = attributes[attribute];
+    else element.setAttribute(attribute, attributes[attribute]);
+  }
+  for (let child of children) element.append(child);
+  return element;
+}
+
+/**
  * sliderSetup
  * @description Set up the simple image slider used on catalogue entry pages for
  * objects with multiple figure images. See also slideImage function below.

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -123,33 +123,43 @@ async function sliderSetup() {
     document.getElementById("quire-entry__image")
   );
 
-  let slider = $(".quire-entry__image__group-container");
-  slider.each(function() {
-    let sliderImages = $(this).find("figure");
-    sliderImages.each((i, v) => {
-      if (sliderImages.length > 1) {
-        $(v)
-          .find(".quire-image-counter-download-container")
-          .append(
-            `<div class="quire-counter-container"><span class="counter">${i +
-              1} of ${sliderImages.length}</span></div>`
-          );
+  let jqueryslider = $(".quire-entry__image__group-container");
+  const slider = document.querySelector(".quire-entry__image__group-container");
+  if (slider) {
+    const sliderImages = slider.querySelectorAll("figure");
+    const sliderImageCount = sliderImages.length
+    sliderImages.forEach((sliderImage, index) => {
+      if (sliderImageCount > 1) {
+        const counterDownloadContainer = sliderImage.querySelector(".quire-image-counter-download-container");
+        counterDownloadContainer && counterDownloadContainer.append(
+          createHtml(
+            "div",
+            { className: "quire-counter-container" },
+            createHtml(
+              "span",
+              { className: "counter" },
+              `${index + 1} of ${sliderImageCount}`
+            )
+          )
+        );
+        if (index > 0) {
+          sliderImage.classList.add("visually-hidden")
+        }
       }
     });
-    let firstImage = $(sliderImages.first());
-    let lastImage = $(sliderImages.last());
-    sliderImages.addClass("visually-hidden");
-    firstImage.addClass("current-image first-image");
-    firstImage.removeClass("visually-hidden");
-    firstImage.css("display", "flex");
-    lastImage.addClass("last-image");
-  });
+    const firstImage = sliderImages[0];
+    firstImage.classList.add("current-image", "first-image");
+    firstImage.style.display = "flex";
+    const lastImage = sliderImages[sliderImageCount - 1];
+    lastImage.classList.add("last-image");
+  }
   const images = [...document.querySelectorAll(".quire-deepzoom-entry")];
-  const imageSrcs = images.filter(v => {
-      return v.getAttribute("src") !== null ? v : "";
+  const imageSrcs = images
+    .filter((image) => {
+      return image.getAttribute("src");
     })
-    .map(v => {
-      return v.getAttribute("src");
+    .map((image) => {
+      return image.getAttribute("src");
     });
   await preloadImages(imageSrcs);
   mapSetup(".quire-map-entry");

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -477,6 +477,10 @@ function slideImage(direction, event, mapArr) {
   const prevSlide = slides.slice((currentSlideIndex - 1) % slides.length)[0];
 
   const showSlide = (slide) => {
+    // TODO refactor slideshow navigation logic to not require a complex combination of setting/unsetting class names and inline styles
+    // the `visually-hidden` class is added to keep slides in the DOM but not visible
+    // toggling `display: none`/`display: flex` on <figure>s (slide containers) replaced previous slideshow display logic depending on <jQueryElement>.hide()
+    // toggling `display: none`/`display: block` and `class="current-image"` on leaflet image layer `<img>` tags triggers CSS `fadeIn` animation, replacing animation delays previously set with a `setTimeout`
     leafletImages.forEach((image) => {
       hideElement(image);
     });

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -38,19 +38,17 @@ const mapArr = [];
  * templates without additional binding.
  */
 window["toggleMenu"] = () => {
-  let menu = document.getElementById("site-menu");
-  document.getElementsByClassName;
-  let menuAriaStatus = menu.getAttribute("aria-expanded");
+  const menu = document.getElementById("site-menu");
+  const catalogEntryImage = document.querySelector(
+    ".side-by-side > .quire-entry__image-wrap > .quire-entry__image"
+  );
+  const menuAriaStatus = menu.getAttribute("aria-expanded");
   menu.classList.toggle("is-expanded", !menu.classList.contains("is-expanded"));
   if (menuAriaStatus === "true") {
-    $(
-      ".side-by-side > .quire-entry__image-wrap > .quire-entry__image"
-    ).removeClass("menu_open");
+    catalogEntryImage && catalogEntryImage.classList.remove("menu_open")
     menu.setAttribute("aria-expanded", "false");
   } else {
-    $(
-      ".side-by-side > .quire-entry__image-wrap > .quire-entry__image"
-    ).addClass("menu_open");
+    catalogEntryImage && catalogEntryImage.classList.add("menu_open")
     menu.setAttribute("aria-expanded", "true");
   }
 };

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -443,7 +443,9 @@ function mlaDate(date) {
 function setDate() {
   const dateSpan = document.querySelector(".cite-current-date");
   const formattedDate = mlaDate(new Date());
-  dateSpan && dateSpan.innerHTML = formattedDate;
+  if (dateSpan) {
+    dateSpan.innerHTML = formattedDate;
+  }
 }
 
 /**

--- a/packages/11ty/content/_assets/javascript/application/map.js
+++ b/packages/11ty/content/_assets/javascript/application/map.js
@@ -24,7 +24,7 @@ class Map {
       this.el = id
       this.tiles = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       this.attribution = 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
-      this.data = $(`#${this.el}`).data('geojson')
+      this.data = document.querySelector(`#${this.el}`).dataset.geojson
       this.center = this.getCoordinates()
       this.defaultZoom = 6
       this.map = this.createMap()
@@ -62,32 +62,31 @@ class Map {
   }
 
   getCoordinates() {
-    let lat = $('#' + this.el).data('lat')
-    let long = $('#' + this.el).data('long')
+    let lat = document.querySelector(`#${this.el}`).dataset.lat
+    let long = document.querySelector(`#${this.el}`).dataset.long
     return [lat, long]
   }
 
-  getData() {
-    $.getJSON(this.data, json => {
-      L.geoJson(json, {
-        // Change the style here as desired
-        pointToLayer: (feature, latlng) => {
-          return L.circleMarker(latlng, {
-            radius: 8,
-            fillColor: '#333',
-            color: '#000',
-            weight: 1,
-            opacity: 1,
-            fillOpacity: 0.75
-          })
-        },
-        // Change styles here as desired
-        onEachFeature: (feature, layer) => {
-          let options = { minWidth: 100, maxHeight: 250 }
-          layer.bindPopup(feature.properties.description, options)
-        }
-      }).addTo(this.map)
-    })
+  async getData() {
+    const json = await fetch(this.data).then((data) => data.json());
+    L.geoJson(json, {
+      // Change the style here as desired
+      pointToLayer: (feature, latlng) => {
+        return L.circleMarker(latlng, {
+          radius: 8,
+          fillColor: '#333',
+          color: '#000',
+          weight: 1,
+          opacity: 1,
+          fillOpacity: 0.75
+        })
+      },
+      // Change styles here as desired
+      onEachFeature: (feature, layer) => {
+        let options = { minWidth: 100, maxHeight: 250 }
+        layer.bindPopup(feature.properties.description, options)
+      }
+    }).addTo(this.map)
   }
 }
 

--- a/packages/11ty/content/_assets/javascript/application/popup.js
+++ b/packages/11ty/content/_assets/javascript/application/popup.js
@@ -131,12 +131,13 @@ export default function(gallerySelector, mapArr) {
   };
   updateViewSlidesLink();
 
+  const hasGalleryElement = document.querySelector(gallerySelector)
   /**
    *
    * @description e magnificPopup object
    *
    */
-  $(gallerySelector).magnificPopup({
+  hasGalleryElement && $(gallerySelector).magnificPopup({
     delegate: "a.popup",
     type: "image",
     closeBtnInside: false,

--- a/packages/11ty/content/_assets/styles/components/quire-deepzoom.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-deepzoom.scss
@@ -11,6 +11,10 @@ $fullscreen-button-img: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAA
 }
 
 .quire-deepzoom {
+  img {
+    // opacity transition applied when navigation through popup leaflet image slideshows
+    transition: opacity 0.2s linear;
+  }
   .leaflet-table {
     max-height: 84%;
     margin: 2.5em 3.25em 0em 2.5em;

--- a/packages/11ty/content/_assets/styles/components/quire-entry.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-entry.scss
@@ -114,7 +114,7 @@ $image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAABYCAQAAACjBqE3AA
       align-items: center;
       justify-content: center;
       position: relative;
-      
+
       @media screen and (max-width: $desktop) {
         height: 60vh;
       }
@@ -123,6 +123,14 @@ $image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAABYCAQAAACjBqE3AA
         margin: 0 auto;
         padding: 0;
         height: auto;
+      }
+
+      &.current-image img {
+        // fadeIn animation applied when navigating through non-popup leaflet image slideshows
+        animation-name: fadeIn;
+        animation-delay: 0.25s;
+        animation-duration: 0.2s;
+        animation-fill-mode: backwards;
       }
 
       iframe {


### PR DESCRIPTION
- Refactor jQuery out of `toggleMenu` method
- Add simple HTML templating function
- Refactor jQuery out of `setupSlider` method
- Fix broken popup slideshow
- remove unused `jqueryslider` variable
- Replace `$(window).ready` with vanilla `DOMContentLoaded` event listener
- Refactor jQuery out of `scrollToHash` and `scrollToHashOnLoad` functions, split apart shared logic into separate functions
- Refactor `loadSearchData` to replace jQuery `get()` with `fetch()`
- refactor jQuery out of `setDate`
- Refactor `DeepZoom` `addTiles` method to set opacity after load and initial zoom animation are complete
- Refactor jQuery out of `sliderSetup` and `slideImage` functions; clean up style/classname adding/removing logic from `sliderSetup`
- Setup leaflet images in popups and on catalog entry pages to use CSS animations and transitions instead of relying on `setTimeout`