### PR TITLE
Fix/recent bugs

### DIFF
--- a/packages/cli/lib/project.js
+++ b/packages/cli/lib/project.js
@@ -396,7 +396,8 @@ class Project extends EventEmitter {
       await this.buildTheme(`webpack.config.prod.js`, baseURL);
       this.hugo = await this.spawnHugo(
         "server",
-        "--config=" + configs.join(",")
+        "--config=" + configs.join(","),
+        "--disableFastRender"
       );
       let isReady = await this.hugo.ready;
       if (isReady) {
@@ -501,7 +502,8 @@ class Project extends EventEmitter {
       this.hugo = await this.spawnHugo(
         "server",
         "--renderToDisk",
-        "--config=" + configs.join(",")
+        "--config=" + configs.join(","),
+        "--disableFastRender"
       );
 
       await this.buildTheme(`webpack.config.epub.js`, baseURL);
@@ -631,7 +633,8 @@ class Project extends EventEmitter {
       this.hugo = await this.spawnHugo(
         "server",
         "--renderToDisk",
-        "--config=" + configs.join(",")
+        "--config=" + configs.join(","),
+        "--disableFastRender"
       );
 
       await this.buildTheme(`webpack.config.epub.js`, baseURL);

--- a/themes/default/layouts/data/search-index.html
+++ b/themes/default/layouts/data/search-index.html
@@ -38,7 +38,7 @@ block-scoped .Scratch inside the `range` loop.
 {{- .Scratch.Set "pageType" "" -}}
 {{- .Scratch.Set "pageLength" "" -}}
 
-{{- if gt (len $page.Content) 0 -}}
+{{- if $page.Content -}}
 {{- .Scratch.Set "searchContent" $page.Plain -}}
 {{- .Scratch.Set "pageURL" $page.Permalink -}}
 {{- .Scratch.Set "pageType" $page.Type -}}

--- a/themes/default/layouts/partials/cite-this.html
+++ b/themes/default/layouts/partials/cite-this.html
@@ -36,7 +36,7 @@
 
   {{- if eq $citationRange "page" -}}
 
-    {{ if .page.Params.contributor }}{{ template "page-contributors-chicago" .page }}. {{ end }}{{ if .page.Title }}“{{ partial "page-title.html" .page }}.” {{ else if .page.Params.label }}“{{ .page.Params.label }}.” {{ else }}Untitled. {{ end }}In <em>{{ partial "site-title.html" .page }}</em>{{ if gt $siteAuthorCount 0 }}, {{ if gt $siteEditorCount 0 }}edited {{ end }}by {{ template "publication-contributors-chicago" .page }}{{ end }}. {{ template "publishers-chicago" (dict "site" .site)}}{{ with .site.Data.publication.pub_date }}, {{ dateFormat "2006" . }}{{ end }}. <span class="url-string">{{ if .site.Data.publication.identifier.url }}{{ .site.Data.publication.identifier.url }}{{ .page.RelPermalink }}{{ else }}{{ .page.Permalink }}{{ end }}</span>.
+    {{ if .page.Params.contributor }}{{ template "page-contributors-chicago" .page }}. {{ end }}{{ if .page.Title }}“{{ partial "page-title.html" .page | markdownify }}.” {{ else if .page.Params.label }}“{{ .page.Params.label }}.” {{ else }}Untitled. {{ end }}In <em>{{ partial "site-title.html" .page }}</em>{{ if gt $siteAuthorCount 0 }}, {{ if gt $siteEditorCount 0 }}edited {{ end }}by {{ template "publication-contributors-chicago" .page }}{{ end }}. {{ template "publishers-chicago" (dict "site" .site)}}{{ with .site.Data.publication.pub_date }}, {{ dateFormat "2006" . }}{{ end }}. <span class="url-string">{{ if .site.Data.publication.identifier.url }}{{ .site.Data.publication.identifier.url }}{{ .page.RelPermalink }}{{ else }}{{ .page.Permalink }}{{ end }}</span>.
 
   {{- else if eq $citationRange "site" -}}
 
@@ -49,7 +49,7 @@
 
   {{- if eq $citationRange "page" -}}
 
-    {{ if .page.Params.contributor }}{{ template "page-contributors-mla" .page }}. {{ end }}{{ if .page.Title }}“{{ partial "page-title.html" .page }}.” {{ else if .page.Params.label }}“{{ .page.Params.label }}.” {{ else }}Untitled. {{ end }}<em>{{ partial "site-title.html" .page }}</em>{{ if gt $siteAuthorCount 0 }}, {{ if gt $siteEditorCount 0 }}edited {{ end }}by {{ template "publication-contributors-mla" .page }}{{ end }}. {{ template "publishers-mla" (dict "site" .site)}}{{ with .site.Data.publication.pub_date }}, {{ dateFormat "2006" . }}{{ end }}. <span class="url-string">{{ if .site.Data.publication.identifier.url }}{{ .site.Data.publication.identifier.url }}{{ .page.RelPermalink }}{{ else }}{{ .page.Permalink }}{{ end }}</span>. Accessed <span class="cite-current-date">DD Mon. YYYY</span>.
+    {{ if .page.Params.contributor }}{{ template "page-contributors-mla" .page }}. {{ end }}{{ if .page.Title }}“{{ partial "page-title.html" .page | markdownify }}.” {{ else if .page.Params.label }}“{{ .page.Params.label }}.” {{ else }}Untitled. {{ end }}<em>{{ partial "site-title.html" .page }}</em>{{ if gt $siteAuthorCount 0 }}, {{ if gt $siteEditorCount 0 }}edited {{ end }}by {{ template "publication-contributors-mla" .page }}{{ end }}. {{ template "publishers-mla" (dict "site" .site)}}{{ with .site.Data.publication.pub_date }}, {{ dateFormat "2006" . }}{{ end }}. <span class="url-string">{{ if .site.Data.publication.identifier.url }}{{ .site.Data.publication.identifier.url }}{{ .page.RelPermalink }}{{ else }}{{ .page.Permalink }}{{ end }}</span>. Accessed <span class="cite-current-date">DD Mon. YYYY</span>.
 
   {{- else if eq $citationRange "site" -}}
 

--- a/themes/default/layouts/partials/contents-list/contents-list.html
+++ b/themes/default/layouts/partials/contents-list/contents-list.html
@@ -112,7 +112,7 @@ In order to properly close the /ul/li elements and nest sub-sections, the logic 
   {{/* Check to make sure the page is within the section that the contents list is being rendederd in (the "contents scope"). If it is, and it’s not also the contents page itself, render the list item for it.
   ------------------------------------------------------------------------- */}}
   {{- $pageWithinThisScope := findRE $contentsScopePattern $section -}}
-  {{- if and $pageWithinThisScope (ne $contentsPageID .File.UniqueID) -}}
+  {{- if and $pageWithinThisScope (or (eq $contentsLocation ".Params.menu") (and (eq $contentsLocation ".Params.toc") (ne $contentsPageID .File.UniqueID))) -}}
 
   {{- if and (ne $lastSection $section) (eq $sameAsOpenSection false) -}}
 

--- a/themes/default/layouts/partials/figures/media-types/vimeo.html
+++ b/themes/default/layouts/partials/figures/media-types/vimeo.html
@@ -8,12 +8,14 @@
 
 {{- else -}}
 
+  {{ $mediaIdEmbed := replace .mediaId "/" "?h=" }}
+
   <div
     class="quire-figure__media-wrapper{{ if .aspectRatio }}--{{ .aspectRatio }}{{ else }}--widescreen{{ end }}"
   >
     <iframe
       class="quire-figure__media"
-      src="https://player.vimeo.com/video/{{ .mediaId }}"
+      src="https://player.vimeo.com/video/{{ $mediaIdEmbed }}"
       frameborder="0"
       allow="autoplay; fullscreen"
       allowfullscreen

--- a/themes/default/layouts/partials/page-bibliography.html
+++ b/themes/default/layouts/partials/page-bibliography.html
@@ -28,7 +28,7 @@
       {{- end -}}
   {{- end -}}
 
-  {{- $alphaOrder := $alphaOrder | truncate 100 | urlize -}}
+  {{- $alphaOrder := $alphaOrder | truncate 400 | urlize -}}
   {{- $.Page.Scratch.SetInMap "entry" "0" $short -}}
   {{- $.Page.Scratch.SetInMap "entry" "1" $full -}}
   {{- $entry := ($.Page.Scratch.GetSortedMapValues "entry") -}}

--- a/themes/default/layouts/shortcodes/q-bibliography.html
+++ b/themes/default/layouts/shortcodes/q-bibliography.html
@@ -16,30 +16,30 @@
 {{- range $.Site.Data.references.entries -}}
 
   {{- $bibFull := .full -}}
-  
+
   {{- $bibShort := "" -}}
   {{ if .short }}
     {{- $bibShort = .short -}}
   {{ else }}
     {{- $bibShort = .id -}}
   {{ end }}
-  
+
   {{- $bibSort := "" -}}
   {{ if .sort }}
     {{- $bibSort = .sort -}}
   {{ else }}
     {{- $bibSort = .full -}}
-  {{ end }}  
-  {{- $bibSort = $bibSort | truncate 100 | urlize -}} 
-     
+  {{ end }}
+  {{- $bibSort = $bibSort | truncate 400 | urlize -}} 
+
   {{- $.Page.Scratch.SetInMap "ref" "0" $bibShort -}}
   {{- $.Page.Scratch.SetInMap "ref" "1" $bibFull -}}
   {{- $ref := ($.Page.Scratch.GetSortedMapValues "ref") -}}
-  {{- $.Page.Scratch.SetInMap "biblio" $bibSort $ref -}}  
+  {{- $.Page.Scratch.SetInMap "biblio" $bibSort $ref -}}
   {{- $.Page.Scratch.Delete "ref" -}}
-  
+
 {{- end -}}
-  
+
 {{- if ($.Page.Scratch.GetSortedMapValues "biblio") }}
 <div class="quire-page__content__references">
     {{- if eq .Site.Params.displayBiblioShort true }}

--- a/themes/default/source/css/print.scss
+++ b/themes/default/source/css/print.scss
@@ -444,7 +444,7 @@ $print-trim: $print-bleed * 2;
   // that are printed in the text of the book, in order to facilitate better
   // line breaking per Chicago Manual of Style
   // https://www.chicagomanualofstyle.org/book/ed17/part3/ch14/psec018.html
-  a[target=_blank] {
+  a[href^="http"] {
     prince-text-replace: "/" "\200B/"
                           "~" "\200B~"
                           "." "\200B."

--- a/themes/default/source/js/popup.js
+++ b/themes/default/source/js/popup.js
@@ -11,14 +11,14 @@ require("magnific-popup");
 export default function(gallerySelector, mapArr) {
   /** set var */
   const fullscreenButton = `
-  <div 
+  <div
   class="leaflet-control-fullscreen leaflet-bar leaflet-control remove-from-epub"
   >
     <a
-    id="toggleFullscreen" 
-    class="leaflet-control-fullscreen-button leaflet-bar-part" 
-    href="#" 
-    title="View Fullscreen" 
+    id="toggleFullscreen"
+    class="leaflet-control-fullscreen-button leaflet-bar-part"
+    href="#"
+    title="View Fullscreen"
     style="outline: none;">
     </a>
   </div>
@@ -229,11 +229,15 @@ export default function(gallerySelector, mapArr) {
           if (id.indexOf("deepzoom") !== -1) {
             setTimeout(() => {
               let url = $(`#${id}`).attr("src");
-              let image = new Image();
-              image.src = url;
-              image.onload = function() {
-                deepzoom = new DeepZoom(id, mapArr);
-              };
+              if (url) {
+                let image = new Image();
+                image.src = url;
+                image.onload = function() {
+                  deepzoom = new DeepZoom(id, mapArr);
+                };
+              } else {
+                deepzoom = null;
+              }
             }, waitForDOMUpdate);
           }
           if (id.indexOf("iiif") !== -1) {


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team

### Is this pull request related to an open issue? If so, what is the issue number?

n/a

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Fix a few lingering issues

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

This ports in a number of small template fixes I came across working in recent Getty books, as well as a fix from @anderspollack on table rendering in the image modal.

It also, importantly, expands the use of `--disableFastRender` to whenever `hugo server` is run to avoid hang ups with PDF and EPUB generation that we were seeing here and that were being reported by other Quire users. (We'd previously implemented `--disableFastRender` for `quire preview`.)

### Does this pull request necessitate changes to Quire's documentation?

Yes, just a small one to note a change in Vimeo `media_id`s. I'll do that now.

### Include screenshots of before/after if applicable.



### Additional Comments

