### PR TITLE
Refactor: Global Data

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -10,6 +10,7 @@ const componentsPlugin = require('./_plugins/components')
 const epubPlugin = require('./_plugins/epub')
 const filtersPlugin = require('./_plugins/filters')
 const frontmatterPlugin = require('./_plugins/frontmatter')
+const globalDataPlugin = require('./_plugins/globalData')
 const iiifPlugin = require('./_plugins/iiif')
 const lintingPlugin = require('./_plugins/linting')
 const markdownPlugin = require('./_plugins/markdown')
@@ -65,6 +66,12 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addDataExtension('toml', (contents) => toml.load(contents))
   eleventyConfig.addDataExtension('yaml', (contents) => yaml.load(contents))
   eleventyConfig.addDataExtension('geojson', (contents) => JSON.parse(contents))
+
+  /**
+   * Load global data files into eleventyConfig.globalData
+   * Must go before other plugins
+   */
+  eleventyConfig.addPlugin(globalDataPlugin)
 
   /**
    * Load plugin for custom configuration of the markdown library

--- a/packages/11ty/_includes/components/abstract.js
+++ b/packages/11ty/_includes/components/abstract.js
@@ -3,9 +3,8 @@ const { html } = require('common-tags')
 /**
  * Publication abstract
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   return function (params) {
     const { abstract } = params

--- a/packages/11ty/_includes/components/analytics.js
+++ b/packages/11ty/_includes/components/analytics.js
@@ -5,8 +5,8 @@ const { html } = require('common-tags')
  * @param      {Object}  eleventyConfig
  * @param      {Object}  data
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config } = globalData
+module.exports = function(eleventyConfig) {
+  const { config } = eleventyConfig.globalData
   return function(params) {
     if (!config.analytics || !config.GoogleAnalytics) return ''
     return html`

--- a/packages/11ty/_includes/components/citation/chicago/page.js
+++ b/packages/11ty/_includes/components/citation/chicago/page.js
@@ -5,12 +5,12 @@ const { html } = require('common-tags')
  * @property  {Object} publication
  * @property  {Object} page
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationContributors = eleventyConfig.getFilter('citationContributors')
   const citationChicagoPublicationContributors = eleventyConfig.getFilter('citationChicagoPublicationContributors')
   const citationChicagoPublishers = eleventyConfig.getFilter('citationChicagoPublishers')
   const citationPubDate = eleventyConfig.getFilter('citationPubDate')
-  const { config, publication } = globalData
+  const { config, publication } = eleventyConfig.globalData
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const siteTitle = eleventyConfig.getFilter('siteTitle')
 

--- a/packages/11ty/_includes/components/citation/chicago/publication-contributors.js
+++ b/packages/11ty/_includes/components/citation/chicago/publication-contributors.js
@@ -5,7 +5,7 @@
  * @param  {Object} params
  * @property  {Object} contributors - publication contributors
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationContributors = eleventyConfig.getFilter('citationContributors')
 
   return function (params) {

--- a/packages/11ty/_includes/components/citation/chicago/publication.js
+++ b/packages/11ty/_includes/components/citation/chicago/publication.js
@@ -2,11 +2,11 @@
  * @param  {Object} eleventyConfig
  * @param  {Object} params
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationPubDate = eleventyConfig.getFilter('citationPubDate')
   const citationPubSeries = eleventyConfig.getFilter('citationPubSeries')
   const citationPublishers = eleventyConfig.getFilter('citationChicagoPublishers')
-  const { publication } = globalData
+  const { publication } = eleventyConfig.globalData
 
   return function (params) {
     const { identifier, pub_date: pubDate, publisher } = publication

--- a/packages/11ty/_includes/components/citation/chicago/publishers.js
+++ b/packages/11ty/_includes/components/citation/chicago/publishers.js
@@ -1,8 +1,8 @@
 /**
  * @param  {Object} context
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { publication } = eleventyConfig.globalData
 
   return function (params) {
     const publishers = publication.publisher

--- a/packages/11ty/_includes/components/citation/chicago/site.js
+++ b/packages/11ty/_includes/components/citation/chicago/site.js
@@ -1,10 +1,10 @@
 /**
  * @param  {Object} context
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationChicagoPublication = eleventyConfig.getFilter('citationChicagoPublication')
   const citationChicagoPublicationContributors = eleventyConfig.getFilter('citationChicagoPublicationContributors')
-  const { config, publication } = globalData
+  const { config, publication } = eleventyConfig.globalData
   const pageTitle = eleventyConfig.getFilter('pageTitle')
 
   return function (params) {

--- a/packages/11ty/_includes/components/citation/contributors.js
+++ b/packages/11ty/_includes/components/citation/contributors.js
@@ -13,7 +13,7 @@
  * 
  * @return {String}
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const fullname = eleventyConfig.getFilter('fullname')
   const getContributor = eleventyConfig.getFilter('getContributor')
 

--- a/packages/11ty/_includes/components/citation/index.js
+++ b/packages/11ty/_includes/components/citation/index.js
@@ -18,12 +18,12 @@
  * @return {String}                citation markup
  */
 
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationChicagoPage = eleventyConfig.getFilter('citationChicagoPage')
   const citationChicagoSite = eleventyConfig.getFilter('citationChicagoSite')
   const citationMLAPage = eleventyConfig.getFilter('citationMLAPage')
   const citationMLASite = eleventyConfig.getFilter('citationMLASite')
