### PR TITLE
DEV-12062: Citation formatting

### DIFF
--- a/packages/11ty/_plugins/shortcodes/cite.js
+++ b/packages/11ty/_plugins/shortcodes/cite.js
@@ -75,7 +75,7 @@ module.exports = function(eleventyConfig, { page }) {
 
     return stripIndents`
       <cite class="quire-citation expandable">
-        ${button.replace(/\n/g, '')}
+        ${button}
         <span hidden class="quire-citation__content">
           ${markdownify(citation.full)}
         </span>

--- a/packages/11ty/_plugins/shortcodes/cite.js
+++ b/packages/11ty/_plugins/shortcodes/cite.js
@@ -1,4 +1,4 @@
-const { oneLine } = require('common-tags')
+const { stripIndents } = require('common-tags')
 
 /**
  *  @todo Remove reliance on `this.page` in context. 
@@ -61,25 +61,25 @@ module.exports = function(eleventyConfig, { page }) {
     if (pageNumber) buttonText += divider + pageNumber
 
     const button = popupStyle === 'icon'
-      ? oneLine`
+      ? stripIndents`
           ${buttonText}
           <button class="quire-citation__button material-icons md-18 material-control-point" aria-expanded="false">
             control_point
           </button>
-        `
-      : oneLine`
+      `
+      : stripIndents`
           <span class="quire-citation__button" role="button" tabindex="0" aria-expanded="false">
             ${buttonText}
           </span>
-        `
+      `
 
-    return oneLine`
+    return stripIndents`
       <cite class="quire-citation expandable">
-        ${button}
+        ${button.replace(/\n/g, '')}
         <span hidden class="quire-citation__content">
           ${markdownify(citation.full)}
         </span>
       </cite>
-    `
+    `.replace(/\n/g, '')
   }
 }

--- a/packages/11ty/content/_assets/styles/components/quire-citation.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-citation.scss
@@ -15,6 +15,7 @@
     font-size: 1em;
     background-color: inherit;
     font-family: inherit;
+    font-style: normal;
     color: inherit;
     cursor: pointer;
     @if $theme == classic {


### PR DESCRIPTION
Prevent `cite` shortcode from rendering template indention whitespace to remove spaces around citation popup link

example: `({% cite 'Evans 1938' %})` => **( Evans 1938 )** now renders **(Evans 1938)**