### PR TITLE
Fix: Undefined canvas-panel and image-service properties

### DIFF
--- a/packages/11ty/_includes/components/figure/imageservice.js
+++ b/packages/11ty/_includes/components/figure/imageservice.js
@@ -12,7 +12,7 @@ const path = require('path')
 module.exports = function(eleventyConfig) {
   const { imageServiceDirectory, output } = eleventyConfig.globalData.iiifConfig
 
-  return function({ alt, height, id, preset, region, src, virtualSizes, width}) {
+  return function({ alt='', height='', preset='', region='', src, virtualSizes='', width='' }) {
     const imageService = ((src).startsWith('http'))
       ? src
       : path.join('/', output, path.parse(src).name, imageServiceDirectory)

--- a/packages/11ty/_includes/components/figure/imageservice.js
+++ b/packages/11ty/_includes/components/figure/imageservice.js
@@ -22,7 +22,6 @@ module.exports = function(eleventyConfig) {
         alt="${alt}"
         class="q-figure__image"
         height="${height}"
-        id="${id}"
         preset="${preset}"
         region="${region}"
         src="${imageService}"

--- a/packages/11ty/_plugins/shortcodes/canvasPanel.js
+++ b/packages/11ty/_plugins/shortcodes/canvasPanel.js
@@ -21,7 +21,7 @@ module.exports = function(eleventyConfig) {
    * @return {String}        <canvas-panel> markup
    */
   return async function(params) {
-    let { height, id, iiifContent, manifestId, preset, region, virtualSizes, width } = params
+    let { height='', id, iiifContent, manifestId, preset='', region='', virtualSizes='', width='' } = params
 
     const { canvas, choiceId, manifest } = await figureIIIF(params)
     

--- a/packages/11ty/_plugins/shortcodes/canvasPanel.js
+++ b/packages/11ty/_plugins/shortcodes/canvasPanel.js
@@ -35,7 +35,6 @@ module.exports = function(eleventyConfig) {
         canvas-id="${canvas.id}"
         choice-id="${choiceId}"
         height="${height}"
-        id="${id}"
         iiif-content="${iiifContent}"
         manifest-id="${manifest.id}"
         preset="${preset}"


### PR DESCRIPTION
Changes:
- Removes `id` from canvas-panel and image-service (id is defined on the `figure`)
- Sets default properties to empty string