-  const { config, publication } = globalData
+  const { config, publication } = eleventyConfig.globalData
 
   return function (params) {
     const { page, range, type } = params

--- a/packages/11ty/_includes/components/citation/mla/page.js
+++ b/packages/11ty/_includes/components/citation/mla/page.js
@@ -5,12 +5,12 @@ const { html } = require('common-tags')
  * @property  {Object} page
  * @property  {Object} publication
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationContributors = eleventyConfig.getFilter('citationContributors')
   const citationMLAPublicationContributors = eleventyConfig.getFilter('citationMLAPublicationContributors')
   const citationMLAPublishers = eleventyConfig.getFilter('citationMLAPublishers')
   const citationPubDate = eleventyConfig.getFilter('citationPubDate')
-  const { config, publication } = globalData
+  const { config, publication } = eleventyConfig.globalData
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const siteTitle = eleventyConfig.getFilter('siteTitle')
 

--- a/packages/11ty/_includes/components/citation/mla/publication-contributors.js
+++ b/packages/11ty/_includes/components/citation/mla/publication-contributors.js
@@ -5,7 +5,7 @@
  * @param  {Object} params
  * @property  {Object} contributors - publication contributors
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationContributors = eleventyConfig.getFilter('citationContributors')
 
   return function (params) {

--- a/packages/11ty/_includes/components/citation/mla/publication.js
+++ b/packages/11ty/_includes/components/citation/mla/publication.js
@@ -1,11 +1,11 @@
 /**
  * @param  {Object} context
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citationPubDate = eleventyConfig.getFilter('citationPubDate')
   const citationPublishers = eleventyConfig.getFilter('citationMLAPublishers')
   const citationPubSeries = eleventyConfig.getFilter('citationPubSeries')
-  const { publication } = globalData
+  const { publication } = eleventyConfig.globalData
 
   return function (params) {
     const { type } = params

--- a/packages/11ty/_includes/components/citation/mla/publishers.js
+++ b/packages/11ty/_includes/components/citation/mla/publishers.js
@@ -1,8 +1,8 @@
 /**
  * @param  {Object} context
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { publication } = eleventyConfig.globalData
 
   return function (params) {
     const publishers = publication.publisher

--- a/packages/11ty/_includes/components/citation/mla/site.js
+++ b/packages/11ty/_includes/components/citation/mla/site.js
@@ -2,8 +2,8 @@
  * @todo write this component!?
  * @param  {Object} context
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config, publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { config, publication } = eleventyConfig.globalData
 
   return function (params) {
     const { page } = params

--- a/packages/11ty/_includes/components/citation/pub-date.js
+++ b/packages/11ty/_includes/components/citation/pub-date.js
@@ -1,4 +1,4 @@
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function (params) {
     const { date } = params
     return new Date(date).getFullYear()

--- a/packages/11ty/_includes/components/citation/pub-series.js
+++ b/packages/11ty/_includes/components/citation/pub-series.js
@@ -1,5 +1,5 @@
-module.exports = function(eleventyConfig, globalData) {
-  const { publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { publication } = eleventyConfig.globalData
 
   return function (params) {
     const { series, number_in_series } = publication

--- a/packages/11ty/_includes/components/contributor/header.js
+++ b/packages/11ty/_includes/components/contributor/header.js
@@ -1,7 +1,6 @@
 const { html } = require('common-tags')
 /**
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * @param  {Object} params
  * @property  {Array<Object>} contributor Page contributors
  * @property  {String} contributorAsItAppears Text override for contributor field
@@ -9,11 +8,11 @@ const { html } = require('common-tags')
  * 
  * @return {String} Contributor markup for inclusion in page headers
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const contributorList = eleventyConfig.getFilter('contributorList')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  const { contributorByline: globalContributorByline } = globalData.config.params
+  const { contributorByline: globalContributorByline } = eleventyConfig.globalData.config.params
 
   return function (params) {
     const {

--- a/packages/11ty/_includes/components/contributor/list.js
+++ b/packages/11ty/_includes/components/contributor/list.js
@@ -6,7 +6,7 @@
  * 
  * @return {String}                 Markup for contributors
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const contributorTitle = eleventyConfig.getFilter('contributorTitle')
   const fullname = eleventyConfig.getFilter('fullname')
   const getContributor = eleventyConfig.getFilter('getContributor')

--- a/packages/11ty/_includes/components/contributor/title.js
+++ b/packages/11ty/_includes/components/contributor/title.js
@@ -1,13 +1,12 @@
 /**
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * @param  {Object} params
  * @property  {String} affiliation
  * @property  {String} title
  * 
  * @return {String}                     Contributor title and affiliation
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function (params) {
     const { affiliation, title } = params
     const affiliationElement = affiliation ? `<span class="quire-contributor__affiliation">${ affiliation }</span>` : ''

--- a/packages/11ty/_includes/components/copyright/index.js
+++ b/packages/11ty/_includes/components/copyright/index.js
@@ -6,12 +6,12 @@ const path = require('path')
  * 
  * @return {String}
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const copyrightLicensing = eleventyConfig.getFilter('copyrightLicensing')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
   return function (params) {
-    const { config, publication } = globalData
+    const { config, publication } = eleventyConfig.globalData
 
     const publisherImages = publication.publisher.filter((item) => item.logo).map(({ logo }) => {
       return `<img src="${ path.join(config.params.imageDir, logo) }" class="quire-copyright__icon__logo" alt="logo" />`

--- a/packages/11ty/_includes/components/copyright/licensing.js
+++ b/packages/11ty/_includes/components/copyright/licensing.js
@@ -1,6 +1,6 @@
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function (params) {
-    const { publication } = globalData
+    const { publication } = eleventyConfig.globalData
     const { license } = publication
 
     let licenseText = ''

--- a/packages/11ty/_includes/components/figure/caption.js
+++ b/packages/11ty/_includes/components/figure/caption.js
@@ -3,14 +3,13 @@ const { oneLine } = require('common-tags')
 /**
  * Figure caption and credit
  * @param      {Object} eleventyConfig  eleventy configuration
- * @param      {Object} globalData
  * 
  * @param      {Object} params
  * @property   {String} figure
  * @property   {String} content
  * @return     {String}  An HTML <figcaption> element
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
 
   return function({ caption, credit, content='' }) {

--- a/packages/11ty/_includes/components/figure/image.js
+++ b/packages/11ty/_includes/components/figure/image.js
@@ -5,18 +5,17 @@ const path = require('path')
  * Renders an <img> element
  *
  * @param      {Object} eleventyConfig  eleventy configuration
- * @param      {Object} globalData
  * 
  * @return     {String}  An HTML <img> element
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const canvasPanel = eleventyConfig.getFilter('canvasPanel')
   const figurecaption = eleventyConfig.getFilter('figurecaption')
   const figurelabel = eleventyConfig.getFilter('figurelabel')
   const figuremodallink = eleventyConfig.getFilter('figuremodallink')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  const { imageDir, figureLabelLocation } = globalData.config.params
+  const { imageDir, figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return async function({ alt='', canvasId, caption, choices, credit, id, iiifContent, label, manifestId, preset, src='' }) {
     const imageSrc = path.join(imageDir, src)

--- a/packages/11ty/_includes/components/figure/label.js
+++ b/packages/11ty/_includes/components/figure/label.js
@@ -3,16 +3,15 @@ const { oneLine } = require('common-tags')
 /**
  * A figure label element
  * @param  {Object} eleventyConfig  eleventy configuration
- * @param  {Object} globalData
  * @return
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const icon = eleventyConfig.getFilter('icon')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const modalLink = eleventyConfig.getFilter('figuremodallink')
 
-  const { epub } = globalData.config
-  const { figureLabelLocation } = globalData.config.params
+  const { epub } = eleventyConfig.globalData.config
+  const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return function({ caption, id, label }) {
     let labelElement

--- a/packages/11ty/_includes/components/figure/modal-link.js
+++ b/packages/11ty/_includes/components/figure/modal-link.js
@@ -1,10 +1,10 @@
 const { html } = require('common-tags')
 
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const icon = eleventyConfig.getFilter('icon')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  const { figureLabelLocation, figureModal } = globalData.config.params
+  const { figureLabelLocation, figureModal } = eleventyConfig.globalData.config.params
 
   return function({ caption, content, id }) {
 

--- a/packages/11ty/_includes/components/figure/placeholder.js
+++ b/packages/11ty/_includes/components/figure/placeholder.js
@@ -1,10 +1,10 @@
 const path = require('path')
 const { html } = require('common-tags')
 
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const figurelabel = eleventyConfig.getFilter('figurelabel')
 
-  const { figureLabelLocation, imageDir } = globalData.config.params
+  const { figureLabelLocation, imageDir } = eleventyConfig.globalData.config.params
 
   return function({ alt, caption, id, label, media_type: mediaType, src }) {
     let imageElement

--- a/packages/11ty/_includes/components/figure/soundcloud.js
+++ b/packages/11ty/_includes/components/figure/soundcloud.js
@@ -4,17 +4,16 @@ const { html } = require('common-tags')
  * Renders an iframe element with the SoundCloud audio player
  *
  * @param      {Object}  eleventyConfig  eleventy configuration
- * @param      {Object}  globalData      global data
  * @param      {Object}  figure          The figure
  * @return     {String}  HTML to display a SoundCloud player
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const figurecaption = eleventyConfig.getFilter('figurecaption')
   const figureimage = eleventyConfig.getFilter('figureimage')
   const figurelabel = eleventyConfig.getFilter('figurelabel')
   const figureplaceholder = eleventyConfig.getFilter('figureplaceholder')
 
-  const { figureLabelLocation } = globalData.config.params
+  const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return function({ caption, credit, id, label, media_id }) {
     const src = `https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/${media_id}`

--- a/packages/11ty/_includes/components/figure/table.js
+++ b/packages/11ty/_includes/components/figure/table.js
@@ -6,13 +6,13 @@ const path = require('path')
  * @param {String}
  * @return {String}  An HTML <table> element
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const figurecaption = eleventyConfig.getFilter('figurecaption')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const renderFile = eleventyConfig.getFilter('renderFile')
 
   const assetsDir = path.join(eleventyConfig.dir.input, '_assets/images')
-  const { figureLabelLocation } = globalData.config.params
+  const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return async function({ caption, credit, id, src }) {
     const table = await renderFile(path.join(assetsDir, src))

--- a/packages/11ty/_includes/components/figure/video.js
+++ b/packages/11ty/_includes/components/figure/video.js
@@ -5,7 +5,7 @@ const { html } = require('common-tags')
  * @param {String} src  Source url for the video
  * @return {String}  An HTML <video> element
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const unsupported = 'Sorry, your browser does not support embedded videos.'
 
   return function({ figure }) {

--- a/packages/11ty/_includes/components/figure/youtube.js
+++ b/packages/11ty/_includes/components/figure/youtube.js
@@ -4,17 +4,16 @@ const { html } = require('common-tags')
  * Renders an iframe element with a Youtube video player
  *
  * @param      {Object}  eleventyConfig  eleventy configuration
- * @param      {Object}  globalData      global data
  * @param      {Object}  figure          The figure
  * @return     {String}  An HTML
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const figurecaption = eleventyConfig.getFilter('figurecaption')
   const figureimage = eleventyConfig.getFilter('figureimage')
   const figureplaceholder = eleventyConfig.getFilter('figureplaceholder')
   const figurelabel = eleventyConfig.getFilter('figurelabel')
 
-  const { figureLabelLocation } = globalData.config.params
+  const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return function({ aspectRatio, caption, credit, id, label, media_id }) {
     const src = `https://youtu.be/${media_id}`

--- a/packages/11ty/_includes/components/head-tags/dublin-core.js
+++ b/packages/11ty/_includes/components/head-tags/dublin-core.js
@@ -8,8 +8,8 @@ const path = require('path')
  * 
  * @return     {String}  HTML meta and link elements
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config, publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { config, publication } = eleventyConfig.globalData
 
   return function (params) {
     const links = [

--- a/packages/11ty/_includes/components/head-tags/jsonld.js
+++ b/packages/11ty/_includes/components/head-tags/jsonld.js
@@ -8,8 +8,8 @@ const path = require('path')
  * 
  * @return     {String}  An HTML script element with JSON-LD
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config, publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { config, publication } = eleventyConfig.globalData
   const { imageDir } = config.params
 
   return function ({ canonicalURL, page }) {

--- a/packages/11ty/_includes/components/head-tags/opengraph.js
+++ b/packages/11ty/_includes/components/head-tags/opengraph.js
@@ -6,8 +6,8 @@
  * 
  * @return     {String}  HTML meta and link elements
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config, publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { config, publication } = eleventyConfig.globalData
 
   return function ({ page }) {
     const { description, identifier, promo_image, pub_date, pub_type } = publication

--- a/packages/11ty/_includes/components/head-tags/twitter-card.js
+++ b/packages/11ty/_includes/components/head-tags/twitter-card.js
@@ -8,8 +8,8 @@ const path = require('path')
  * 
  * @return     {String}  HTML meta and link elements
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config, publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { config, publication } = eleventyConfig.globalData
   const { description, promo_image } = publication
   const { imageDir } = config.params
 

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -2,16 +2,15 @@
  * Head Tag
  * 
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const analytics = eleventyConfig.getFilter('analytics')
   const dublinCore = eleventyConfig.getFilter('dublinCore')
   const jsonld = eleventyConfig.getFilter('jsonld')
   const opengraph = eleventyConfig.getFilter('opengraph')
   const twitterCard = eleventyConfig.getFilter('twitterCard')
 
-  const { config, publication } = globalData
+  const { config, publication } = eleventyConfig.globalData
 
   const { imageDir } = config.params
 

--- a/packages/11ty/_includes/components/icon.js
+++ b/packages/11ty/_includes/components/icon.js
@@ -12,8 +12,8 @@ const path = require('path')
  * @example.liquid
  * {% icon type="link", description="Open in new window" %}
  */
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
 
   return function (params) {
     const { description, type } = params

--- a/packages/11ty/_includes/components/icons-cc.js
+++ b/packages/11ty/_includes/components/icons-cc.js
@@ -3,8 +3,8 @@
   The individual svg elements are assembled according to the specific license used:
   "CC 0", "CC BY", "CC BY-SA", "CC BY-ND", "CC BY-NC", "CC BY-NC-SA", or "CC BY-NC-ND".
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config } = globalData
+module.exports = function(eleventyConfig) {
+  const { config } = eleventyConfig.globalData
 
   return function() {
     if (!config.params.licenseIcons) return ''

--- a/packages/11ty/_includes/components/icons.js
+++ b/packages/11ty/_includes/components/icons.js
@@ -4,7 +4,7 @@ const { html } = require('common-tags')
  * This file contains inline SVG elements which can be referenced elsewhere in
  * the templates. This file can be included at the end of the <body> tag.
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function(params) {
     return html`
       <svg style="display:none">

--- a/packages/11ty/_includes/components/license-icons/0.js
+++ b/packages/11ty/_includes/components/license-icons/0.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/BY-NC-ND.js
+++ b/packages/11ty/_includes/components/license-icons/BY-NC-ND.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/BY-NC-SA.js
+++ b/packages/11ty/_includes/components/license-icons/BY-NC-SA.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/BY-NC.js
+++ b/packages/11ty/_includes/components/license-icons/BY-NC.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/BY-ND.js
+++ b/packages/11ty/_includes/components/license-icons/BY-ND.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/BY-SA.js
+++ b/packages/11ty/_includes/components/license-icons/BY-SA.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/BY.js
+++ b/packages/11ty/_includes/components/license-icons/BY.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
-module.exports = function(eleventyConfig, globalData) {
-  const imageDir = globalData.config.params.imageDir
+module.exports = function(eleventyConfig) {
+  const imageDir = eleventyConfig.globalData.config.params.imageDir
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/license-icons/CC.js
+++ b/packages/11ty/_includes/components/license-icons/CC.js
@@ -1,4 +1,4 @@
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function(params) {
     return `
       <switch>

--- a/packages/11ty/_includes/components/link-list.js
+++ b/packages/11ty/_includes/components/link-list.js
@@ -9,7 +9,7 @@ const { html } = require('common-tags')
  * @property  {Array<String>} classes
  * @return    {String}                Unordered list of links
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const link = eleventyConfig.getFilter('link')
 
   return function(params) {

--- a/packages/11ty/_includes/components/link.js
+++ b/packages/11ty/_includes/components/link.js
@@ -11,7 +11,7 @@ const { oneLine } = require('common-tags');
  * @param  {Array<String>} classes
  * @return {String}                anchor tag
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const link = eleventyConfig.getFilter('link')
 
   return function (params) {

--- a/packages/11ty/_includes/components/menu/header.js
+++ b/packages/11ty/_includes/components/menu/header.js
@@ -4,17 +4,16 @@ const { html } = require('common-tags')
  * Publication title block in menu
  *
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  * @param      {Object}  params
  * @property   {String}  currentURL
  * @property   {Array|String}   contributors - publication contributors array or string override
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const contributorList = eleventyConfig.getFilter('contributorList')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const siteTitle = eleventyConfig.getFilter('siteTitle')
 
-  const { publication } = globalData
+  const { publication } = eleventyConfig.globalData
   const contributors = publication.contributor_as_it_appears || publication.contributor
 
   return function(params) {

--- a/packages/11ty/_includes/components/menu/index.js
+++ b/packages/11ty/_includes/components/menu/index.js
@@ -8,10 +8,9 @@ const { html } = require('common-tags')
  * by default. Users with JS disabled will alwasy see the menu in its expanded state.
  *
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  * @param      {Object}  params
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const citation = eleventyConfig.getFilter('citation')
   const copyright = eleventyConfig.getFilter('copyright')
   const linkList = eleventyConfig.getFilter('linkList')
@@ -19,7 +18,7 @@ module.exports = function(eleventyConfig, globalData) {
   const menuList = eleventyConfig.getFilter('menuList')
   const menuResources = eleventyConfig.getFilter('menuResources')
 
-  const { config, publication } = globalData
+  const { config, publication } = eleventyConfig.globalData
   const { resource_link: resourceLinks } = publication
 
   return function(params) {

--- a/packages/11ty/_includes/components/menu/item.js
+++ b/packages/11ty/_includes/components/menu/item.js
@@ -2,10 +2,9 @@
  * Renders a menu item
  *
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  * @param      {Object}  params
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
 
   return function(params) {

--- a/packages/11ty/_includes/components/menu/list.js
+++ b/packages/11ty/_includes/components/menu/list.js
@@ -2,13 +2,12 @@
  * Renders the menu list
  *
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  * @param      {Object}  params
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const menuItem = eleventyConfig.getFilter('menuItem')
 
-  const { config } = globalData
+  const { config } = eleventyConfig.globalData
 
   return function(params) {
     const { pages } = params

--- a/packages/11ty/_includes/components/menu/resources.js
+++ b/packages/11ty/_includes/components/menu/resources.js
@@ -4,11 +4,10 @@ const { html } = require('common-tags')
  * Renders the "Other Formats" and "Resources" sections of the menu
  *
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  * @param      {Object}  params
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { publication } = eleventyConfig.globalData
   const { resource_link: resourceLinks } = publication
 
   return function() {

--- a/packages/11ty/_includes/components/navigation.js
+++ b/packages/11ty/_includes/components/navigation.js
@@ -12,10 +12,10 @@ const { html } = require('common-tags');
  * eligible pages are ranged through and based on weight, the next or previous
  * one in the range is linked to.
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const eleventyNavigation = eleventyConfig.getFilter('eleventyNavigation')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
-  const { config } = globalData
+  const { config } = eleventyConfig.globalData
 
   return function (params) {
     const { collections, pages, pagination, title } = params

--- a/packages/11ty/_includes/components/page-buttons.js
+++ b/packages/11ty/_includes/components/page-buttons.js
@@ -4,16 +4,15 @@ const { html } = require('common-tags')
  * Renders previous page and next page buttons
  *
  * @param {Object} eleventyConfig
- * @param {Object} globalData
  * 
  * @param {Object} params
  * @param {Object} options
  *
  * @return {String} "previous" and "next" buttons
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const icon = eleventyConfig.getFilter('icon')
-  const { config } = globalData
+  const { config } = eleventyConfig.globalData
 
   return function(params, options={}) {
     const { pagination } = params

--- a/packages/11ty/_includes/components/page-class.js
+++ b/packages/11ty/_includes/components/page-class.js
@@ -2,13 +2,12 @@
  * Renders quire page classes
  *
  * @param {Object} eleventyConfig
- * @param {Object} globalData
  *
  * @param {Object} params
  *
  * @return {String} quire page classes
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function({ pages, pagination }) {
     const { class: currentPageClass, weight: currentPageWeight } = pagination.currentPage.data
     const pageOne = pages.find(({ data }) => data.class === 'page-one')

--- a/packages/11ty/_includes/components/page-header.js
+++ b/packages/11ty/_includes/components/page-header.js
@@ -5,15 +5,14 @@ const path = require('path')
  * Publication page header
  *
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const contributorHeader = eleventyConfig.getFilter('contributorHeader')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const slugify = eleventyConfig.getFilter('slugify')
 
-  const { imgDir, pageLabelDivider } = globalData.config.params
+  const { imgDir, pageLabelDivider } = eleventyConfig.globalData.config.params
 
   return function (params) {
     const {

--- a/packages/11ty/_includes/components/page-title.js
+++ b/packages/11ty/_includes/components/page-title.js
@@ -3,7 +3,6 @@
  * See also site-title.js
  * 
  * @param {Object} eleventyConfig
- * @param {Object} globalData
  * @param {Object} params
  * @property {Object} label
  * @property {Object} subtitle
@@ -11,10 +10,10 @@
  *
  * @return {string} `page title: subtitle`
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  const { pageLabelDivider } = globalData.config.params
+  const { pageLabelDivider } = eleventyConfig.globalData.config.params
 
   return function(params) {
 

--- a/packages/11ty/_includes/components/pdf/info.js
+++ b/packages/11ty/_includes/components/pdf/info.js
@@ -2,8 +2,8 @@
  *   Adds info to use in PrinceXML running page footers
  *   @todo if there are sections, set section title to title if slug == '.'
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config } = globalData
+module.exports = function(eleventyConfig) {
+  const { config } = eleventyConfig.globalData
 
   return function (params) {
     if (!config.params.pdf) return ''

--- a/packages/11ty/_includes/components/scripts.js
+++ b/packages/11ty/_includes/components/scripts.js
@@ -1,11 +1,10 @@
 /**
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * 
  * @return {String} script tags
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config } = globalData
+module.exports = function(eleventyConfig) {
+  const { config } = eleventyConfig.globalData
   return function() {
     return `
       <script type="text/javascript"> var figureModal = ${config.params.figureModal}</script>

--- a/packages/11ty/_includes/components/site-title.js
+++ b/packages/11ty/_includes/components/site-title.js
@@ -3,12 +3,11 @@
  * See also page/title.liquid
  *
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * 
  * @return  {String} Site title
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { publication } = globalData
+module.exports = function(eleventyConfig) {
+  const { publication } = eleventyConfig.globalData
   const { reading_line: readingLine, subtitle, title } = publication
   return function() {
     const lastLetter = title.slice(-1)

--- a/packages/11ty/_includes/components/table-of-contents/image.js
+++ b/packages/11ty/_includes/components/table-of-contents/image.js
@@ -3,14 +3,13 @@ const path = require('path')
  * Renders a TOC item image
  *
  * @param     {Object} eleventyConfig
- * @param     {Object} globalData
  * @param     {Object} params
  * @property  {String} imageDir - image directory from eleventyComputed
  * @property  {String} src - image src
  *
  * @return {String} TOC image markup
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   return function(params) {
     const { imageDir, src } = params
     if (!imageDir || !src) return ''

--- a/packages/11ty/_includes/components/table-of-contents/item.js
+++ b/packages/11ty/_includes/components/table-of-contents/item.js
@@ -13,7 +13,7 @@ const { oneLine } = require('common-tags')
  *
  * @return {String} TOC item markup
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const contributorList = eleventyConfig.getFilter('contributorList')
   const getFigure = eleventyConfig.getFilter('getFigure')
   const getObject = eleventyConfig.getFilter('getObject')
@@ -22,7 +22,7 @@ module.exports = function (eleventyConfig, globalData) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const tableOfContentsImage = eleventyConfig.getFilter('tableOfContentsImage')
   const urlFilter = eleventyConfig.getFilter('url')
-  const { imageDir } = globalData.config.params
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function (params) {
     /**

--- a/packages/11ty/_plugins/components/addComponentTag.js
+++ b/packages/11ty/_plugins/components/addComponentTag.js
@@ -1,4 +1,3 @@
-const globalData = require('../globalData')
 const liquidArgs = require('liquid-args')
 // const { Liquid, Hash } = require('liquidjs')
 
@@ -21,18 +20,18 @@ module.exports = function(eleventyConfig, component, tagName) {
    */
   if (component.constructor.name === "AsyncFunction") {
     eleventyConfig.addJavaScriptFunction(tagName, async function(...args) {
-      return await component(eleventyConfig, globalData, { page: this.page })(...args)
+      return await component(eleventyConfig, { page: this.page })(...args)
     })
   } else {
     eleventyConfig.addJavaScriptFunction(tagName, function(...args) {
-      return component(eleventyConfig, globalData, { page: this.page })(...args)
+      return component(eleventyConfig, { page: this.page })(...args)
     })
   }
 
   // Component function for a Liquid tag with keyword arguments
   const renderComponent = async function(...args) {
     const kwargs = args.find((arg) => arg.__keywords)
-    return component(eleventyConfig, globalData, { page: this.page })(kwargs)
+    return component(eleventyConfig, { page: this.page })(kwargs)
   }
 
   /**
@@ -57,7 +56,7 @@ module.exports = function(eleventyConfig, component, tagName) {
    * @see https://www.11ty.dev/docs/languages/nunjucks/#single-shortcode
    */
   eleventyConfig.addNunjucksShortcode(tagName, function(...args) {
-    return component(eleventyConfig, globalData, { page: this.page })(...args)
+    return component(eleventyConfig, { page: this.page })(...args)
   })
 
   /**
@@ -65,6 +64,6 @@ module.exports = function(eleventyConfig, component, tagName) {
    * @see https://www.11ty.dev/docs/languages/handlebars/#single-shortcode
    */
   eleventyConfig.addHandlebarsShortcode(tagName, function(...args) {
-    return component(eleventyConfig, globalData, { page: this.page })(...args)
+    return component(eleventyConfig, { page: this.page })(...args)
   })
 }

--- a/packages/11ty/_plugins/filters/getContributor.js
+++ b/packages/11ty/_plugins/filters/getContributor.js
@@ -1,11 +1,11 @@
 /**
  * Looks up a contributor in publication.yaml[contributor] by id
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * @param  {String} id             contributor id
  * @return {Object}                contributor
  */
-module.exports = function(eleventyConfig, { publication }, id) {
+module.exports = function(eleventyConfig, id) {
+  const { publication } = eleventyConfig.globalData
   const contributor = publication.contributor.find((item) => item.id === id)
   if (!contributor) {
     console.warn(`Error: the id '${id}' was not found under contributor in 'publication.yaml'`)

--- a/packages/11ty/_plugins/filters/getFigure.js
+++ b/packages/11ty/_plugins/filters/getFigure.js
@@ -1,12 +1,12 @@
 /**
  * Looks up a figure in figures.yaml by id
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * @param  {String} id             figure id
  * @return {Object}                figure
  */
-module.exports = function(eleventyConfig, { figures }, id) {
-  const figure = figures.figure_list.find((item) => item.id === id)
+module.exports = function(eleventyConfig, id) {
+  const { figure_list } = eleventyConfig.globalData.figures
+  const figure = figure_list.find((item) => item.id === id)
   if (!figure) {
     console.warn(`Error: the id '${id}' was not found in 'figures.yaml'`)
     return ''

--- a/packages/11ty/_plugins/filters/getObject.js
+++ b/packages/11ty/_plugins/filters/getObject.js
@@ -1,11 +1,11 @@
 /**
  * Looks up a object in objects.yaml by id
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * @param  {String} id             object id
  * @return {Object}                object
  */
-module.exports = function(eleventyConfig, { objects }, id) {
+module.exports = function(eleventyConfig, id) {
+  const { objects } = eleventyConfig.globalData
   const object = objects.object_list.find((item) => item.id === id)
   if (!object) {
     console.warn(`Error: the id '${id}' was not found in 'objects.yaml'`)

--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -1,5 +1,3 @@
-const globalData = require('../globalData')
-
 const capitalize = require('./capitalize')
 const fullname = require('./fullname')
 const getContributor = require('./getContributor')
@@ -14,13 +12,13 @@ module.exports = function(eleventyConfig, options) {
 
   eleventyConfig.addFilter('fullname', (person, options) => fullname(person, options))
 
-  eleventyConfig.addFilter('getContributor', (id) => getContributor(eleventyConfig, globalData, id))
+  eleventyConfig.addFilter('getContributor', (id) => getContributor(eleventyConfig, id))
 
-  eleventyConfig.addFilter('getFigure', (id) => getFigure(eleventyConfig, globalData, id))
+  eleventyConfig.addFilter('getFigure', (id) => getFigure(eleventyConfig, id))
 
-  eleventyConfig.addFilter('getObject', (id) => getObject(eleventyConfig, globalData, id))
+  eleventyConfig.addFilter('getObject', (id) => getObject(eleventyConfig, id))
 
-  eleventyConfig.addFilter('keywords', () => keywords(eleventyConfig, globalData))
+  eleventyConfig.addFilter('keywords', () => keywords(eleventyConfig))
 
   eleventyConfig.addFilter('json', (string) => json(string))
 }

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -2,15 +2,13 @@ const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
 
-const loadData = (fileName) => {
-  const filePath = path.join('content', '_data', fileName)
-  return yaml.load(fs.readFileSync(filePath))
+module.exports = function(eleventyConfig, options) {
+  const dataDirectory = path.join('content', '_data')
+  const filenames = fs.readdirSync(dataDirectory)
+  filenames.forEach((item) => {
+    const { base, ext, name } = path.parse(item)
+    if (!['.yaml', '.yml'].includes(ext)) return;
+    const data = yaml.load(fs.readFileSync(path.join(dataDirectory, item)))
+    eleventyConfig.addGlobalData(name, data)
+  })
 }
-
-const config = loadData('config.yaml')
-const figures = loadData('figures.yaml')
-const objects = loadData('objects.yaml')
-const publication = loadData('publication.yaml')
-const references = loadData('references.yaml')
-
-module.exports = { config, figures, objects, publication, references }

--- a/packages/11ty/_plugins/shortcodes/backmatter.js
+++ b/packages/11ty/_plugins/shortcodes/backmatter.js
@@ -5,6 +5,6 @@
  *
  * @return     {boolean}  A styled HTML <div> element with the content
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   return (content) => `<div class="backmatter">${content}</div>`
 }

--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -3,11 +3,10 @@ const { html } = require('common-tags')
 /**
  * Publication bibliography
  * @param      {Object}  eleventyConfig
- * @param      {Object}  globalData
  */
-module.exports = function (eleventyConfig, globalData, { page }) {
-  const biblioHeading = globalData.config.params.biblioHeading
-  const displayBiblioShort = globalData.config.params.displayBiblioShort
+module.exports = function (eleventyConfig, { page }) {
+  const biblioHeading = eleventyConfig.globalData.config.params.biblioHeading
+  const displayBiblioShort = eleventyConfig.globalData.config.params.displayBiblioShort
   const markdownify = eleventyConfig.getFilter('markdownify')
   const slugify = eleventyConfig.getFilter('slugify')
 

--- a/packages/11ty/_plugins/shortcodes/canvasPanel.js
+++ b/packages/11ty/_plugins/shortcodes/canvasPanel.js
@@ -27,7 +27,7 @@ const getChoices = (annotations=[]) => {
   }).filter(item => item)
 }
 
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
 
   /**
    * Canvas Panel Shortcode

--- a/packages/11ty/_plugins/shortcodes/cite.js
+++ b/packages/11ty/_plugins/shortcodes/cite.js
@@ -26,15 +26,15 @@ const { oneLine } = require('common-tags')
  *  @example {% cite "Faure 1909" "" "1909" %}
  *  renders the citation "1909"
  */
-module.exports = function(eleventyConfig, globalData, { page }) {
+module.exports = function(eleventyConfig, { page }) {
   const markdownify = eleventyConfig.getFilter('markdownify')
 
   const {
     citationPageLocationDivider: divider,
     citationPopupStyle: popupStyle
-  } = globalData.config.params
+  } = eleventyConfig.globalData.config.params
 
-  let references = globalData.references
+  let references = eleventyConfig.globalData.references
 
   return function(id, pageNumber, text) {
     if (!id) {

--- a/packages/11ty/_plugins/shortcodes/contributor.js
+++ b/packages/11ty/_plugins/shortcodes/contributor.js
@@ -10,7 +10,6 @@ const path = require('path')
  * Render formats other than 'bio'
  *
  * @param  {Object} eleventyConfig
- * @param  {Object} globalData
  * @param  {Object} params
  * @property  {Object} contributor
  * @property  {String} format              'bio' or... ?
@@ -18,7 +17,7 @@ const path = require('path')
  * 
  * @return {String} contributor markup
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const fullname = eleventyConfig.getFilter('fullname')
   const getContributor = eleventyConfig.getFilter('getContributor')
   const icon = eleventyConfig.getFilter('icon')

--- a/packages/11ty/_plugins/shortcodes/div.js
+++ b/packages/11ty/_plugins/shortcodes/div.js
@@ -6,7 +6,7 @@
  *
  * @return  {boolean}  A styled HTML <div> element containing the content
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   return ({ content, classes=[] }) => {
     classes = [classes].flatMap((item) => item).join(' ')

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -16,7 +16,7 @@ const { oneLine } = require('common-tags')
  *
  * @return     {boolean}  An HTML <figure> element
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const figureimage = eleventyConfig.getFilter('figureimage')
   const figurelabel = eleventyConfig.getFilter('figurelabel')
   const figuremodallink = eleventyConfig.getFilter('figuremodallink')
@@ -26,7 +26,7 @@ module.exports = function (eleventyConfig, globalData) {
   const getFigure = eleventyConfig.getFilter('getFigure')
   const slugify = eleventyConfig.getFilter('slugify')
 
-  const { epub, pdf } = globalData.config.params
+  const { epub, pdf } = eleventyConfig.globalData.config.params
 
   return async function (params) {
     let { id, class: classes=[] } = params

--- a/packages/11ty/_plugins/shortcodes/figureGroup.js
+++ b/packages/11ty/_plugins/shortcodes/figureGroup.js
@@ -4,11 +4,10 @@ const { html } = require('common-tags')
  * Render multiple <figure> elements in a group
  *
  * @param      {Object}  eleventyConfig  eleventy configuration
- * @param      {Object}  globalData      Eleventy global data
  * @param      {Array<id>}  ids          An array or list of figure identifiers
  * @return     {String}  An HTML string of the elements to render
  */
-module.exports = function (eleventyConfig, globalData) {
+module.exports = function (eleventyConfig) {
   const figure = eleventyConfig.getFilter('figure')
 
   return async function (params) {

--- a/packages/11ty/_plugins/shortcodes/figureRef.js
+++ b/packages/11ty/_plugins/shortcodes/figureRef.js
@@ -8,7 +8,7 @@ const { oneLineCommaLists } = require('common-tags')
  * renders the following markdown
  *  (fig. [4](#fig-4), [5](#fig-5), [6](#fig-6), [7](#fig-7))
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const fig = 'fig.'
 
   return function (ids) {

--- a/packages/11ty/_plugins/shortcodes/index.js
+++ b/packages/11ty/_plugins/shortcodes/index.js
@@ -11,25 +11,23 @@ const ref = require('./figureRef.js')
 const title = require('./title.js')
 const tombstone = require('./tombstone.js')
 
-const globalData = require('../globalData')
-
 module.exports = function(eleventyConfig, options) {
   eleventyConfig.addPairedShortcode('backmatter', function(content, ...args) {
-    return backmatter(eleventyConfig, globalData)(content, ...args)
+    return backmatter(eleventyConfig)(content, ...args)
   })
 
   eleventyConfig.addShortcode('bibliography', function() {
-    return bibliography(eleventyConfig, globalData, { page: this.page })()
+    return bibliography(eleventyConfig, { page: this.page })()
   })
 
   addComponentTag(eleventyConfig, canvasPanel, 'canvasPanel')
 
   eleventyConfig.addPairedShortcode('class', function(content, ...args) {
-    return div(eleventyConfig, globalData)(content, ...args)
+    return div(eleventyConfig)(content, ...args)
   })
   
   eleventyConfig.addShortcode('cite', function(...args) {
-    return cite(eleventyConfig, globalData, { page: this.page })(...args)
+    return cite(eleventyConfig, { page: this.page })(...args)
   })
 
   addComponentTag(eleventyConfig, contributor, 'contributor')
@@ -37,7 +35,7 @@ module.exports = function(eleventyConfig, options) {
   addComponentTag(eleventyConfig, figureGroup, 'figuregroup')
 
   eleventyConfig.addShortcode('ref', function(...args) {
-    return ref(eleventyConfig, globalData)(...args)
+    return ref(eleventyConfig)(...args)
   })
 
   eleventyConfig.addShortcode('title', function(...args) {
@@ -45,6 +43,6 @@ module.exports = function(eleventyConfig, options) {
   })
 
   eleventyConfig.addShortcode('tombstone', function(...args) {
-    return tombstone(eleventyConfig, globalData)(...args)
+    return tombstone(eleventyConfig)(...args)
   })
 }

--- a/packages/11ty/_plugins/shortcodes/title.js
+++ b/packages/11ty/_plugins/shortcodes/title.js
@@ -4,9 +4,9 @@ const { oneLine } = require('common-tags')
  * A shortcode for the Quire project or publication title,
  * currently used for the Quire cover template.
  */
-module.exports = function(eleventyConfig, globalData) {
+module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
-  const { publication } = globalData
+  const { publication } = eleventyConfig.globalData
 
   return function(params) {
     const seperator = publication.title.slice(-1).match(/[a-zA-Z]/)

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -4,8 +4,8 @@ const path = require('path')
 /**
  * A shortcode for tombstone display of object data on an entry page
  */
-module.exports = function(eleventyConfig, globalData) {
-  const { config, objects } = globalData
+module.exports = function(eleventyConfig) {
+  const { config, objects } = eleventyConfig.globalData
 
   return function (pageObjects) {
     const capitalize = eleventyConfig.getFilter('capitalize')


### PR DESCRIPTION
Changes:
- Add data in all yaml files in `_assets/_data` to `eleventyConfig.globalData`
- Fixes issue where previously you would need to restart the server to see changes to yaml data reflected in the project

Maybe I'm forgetting a very good reason we didn't do this to begin with when we refactored the shortcodes, but I was trying to figure out how to access data from one of the yaml files from the IIIF plugin, and adding them to `eleventyConfig.globalData` using [`addGlobalData`](https://www.11ty.dev/docs/data-global-custom/) seemed like the simplest way to make that data available to all plugins. This change does make destructuring global data in shortcodes very verbose.
