### PR TITLE
Reimplement popup/lightbox js to remove jQuery/magnific-popup

### DIFF
--- a/packages/11ty/content/_assets/javascript/application/helper.js
+++ b/packages/11ty/content/_assets/javascript/application/helper.js
@@ -195,3 +195,17 @@ export const toggleFullscreen = (
     });
   }
 };
+
+/**
+ * Paul Frazee's easy templating function
+ * https://twitter.com/pfrazee/status/1223249561063477250?s=20
+ */
+export const createHtml = (tag, attributes, ...children) => {
+  const element = document.createElement(tag);
+  for (let attribute in attributes) {
+    if (attribute === 'className') element.className = attributes[attribute];
+    else element.setAttribute(attribute, attributes[attribute]);
+  }
+  for (let child of children) element.append(child);
+  return element;
+}

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -20,7 +20,7 @@ import "velocity-animate";
 import "./soundcloud-api";
 
 // Modules (feel free to define your own and import here)
-import { preloadImages, stopVideo, toggleFullscreen } from "./helper";
+import { createHtml, preloadImages, stopVideo, toggleFullscreen } from "./helper";
 import DeepZoom from "./deepzoom";
 import Map from "./map";
 import Navigation from "./navigation";
@@ -95,20 +95,6 @@ window["toggleSearch"] = () => {
     searchControls.setAttribute("aria-expanded", "true");
   }
 };
