### PR TITLE
DEV-12052: Contributor QA

### DIFF
--- a/packages/11ty/_includes/components/contributor/header.js
+++ b/packages/11ty/_includes/components/contributor/header.js
@@ -25,7 +25,7 @@ module.exports = function(eleventyConfig) {
 
     const format = pageContributorByline || globalContributorByline
 
-    const contributorLine = contributorAsItAppears || contributorList({ contributors, format })
+    const contributorLine = markdownify(contributorAsItAppears) || contributorList({ contributors, format })
     const contributorElement = contributorLine
       ? `<div class="quire-page__header__contributor">
            ${contributorLine}

--- a/packages/11ty/_includes/components/contributor/list.js
+++ b/packages/11ty/_includes/components/contributor/list.js
@@ -12,7 +12,7 @@ module.exports = function (eleventyConfig) {
   const getContributor = eleventyConfig.getFilter('getContributor')
 
   return function (params) {
-    const { contributors, type = 'all', format = 'string' } = params
+    const { contributor: contributors, type = 'all', format = 'string' } = params
 
     if (!Array.isArray(contributors)) return ''
 

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -77,12 +77,12 @@ Entry content, including entry image and tombstone data
             <h1 class="quire-page__header__title" id="{{ title | url }}">
               {% pageTitle label=label, title=title, subtitle=subtitle %}
             </h1>
+            {% contributorHeader
+              contributor=contributor,
+              contributor_as_it_appears=contributor_as_it_appears,
+              contributor_byline=contributor_byline
+            %}
           </div>
-          {% contributorHeader
-            contributor=contributor,
-            contributor_as_it_appears=contributor_as_it_appears,
-            contributor_byline=contributor_byline
-          %}
         </header>
       {% endif %}
 

--- a/packages/11ty/_plugins/shortcodes/contributor.js
+++ b/packages/11ty/_plugins/shortcodes/contributor.js
@@ -22,6 +22,7 @@ module.exports = function (eleventyConfig) {
   const getContributor = eleventyConfig.getFilter('getContributor')
   const icon = eleventyConfig.getFilter('icon')
   const link = eleventyConfig.getFilter('link')
+  const markdownify = eleventyConfig.getFilter('markdownify')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const slugify = eleventyConfig.getFilter('slugify')
 
@@ -55,7 +56,7 @@ module.exports = function (eleventyConfig) {
     const contributorBio = bio
       ? oneLine`
           <div class="quire-contributor__bio">
-            ${bio}
+            ${markdownify(bio)}
           </div>
       `
       : ''

--- a/packages/11ty/_plugins/shortcodes/contributor.js
+++ b/packages/11ty/_plugins/shortcodes/contributor.js
@@ -40,21 +40,37 @@ module.exports = function (eleventyConfig) {
       })}`
     })
 
+    const contributorLink = url
+      ? link({ classes: ["quire-contributor__url"], name: icon({ type: 'link', description:'' }), url })
+      : ''
+
+    const contributorImage = imagePath
+      ? oneLine`
+          <div class="media-left">
+            <img class="image quire-contributor__pic" src="${imagePath}" alt="Picture of ${name}">
+          </div>
+      `
+      : ''
+
+    const contributorBio = bio
+      ? oneLine`
+          <div class="quire-contributor__bio">
+            ${bio}
+          </div>
+      `
+      : ''
+
     return oneLine`
       <ul class="quire-contributors-list bio">
         <li class="quire-contributor" id="${slugify(name)}">
           <div class="title is-5">
             <span class="quire-contributor__name">${name}</span>
-            ${link({ classes: ["quire-contributor__url"], name: icon({ type: 'link', description:'' }), url })}
+            ${contributorLink}
           </div>
           <div class="media">
             <div class="quire-contributor__details media-content">
-              <div class="media-left">
-                <img class="image quire-contributor__pic" src="${imagePath}" alt="Picture of ${name}">
-              </div>
-              <div class="quire-contributor__bio">
-                ${bio}
-              </div>
+              ${contributorImage}
+              ${contributorBio}
               ${contributorPages}
             </div>
           </div>


### PR DESCRIPTION
Various contributor-related QA tasks. These could be merged in at any time, there's just one outstanding subtask left

- DEV-12054: Support mardown in contributor bio
- DEV-12055: Only render contributor properties with values
- DEV-12056: Markdownify `contributor_as_it_appears` on pages
- DEV-12057: Move contributor info inside `.quire-entry__content > .container`
- DEV-12058: Render page `contributor` with `contributorList` on splash pages

**TODO**: DEV-12059: Contributor shortcode only supports `bio` variant https://jira.getty.edu/browse/DEV-12059

@geealbers had also mentioned that `contributor_as_it_appears` should render on all page templates. It's currently missing on `splash.liquid`, which uses the`contributorList` shortcode. We could add support for `contributor_as_it_appears` to that shortcode, like `contributorHeader`, but there might be a different way to handle that/refactor the various contributor shortcodes to be a bit more uniform