### PR TITLE
Reset current lightbox figure ID when closing a parent `q-modal`

### DIFF
--- a/packages/11ty/content/_assets/javascript/lit/modal.js
+++ b/packages/11ty/content/_assets/javascript/lit/modal.js
@@ -63,6 +63,7 @@ class Modal extends LitElement {
 
   close() {
     this.active = false;
+    this.currentId = null;
     this.enableScrolling();
   }
 


### PR DESCRIPTION
Fixes an issue where closing a `modal` wouldn't reset the current lightbox slide.

Example scenario this fixes: 
- viewer opens the first figure in a modal lightbox
- viewer navigates to the figure 2 in the lightbox
- viewer closes modal lightbox
- viewer reopens the first figure in a modal lightbox
- lightbox is still stuck on the last viewed slide -- figure 2