-
-/**
- * Paul Frazee's easy templating function
- * https://twitter.com/pfrazee/status/1223249561063477250?s=20
- */
-function createHtml(tag, attributes, ...children) {
-  const element = document.createElement(tag);
-  for (let attribute in attributes) {
-    if (attribute === 'className') element.className = attributes[attribute];
-    else element.setAttribute(attribute, attributes[attribute]);
-  }
-  for (let child of children) element.append(child);
-  return element;
-}
 
 /**
  * sliderSetup

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -22,6 +22,7 @@ import "./soundcloud-api";
 // Modules (feel free to define your own and import here)
 import { createHtml, preloadImages, stopVideo, toggleFullscreen } from "./helper";
 import DeepZoom from "./deepzoom";
+import Lightbox from "./lightbox";
 import Map from "./map";
 import Navigation from "./navigation";
 import Popup from "./popup";
@@ -336,7 +337,10 @@ function popupSetup(figureModal) {
     document.querySelector(".mfp-wrap")
   );
   if (figureModal) {
-    Popup(".q-figure__wrapper", mapArr);
+    // Popup(".q-figure__wrapper", mapArr);
+    if (Lightbox.figures.length) {
+      new Lightbox();
+    }
   } else {
     mapSetup(".quire-map");
     deepZoomSetup(".quire-deepzoom", mapArr);

--- a/packages/11ty/content/_assets/javascript/application/lightbox.js
+++ b/packages/11ty/content/_assets/javascript/application/lightbox.js
@@ -1,0 +1,84 @@
+import { createHtml, preloadImages, stopVideo, toggleFullscreen } from "./helper";
+
+export default class Lightbox {
+  static figures = document.querySelectorAll('.q-figure')
+  static triggerSelector = 'a.popup, .open-lightbox';
+  static lightboxClass = 'lightbox';
+  static lightboxClassHidden = `${this.lightboxClass}--hidden`;
+
+  constructor() {
+    this.lightbox = this.createLightbox();
+    this.currentTrigger = null;
+    this.currentFigure = null;
+    this.init();
+  }
+
+  createLightbox() {
+    const { lightboxClass, lightboxClassHidden } = this.constructor;
+    function caption() {
+      return createHtml('div', { className: `${lightboxClass}__caption` });
+    }
+    function lightboxContent() {
+      return createHtml('div', { className: `${lightboxClass}__content` });
+    }
+    function navigationButtons() {
+      return createHtml('div', { className: `${lightboxClass}__navigation` });
+    }
+    function slideCounterAndCloseButton() {
+      return createHtml('div', { className: `${lightboxClass}__slide-counter-container` });
+    }
+    function zoomControls() {
+      return createHtml('div', { className: `${lightboxClass}__zoom-controls` });
+    }
+    return createHtml(
+      'div',
+      { className: `${lightboxClass} ${lightboxClassHidden}` },
+      [
+        lightboxContent(),
+        zoomControls(),
+        slideCounterAndCloseButton(),
+        navigationButtons(),
+        caption()
+      ]
+    );
+  }
+
+  close() {
+    this.lightbox.classList.add(this.constructor.lightboxClassHidden);
+    this.currentTrigger.focus();
+  }
+
+  init() {
+    this.setupTriggers();
+    this.renderLightbox();
+  }
+
+  open({ target, currentTarget }) {
+    console.warn('CURRRENT TARGET', currentTarget);
+    let trigger = target;
+    let figure = target;
+    console.warn('CLICK EVENT BEFORE PARENTS', typeof trigger, trigger, typeof figure, figure);
+    while (!trigger.matches(this.constructor.triggerSelector)) {
+      trigger = trigger.parentNode;
+    }
+    while (!figure.matches('figure')) {
+      figure = figure.parentNode;
+    }
+    console.warn('CLICK EVENT AFTER PARENTS', trigger, figure);
+    this.currentTrigger = trigger;
+    this.currentFigure = figure;
+    this.lightbox.classList.remove(this.constructor.lightboxClassHidden);
+    this.lightbox.focus();
+  }
+
+  renderLightbox() {
+    const quireContainer = document.getElementById('container');
+    quireContainer.insertAdjacentElement('afterend', this.lightbox);
+  }
+
+  setupTriggers() {
+    document.querySelectorAll(this.constructor.triggerSelector).forEach((item) => {
+      item.addEventListener('click', this.open);
+    });
+  }
+}


### PR DESCRIPTION
- Replace Hugo with e11ty
- Replace go-iiif with node-iiif
- WIP setup eleventy build
- Add layouts for HTML5 audio and video elements
- Add src for testing
- Fix syntax error and import path for shortcodes
- Update bibliography, contributors  files to use nunjucks-style shortcodes
- Rewrite shortcodes in nunjucks syntax
- Remove - from shortcodes
- Update essay.md
- Translate intro shortcodes into nunjucks
- Use .geojson extension
- Remove templates directory
- Move project css and js directories
- Move figure templates to _includes
- Add figures README files
- Fix whitespace
- Convert fallback media-types template to liquid
- Set fallback include template extension
- Rename includes with liquid template extension
- Rewrite soundcloud include as a liquid template
- Rename includes using liquid template extension
- Cleanup fallback and image include
- Rewrite content with liquid
- Ensure Essay template named params are comma-separated
- Cleanup video include template
- Add _includes/page with converted `abstract.liquid`, and empty `bibliography`, `class`, and `header` includes
- Cleanup audio include template
- Add empty footer-buttons.liquid include file
- Add essay page layout
- Move config.yml to _data/site.json
- Rewrite media-type includes as liquid templates
- Use relative include paths
- Move contents-list, but comment out for now
- Rename includes with liquid template extension
- Add module for a universal markdown filter
- Correct render syntax
- Correct extension for figure includes
- Add custom data parser for json5
- Change extension for site data json to allow comments
- Remove global data file meta.json
- Implement markdown filter
- Add include for Google analytics
- Migrate copyright partial
- Updating a few variables to use 11ty naming and adding comments
- Getting rid of dollar signs
- Convert media-type table include to liquid
- Use liquid with to pass params to includes
- Convert debug include to a liquid template
- Convert icons liquid templates
- Add liquid extension to icon include
- Migrate site-title partial
- Set options for the Liquid template parsing engine
- Convert dublin-core include to liquid
- Remove include extension, assume .liquid
- Convert error-message include to liquid
- Convert twitter-card include to liquid
- Move templates to includes
- Convert pdf includes to liquid templates
- Implement `cover` layout, `contributor` includes to replace `contributor-list``
- fix syntax errors in cover page template
- Update essay tempalte to use `render` instead of `include`
- Implement `page/header` include
- Convert page tombstone to liquid template
- Don't rename `contributor` `contributors`...
- Implement page/contributor include
- Finish migrating remaining bits of golang template syntax in page/header.liquid
- Ensure relative path to contributor/list is correct
- Fix assign statement in site-title.liquid, change comment to reference new liquid page/title include
- Implement page/title include
- Fix cover title rendering logic to match `site-title.liquid`, `page/title.liquid`
- Migrate citations
- Rename include as 'citations'
- Convert metadata include to liquid template
- Move dublin-core and twitter-card includes
- Convert opengraph include to liquid template
- Use `forloop` instead of `forLoop` in contributor list and cover layout
- Move computed data into citations templates
- Implement page/bibliography include
- Replace `urlize` with `slugify` in page/bibliography
- Switch comparison operator to determine `nextPages`, add TODO comment about array filtering
- WIP JavaScript template for JSON-LD include
- Implement JSON-LD authors
- Build json-ld partOf
- Call toString on array of subjects
- Move head meta includes
- Rewrite Dublin Core include template
- Move content -> contents
- Fix closing tags and update config variable name to site.params
- Add page layout
- Add missing comma
- Implement OpenGraph include as an 11ty.js template
- Update abstract param
- Migrate entry layout
- Add markdown to templateFormats
- Include all shortcodes in shortcodes/index and comment out
- Update paths to page partials
- Change template type of twitter-card include
- Rewrite twitter-card as a JavaScript template
- Add liquid extension to base layout
- Migrate splash layout
- Correct class name of twitter-card template
- Rewrite metadata include as a JavaScript template
- Comment statement to add README to ignore list
- Set relative path for _includes and _layouts
- Set layout in md files
- Stub search-index layout
- Register shortcodes
- Fix contributor shortcode
- Install eleventy@1.0.0 canary build
- Convert shortcodes to named functions
- Configure relative path to _data directory
- Pass eleventyConfig to shortcodes
- Rename q-figure-group qfiguregroup
- Debug: Return shortcode name from all shortcodes
- Change === to ==
- Return shortcode name from qbibliography
- Fix syntax errors
- Fix syntax errors
- Fix syntax errors
- Fix array filter syntax
- Set dynamicPartials to true
- start page/class partial
- Fix syntax
- Fix page/title last letter getting
- Fix syntax errors
- Fix partial names
- Fix partial paths and closing tags
- Check if abstract is defined
- Rewrite shortcodes with positional arguments
- Fix paths to partials
- Fix liquid syntax errors
- Update shortcode to use unnamed arguments
- Add 11ty test playground
- Update to @11ty/eleventy@beta
- Update `11ty-test` playground to 11ty 1.0 beta 3
- Fix unquoted head template filename
- Rename qclass to qbackmatter
- Remove qbibliography shortcode
- Refactor citation sorting
- Comment out menu, navbar, and search partials
- Include scripts partial
- Remove layout
- Update @11ty/eleventy dependencies
- Use single quotes in Liquid templates
- Remove shortcode module for bibliography
- relativize script paths
- Move figure shortcode module to a subdirectory
- Remove namespace from markdownify filter
- Use single quotes in liquid template tags
- Use path.relative for css and js directories
- WIP citation shortcode
- Configure markdown library to render footnotes
- Move markdownify filter to markdown plugin module
- Configure markdown-it heading anchor links
- Add common-tags library to dev dependencies
- Use common-tags oneline method for citation output
- Remove redundant instance of MarkdownIt
- WIP refactoring figure shortcode
- Remove erroneous space from figure data
- Add backmatter shortcode
- Remove comments from base layout
- Update eslint
- Use recommended extension for yaml data files
- Update JSDoc for backmatter shortcode parameters
- Add webpack config + default theme assets
- Hardcode relative paths for data, includes, layouts
- hard-code head stylesheet links
- Add missing `template-polyfill` package
- Fix broken head scripts
- Move site global data into src/_data
- Add global data file site.yaml
- Delete `11ty/_assets` Dir
- Remove markdown configuration from site yaml
- Add html comment to unused `render navbar` tag
- Add missing babel and sass dev dependencies
- Comment out broken print style for now
- Move config file to _data directory
- Update config.yaml
- Set suffix for directory and template data files
- Refactor shortcodes for access to global data
- Delete site.yaml - duplicate of config.yaml
- Conigure elevent to passthrough _assets directory
- Merge `assets` dir into `_assets`, update paths in webpack congig and `head.liquid` include
- Refactor base layout and head tags as js templates with simple functions
- Move `_assets` up a level, ensure sass is compiled and written to file, move css/js back into src, fix paths
- Add computed imageDir property
- Sort keys
- Fix baseURL reference and remove .html extension
- Move assets back into `src`
- Move `_assets` dir into `11ty/src`
- Add missing font and image assets
- Remove scripts partial
- Change eleventy output directory to _site
- Allow q-figure to display images
- Fix broken style compilation pointing to `site` dir
- WIP refactoring figure shortcodes
- Add a shortcode component for embedded videos
- Refactor cite shortcode
- Use built-in sass math module
- Refactor figure and image components
- Add documentation of open github issues
- Update github issues checklist
- WIP figuregroup shortcode
- Refactor figure/components/image
- Update eslint
- Fix figure group shortcode
- WIP figure table component
- Add layout attr to bibliography markdown template
- Add _data directory README file
- Add figureRefs shortcode
- Add figures placeholder component
- WIP figure modal component
- Add a Liquid template for the bibliography page
- Pass global data to all shortcodes
- Add icon shortcode
- Add image subcomponents
- Rename .quire-figure* -> .q-figure*
- get modifier from config
- Add modal links
- Fix markup for modal link location on top or below
- Pass classes as string or array to q-figure shortcode
- Add WIP includes for menu, nav-bar, and scripts
- Add menu, navBar, and scripts to base layout
- Fix `dev` and `build` scripts; fix Webpack config; trigger webpack bundle from eleventy build config
- Add dummy menu-header
- Refactor build/watch hooks
- Update to eleventy 1.0 beta.4
- Include base application styles
- Style qfiguregroup rows
- Fix page title
- Clean up webpack bundling logic
- Add a .env.example file
- Add placeholders for figure media types
- Update package with @11ty/eleventy@1.0.0-beta.4
- Rename paired shortcode arg 'data' to 'content'
- Add site-title to menu-header
- Implements a npm script to remove build products
- Add youtube and placeholder components
- Copy cover file to `index.md`, set about to use `page` layout
- Add figureRef shortcode as ref
- Enable qfigure modal
- Update q-ref shortcode and use in essay template
- Use icon shortcode
- Change type -> layout
- Fix liquid syntax errors
- Remove console statement from refs shortcode
- Add liquid example to icon shortcode jsdoc
- Refactor entry-figure media_type conditional
- Update gitignore list
- Update common-tags patch version
- Add duplicate `catalogue/index.md`, a duplicate of `catalogue/catalogue-index.md` to ensure page is generated at `/catalogue/` route
- WIP nav bar updates
- Hack computed imageDir for now
- Update Splash layout to use hard-coded eleventyComputed imageDir
- Expand `@TODO` comment to reference elventy pagination
- Make webpack compile step async-friendly
- Remove `beforeWatch` hook to prevent multiple webpack processes -- `beforeBuild` is still run when watching
- Prevent sass/scss files from getting copied on build, fix `:not(no-js)` styles
- Clean up menu, menu-header
- Make page progress bar work
- Add missing nav bar labels
- Fix page array
- Output cover template as index.html
- Use html template literal for base layout
- Rewrite contents layout, contentsList and menuList as javascript templates
- Filter catalogue contents list by section
- Add docs link to template directory README files
- Add computed pages property to global data
- Update nav-bar to use computed `pages`, sort `eleventyComputed.pages`
- Add notes for refactoring
- Update to eleventy 1.0.0-beta.6
- Update package-lock @11ty/eleventy@1.0.0-beta.6
- Return empty string from markdownify filter
- Update to eleventy 1.0.0-beta.7
- Register RenderPlugin; enable liquid template rendering in `contents.11ty.js`
- Use pages global computed data in menu and toc
- Remove menu layout
- Set permalink on catalogue-index
- Use single quotes
- Add getFigure filter
- Add computed pageObjects and pageFigures properties
- Include tombstone shortcode
- Import EleventyRenderPlugin without renaming
- WIP cover page templates
- Compute eleventyNavigation from directories
- Filter out pages with toc or menu property === false
- Add debug page for JSON
- Add component to render next previous page buttons
- Fix eleventyNavigation page key and parent path
- Add front matter data to Quire DEBUG page
- Set navigation sort using order or weight property
- Add intro.md
- Exclude debug page from menu
- Remove redundant check for page.data.type === data
- Revert removing pageButtons
- Output analytics script using common-tags html
- Add README file to shortcodes directory
- Include title separator if subtitle has value
- Rename site -> config
- Update patch version of common-tags
- Pass 'data' to page/header
- Add custom.js pass-through copy to silence warning
- Update major version of common-tags lib
- Create a components directory within _includes
- Fix catalogue images
- Add getObject filter
- Add JSDoc to json filter
- Update component paths and export
- Add svg icons as an html template
- Add README file for component includes
- Rewrite pageButtons as a stateless function
- Add README file for components plugin
- Refactor contributor list, name, and title includes as shortcodes
- Refactor contentsItemToc as shortcode component
- Add a filter to get publication.subject keywords
- Update to eleventy@1.0.0-beta.8
- Correct package-lock with eleventy@1.0.0-beta.8
- Update plugin variable names for consistency
- Implements a component to render a SoundCloud player
- Refactor contributors page to use contributors layout and simplified q-contributor shortcode
- WIP replace webpack with vite
- Move menu components into components/menu and include contributor-list in menu title
- Move menu component -> components/menu/index
- Add a paired shortcode to render a styled div
- Move contents subcomponents into _includes/components/contents/
- Add pageButtons to cover page
- include pageButtons in all layouts
- Add contributors to publication title on cover page
- Add plugin to configure eleventy linters
- Only render right arrow on cover page if there is no content
- Only include menu pages in navBar
- Set markdownTemplateEngine to nunjucks
- Add closing tag to iframe elements
- Remove webpack compilation from eleventy config; set script tag referencing `/src/application.js` to `type="module"` in base template
- Refactoring figure components
- Rename figure shortcode arguments to params
- Replace const with let in figure component
- Remove extra nested list item and clean up logic
- Update npm scripts
- Update vite config with `root: '_site'`
- Add babel-polyfill to dev dependencies
- Fix JS imports
- Correct arg name passed to figure compontent
- Remove webpack configurations
- Add styles for .is-pulled-left and .is-pulled-right
- Hide citation popups onload
- Handle undefined search data url
- Render menu resources and formats sections
- Handle page title on cover page
- Add footer links
- Add reverse option to contributor name
- Add a pageData computed prop so that it's easier to pass all page data to child components
- Move inline styles into quire-menu.scss
- Refactor page/title include as shortcode component
- Refactor in-menu page citations using shortcodes
- Add cover title
- Refactor copyright and licensing as shortcode components
- Fix fallback to 'untitled'
- Fix markdown, sort and loop on bibliography page
- Fix logo path
- Allow user to specify bibliography sort in frontmatter
- Fixing some globalData references
- Refactor nav-bar as shortcode, and use pagination computed property for previous and next buttons
- Implement page bibliography
- Refactor shortcode function signatures
- Fix incorrect liquid shortcode charactor
- Refactor method signature of figure subcomponents
- Update JSDoc for cite shortcode function
- Wrap JSON filter output in pre and code elements
- Add toc property to eleventyNavigation
- Correct cite shortcode argument name, update JSDoc
- Rename src to content
- Add support for markdown definition lists
- Refactoring search as an eleventy plugin
- Implement search partial
- Add menu property to computed eleventyNavigation
- Use search filter to create search index JSON and register search plugin
- Remove content/js/search.js - replaced by search plugin
- Use js copyrightLicensing shortcode
- Refactor existing quire search in eleventy
- Use liquid search template
- Fix search-index path
- Update dependencies
- Update packages/11ty dependencies
- Update dependencies
- Remove duplicate citations _includes
- Delete 11ty-test directory with dummy 11ty project
- Rename bibliograph layout to publication-bibliography
- Add module for markdown plugin defaults
- Restore  layout name
- Update documentation on _layouts and _includes with examples and usage
- Add data documentation to _includes README
- Remove redundant figures liquid templates
- Remove footer-buttons and site-title liquid templates in favor of js templates
- Fix iconscc component name
- Replace required includes with this[include]
- Move `content/js`, `content/css` into `content/_assets/javascript` and `content/_assets/styles`
- Replace `npx del` with `npx rimraf` in clean script
- Add languages to codeblocks
- Use common-tags
- Revert previous commit
- Rewrite cover layout using liquid
- Add 'contributors' computed property that includes contributor.pages data
- Update head shortcode
- Fix method signature for shortcodes
- Correct pageButtons syntax
- Remove redundnat imageDir assignment for cover
- Correct conditional for empty content
- Use if not blank to test for cover content
- Remove figureRef console log statement
- Add contributor image path to computed properties
- Add link component
- Add contributor page links component
- Refactor contributors page to call qcontributor
- Add withLabel option
- Use link component
- Remove contributors layout
- Update jsdoc
- Use .js extension
- Update npm script to run clean before dev
- Fix spacing
- Use oneLine
- Fix contributor.pages link elements
- Use oneLine
- Use .js for contributor subcomponents
- Change shortcode and components extension to .js
- Move figure shortcode subcomponents to _includes/components/figure
- Correct changes to figure shortcode module
- Remove figureZoom shortcode
- Refactor shortcode components signatures
- Update dependencies
- Rename directory of eleventy plugins
- Add subtitle to cover
- Update contents layout name to table-of-contents
- Return empty string if contributors is undefined
- Fix contributor name being destructured from page.data
- Replace redundant page/title _include with pageTitle component and refactor pageTitle params to accept explicit title, subtitle, and label properties instead of a page
- Fix structure of params passed to page/header
- Include label in menu titles
- Refactor pageTitle to always include the params it's passed instead of using withLabel or withSubtitle params
- Refactor nav label using pageTitle adapter
- Markdonwify page title
- Remove extra space from title with label
- Fix syntax in contributor title component
- Fix map over contributors in list-plus type contributorList
- Refactor page/contributor _include as contributorHeader component
- Rename contributorList format values to match contributor_byline props
- Refactor abstract.liquid as a shortcode component
- Remove page class liquid template
- Include table-of-contents pages in menu
- Destructure page data properties from page.data
- Fix chicago and MLA page citation contributors, dates, and urls
- Implement `pageClass` component, replace all instances of `page/class` include in templates
- Update packages/11ty/_includes/components/page-class.js
- Replace _includes/page templates with components
- Add missing `fullscreen` icon to figure labels
- Fix incorrect usage of `link` component js function to add missing link icon to catalogue item tombstone
- Fix incorrect `link` js function signature in `modalLink.js`
- Add missing `div.container` wrapping `.quire-page__header__title` on catalogue entry pages
- Fix font asset path
- Fix catalogue item button link icon alignment; re-implement conditional description span in icon component
- Add missing page header with contributor list
- Do not render contributor markup in page headers if page has no contributor(s) to prevent empty HTML with margins from affecting layout
- Update to Lerna 4
- Add `backmatter` paired shortcode to essay notes section to apply backmatter class
- Hide `<hr />` added by markdown-it library
- Wrap entire footnotes section with `backmatter` paired shortcode
- Allow Pandoc style attribute in markdown
- Remove themes directory
- Refactor jQuery out of `toggleMenu` method
- Add simple HTML templating function
- Refactor jQuery out of `setupSlider` method
- Fix broken popup slideshow
- remove unused `jqueryslider` variable
- Replace `$(window).ready` with vanilla `DOMContentLoaded` event listener
- Refactor jQuery out of `scrollToHash` and `scrollToHashOnLoad` functions, split apart shared logic into separate functions
- Refactor `loadSearchData` to replace with jQuery `get` with `fetch`
- refactor jQuery out of `setDate`
- Set innerHTML correctly
- Stop doing illegal things
- Refactor `DeepZoom` `addTiles` method to set opacity after load and initial zoom animation are complete
- Refactor jQuery out of `sliderSetup` and `slideImage` functions
- Set opacity CSS transition on popup slideshow leaflet images
- Set animation CSS on catalog entry leaflet images
- Add TODO refactor comment to `slideImage` function
- Remove jQuery from deepzoom.js
- Remove jquery from `map.js`
- Remove jQuery import from `application/index.js`
- Move createHtml function into `helpers.js`
- Implement basic lightbox class

Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [ ] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [ ] I have made my changes in a new branch and not directly in the main branch

- [ ] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?



### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.


### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

