### PR TITLE
Move canvas panel from figure shortcode into `figure/image.js`

### DIFF
--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -17,7 +17,6 @@ const { oneLine } = require('common-tags')
  * @return     {boolean}  An HTML <figure> element
  */
 module.exports = function (eleventyConfig, globalData) {
-  const canvasPanel = eleventyConfig.getFilter('canvasPanel')
   const getFigure = eleventyConfig.getFilter('getFigure')
   const figureimage = eleventyConfig.getFilter('figureimage')
   const figurelabel = eleventyConfig.getFilter('figurelabel')
@@ -43,8 +42,6 @@ module.exports = function (eleventyConfig, globalData) {
 
     const component = async (figure) => {
       switch (true) {
-        case (!!figure.canvasId && !!figure.manifestId) || !!figure.iiifContent:
-          return await canvasPanel(figure);
         case (epub || pdf) && ['soundcloud', 'youtube'].includes(mediaType):
           return figureplaceholder(figure)
         case mediaType === 'youtube':

--- a/packages/11ty/content/_assets/styles/components/q-figure.scss
+++ b/packages/11ty/content/_assets/styles/components/q-figure.scss
@@ -19,6 +19,7 @@
 // .q-figure
 // -----------------------------------------------------------------------------
 .q-figure {
+  --atlas-z-index: 0;
   border-top: 1px solid $accent-color;
   border-bottom: 1px solid $accent-color;
   padding: 1em 0;

--- a/packages/11ty/content/_data/figures.yaml
+++ b/packages/11ty/content/_data/figures.yaml
@@ -4,13 +4,16 @@ figure_list:
     canvasId: http://cad6b682-68a3-4ea2-aabd-a1c217f7871a
     choiceId: https://iiif-files.s3.us-west-2.amazonaws.com/bronze-guidelines/fig-006/full/full/0/default.jpg
   - id: "example-biiif-image-service"
+    label: BIIIF Image Service
     src: iiif/cats/+tiles
   - id: "example-canvas-with-choices"
     canvasId: https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/canvas/p1
     manifestId: https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/manifest.json
+    label: "With Choices"
     preset: zoom
   - id: "example-canvas"
     canvasId: https://preview.iiif.io/cookbook/3333-choice/recipe/0036-composition-from-multiple-images/canvas/p1
+    label: "Basic"
     manifestId: https://gist.githubusercontent.com/stephenwf/19e61dac5c329c77db8cf22fe0366dad/raw/04971529e364063ac88de722db786c97e2df0e6b/manifest.json
     preset: zoom
   - id: "example-image-service"


### PR DESCRIPTION
- Move canvas panel from `figure` shortcode into `figure/image.js`
- Add some labels to example canvas panel figure data
- Override `--atlas-z-index` default value of 10 to prevent improper stacking order of figure labels