### PR TITLE
Refactor: IIIF Data Fetching

### DIFF
--- a/packages/11ty/_includes/components/figure/choices.js
+++ b/packages/11ty/_includes/components/figure/choices.js
@@ -1,39 +1,7 @@
-const { globalVault } = require('@iiif/vault')
-const vault = globalVault()
-
-/**
- * Very simplified method to get choices - expects a valid manifest where choices all have identifiers
- * @todo replace with vault helper
- */
-const getChoices = (annotations=[]) => {
-  return annotations.flatMap(({ id, type }) => {
-    const annotation = vault.get(id)
-    if (annotation.motivation.includes('painting')) {
-      const bodies = vault.get(annotation.body)
-      for (const body of bodies) {
-        const { items, type } = body
-        return (type === 'Choice') ? items.map(({ id }) => vault.get(id)) : []
-      }
-    }
-  })
-}
-
 module.exports = function(eleventyConfig) {
-  const figureIIIF = eleventyConfig.getFilter('figureIIIF')
-
-  return async function(figure) {
-    const { canvas, choiceId, manifest } = await figureIIIF(figure)
-
-    let choices = getChoices(canvas.annotations)
-    if (!choices.length && canvas.items.length) {
-      canvas.items.map(({ id, type }) => {
-        if (type === 'AnnotationPage') {
-          const annotationPage = vault.get(id)
-          choices = getChoices(annotationPage.items)
-        }
-      })
-    }
-    hasChoices = !!choices.length
+  return function(figure) {
+    const { choiceId, choices } = figure
+    if (!choices || !choices.length) return
     return choices.map((item, index) => {
       const classes = ['canvas-choice']
       if (item.id === choiceId) classes.push('canvas-choice--active')

--- a/packages/11ty/_includes/components/figure/image.js
+++ b/packages/11ty/_includes/components/figure/image.js
@@ -16,6 +16,7 @@ module.exports = function(eleventyConfig) {
   const figuremodallink = eleventyConfig.getFilter('figuremodallink')
   const imageservice = eleventyConfig.getFilter('imageservice')
   const isImageService = eleventyConfig.getFilter('isImageService')
+  const hasCanvasPanelProps = eleventyConfig.getFilter('hasCanvasPanelProps')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
   const { imageDir, figureLabelLocation } = eleventyConfig.globalData.config.params
@@ -36,14 +37,13 @@ module.exports = function(eleventyConfig) {
       src='' 
     } = figure
     const labelElement = figurelabel({ caption, id, label })
-    const hasCanvasPanelProps = (!!canvasId && !!manifestId) || !!iiifContent || !!choices
 
     let choicesElement='', imageElement;
 
     switch (true) {
-      case hasCanvasPanelProps:
-        imageElement = await canvasPanel(figure)
-        choicesElement = await(figurechoices(figure))
+      case hasCanvasPanelProps(figure):
+        imageElement = canvasPanel(figure)
+        choicesElement = figurechoices(figure)
         break;
       case isImageService(figure):
         imageElement = imageservice(figure)

--- a/packages/11ty/_includes/components/figure/imageservice.js
+++ b/packages/11ty/_includes/components/figure/imageservice.js
@@ -1,5 +1,4 @@
 const { html } = require('common-tags')
-const path = require('path')
 
 /**
  * Image Service Web Component
@@ -10,13 +9,7 @@ const path = require('path')
  * @return     {String}  An <image-service> element
  */
 module.exports = function(eleventyConfig) {
-  const { imageServiceDirectory, output } = eleventyConfig.globalData.iiifConfig
-
   return function({ alt='', height='', preset='', region='', src, virtualSizes='', width='' }) {
-    const imageService = ((src).startsWith('http'))
-      ? src
-      : path.join('/', output, path.parse(src).name, imageServiceDirectory)
-
     return html`
       <image-service 
         alt="${alt}"
@@ -24,7 +17,7 @@ module.exports = function(eleventyConfig) {
         height="${height}"
         preset="${preset}"
         region="${region}"
-        src="${imageService}"
+        src="${src}"
         virtual-sizes="${virtualSizes}"
         width="${width}">
       </image-service>`

--- a/packages/11ty/_plugins/filters/hasCanvasPanelProps.js
+++ b/packages/11ty/_plugins/filters/hasCanvasPanelProps.js
@@ -1,0 +1,3 @@
+module.exports = ({ id, canvasId, manifestId, iiifContent, choices }) => {
+  return (!!canvasId && !!manifestId) || !!iiifContent || !!choices
+}

--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -1,18 +1,17 @@
 const capitalize = require('./capitalize')
-const isImageService = require('./isImageService')
 const figureIIIF = require('./figureIIIF')
 const fullname = require('./fullname')
 const getContributor = require('./getContributor')
 const getFigure = require('./getFigure')
 const getObject = require('./getObject')
+const hasCanvasPanelProps = require('./hasCanvasPanelProps')
+const isImageService = require('./isImageService')
 const json = require('./json')
 
 module.exports = function(eleventyConfig, options) {
   // @see https://www.11ty.dev/docs/filters/#universal-filters
 
   eleventyConfig.addFilter('capitalize', (string) => capitalize(string))
-
-  eleventyConfig.addFilter('isImageService', (figure, options) => isImageService(figure, options))
 
   eleventyConfig.addFilter('figureIIIF', (figure, options) => figureIIIF(eleventyConfig, figure, options))
 
@@ -23,6 +22,10 @@ module.exports = function(eleventyConfig, options) {
   eleventyConfig.addFilter('getFigure', (id) => getFigure(eleventyConfig, id))
 
   eleventyConfig.addFilter('getObject', (id) => getObject(eleventyConfig, id))
+
+  eleventyConfig.addFilter('hasCanvasPanelProps', (figure, options) => hasCanvasPanelProps(figure, options))
+
+  eleventyConfig.addFilter('isImageService', (figure, options) => isImageService(figure, options))
 
   eleventyConfig.addFilter('keywords', () => keywords(eleventyConfig))
 

--- a/packages/11ty/_plugins/iiif/README.md
+++ b/packages/11ty/_plugins/iiif/README.md
@@ -14,6 +14,9 @@ If true, logs IIIF processing steps for each image to console. Default: `false`.
 `lazy` {Boolean}
 If true, skips processing images that have previously been processed. If false, re-processess all images. Default: `true`.
 
+## Global Data
+Figures rendered using the `canvas-panel` web component will have the `canvas`, `manifest`, `choices` (if relevant) and `choiceId` (if relevant) properties added to their figure objects in `globalData.figures`.
+
 ## Image Tiling
 Quire uses [`sharp`](https://sharp.pixelplumbing.com/api-output#tile) to generate a IIIF image service for all images in the `figures` directory with the `zoom` preset. When these images are used with the `figure` shortcode, they will be rendered using an [`<image-service/>`](https://iiif-canvas-panel.netlify.app/docs/components/single-image-service) web component. The output for each image includes the original image, thumbnail image, and tiles.
 

--- a/packages/11ty/_plugins/iiif/process/addGlobalData.js
+++ b/packages/11ty/_plugins/iiif/process/addGlobalData.js
@@ -1,14 +1,17 @@
-const { globalVault } = require('@iiif/vault')
-const vault = globalVault()
+const { globalVault } = require('@iiif/vault');
+const path = require('path');
+const vault = globalVault();
 
 /**
  * Fetches IIIF data needed to render canvas panel tags from vault and adds it to figures.yaml
  * @param  {Object} eleventyConfig
  */
-module.exports = (eleventyConfig) => {
-  const figureIIIF = eleventyConfig.getFilter('figureIIIF')
-  const hasCanvasPanelProps = eleventyConfig.getFilter('hasCanvasPanelProps')
-  const { figures } = eleventyConfig.globalData
+module.exports = async (eleventyConfig) => {
+  const figureIIIF = eleventyConfig.getFilter('figureIIIF');
+  const isImageService = eleventyConfig.getFilter('isImageService');
+  const hasCanvasPanelProps = eleventyConfig.getFilter('hasCanvasPanelProps');
+  const { figures, iiifConfig } = eleventyConfig.globalData;
+  const { imageServiceDirectory, output } = iiifConfig;
 
   /**
    * Very simplified method to get choices - expects a valid manifest where choices all have identifiers
@@ -16,41 +19,53 @@ module.exports = (eleventyConfig) => {
    */
   const getChoices = (annotations = []) => {
     return annotations.flatMap(({ id, type }) => {
-      const annotation = vault.get(id)
+      const annotation = vault.get(id);
       if (annotation.motivation.includes('painting')) {
-        const bodies = vault.get(annotation.body)
+        const bodies = vault.get(annotation.body);
         for (const body of bodies) {
-          const { items, type } = body
-          return type === 'Choice'
-            ? items.map(({ id }) => vault.get(id))
-            : []
+          const { items, type } = body;
+          return type === 'Choice' ? items.map(({ id }) => vault.get(id)) : [];
         }
       }
-    })
+    });
+  };
+
+  for (const [index, figure] of figures.figure_list.entries()) {
+    switch (true) {
+      case isImageService(figure):
+        const src = figure.src.startsWith('http')
+          ? figure.src
+          : path.join(
+              '/',
+              output,
+              path.parse(figure.src).name,
+              imageServiceDirectory,
+              'info.json'
+            );
+        Object.assign(eleventyConfig.globalData.figures.figure_list[index], {
+          src
+        });
+        break;
+      case hasCanvasPanelProps(figure):
+        const { canvas, choiceId, manifest } = await figureIIIF(figure);
+        let choices = getChoices(canvas.annotations);
+        if (!choices.length && canvas.items.length) {
+          canvas.items.map(({ id, type }) => {
+            if (type === 'AnnotationPage') {
+              const annotationPage = vault.get(id);
+              choices = getChoices(annotationPage.items);
+            }
+          });
+        }
+        Object.assign(eleventyConfig.globalData.figures.figure_list[index], {
+          canvas,
+          choices,
+          choiceId,
+          manifest
+        });
+        break;
+      default:
+        break;
+    }
   }
-
-  figures.figure_list
-    .forEach(async (figure, index) => {
-      if (!hasCanvasPanelProps(figure)) return
-
-      const { canvas, choiceId, manifest } = await figureIIIF(figure)
-
-      let choices = getChoices(canvas.annotations)
-      if (!choices.length && canvas.items.length) {
-        canvas.items.map(({ id, type }) => {
-          if (type === 'AnnotationPage') {
-            const annotationPage = vault.get(id)
-            choices = getChoices(annotationPage.items)
-          }
-        })
-      }
-
-      eleventyConfig.globalData.figures.figure_list[index] = {
-        ...eleventyConfig.globalData.figures.figure_list[index],
-        canvas,
-        choices,
-        choiceId,
-        manifest
-      }
-    })
-}
+};

--- a/packages/11ty/_plugins/iiif/process/addGlobalData.js
+++ b/packages/11ty/_plugins/iiif/process/addGlobalData.js
@@ -1,0 +1,56 @@
+const { globalVault } = require('@iiif/vault')
+const vault = globalVault()
+
+/**
+ * Fetches IIIF data needed to render canvas panel tags from vault and adds it to figures.yaml
+ * @param  {Object} eleventyConfig
+ */
+module.exports = (eleventyConfig) => {
+  const figureIIIF = eleventyConfig.getFilter('figureIIIF')
+  const hasCanvasPanelProps = eleventyConfig.getFilter('hasCanvasPanelProps')
+  const { figures } = eleventyConfig.globalData
+
+  figures.figure_list
+    .forEach(async (figure, index) => {
+      if (!hasCanvasPanelProps(figure)) return
+
+      /**
+       * Add choices to globalData
+       */
+      const getChoices = (annotations = []) => {
+        return annotations.flatMap(({ id, type }) => {
+          const annotation = vault.get(id)
+          if (annotation.motivation.includes('painting')) {
+            const bodies = vault.get(annotation.body)
+            for (const body of bodies) {
+              const { items, type } = body
+              return type === 'Choice'
+                ? items.map(({ id }) => vault.get(id))
+                : []
+            }
+          }
+        })
+      }
+
+      const { canvas, choiceId, manifest } = await figureIIIF(figure)
+
+      let choices = getChoices(canvas.annotations)
+      if (!choices.length && canvas.items.length) {
+        canvas.items.map(({ id, type }) => {
+          if (type === 'AnnotationPage') {
+            const annotationPage = vault.get(id)
+            choices = getChoices(annotationPage.items)
+          }
+        })
+      }
+      eleventyConfig.globalData.figures.figure_list[index] = {
+        ...eleventyConfig.globalData.figures.figure_list[index],
+        canvas,
+        choices,
+        choiceId,
+        manifest
+      }
+      // console.warn('adding global data to ', figure.id, eleventyConfig.globalData.figures.figure_list[index])
+      // console.warn(eleventyConfig.globalData.figures.figure_list[index])
+    })
+}

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -80,7 +80,7 @@ module.exports = {
        * Must follow creation of manifests
        * Adds necessary IIIF data for rendering to globalData.figures
        */
-      addGlobalData(eleventyConfig)
+      await addGlobalData(eleventyConfig)
 
       if (debug) {
         console.warn(`[iiif:processImages] Done`)

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra')
 const path = require('path')
+const addGlobalData = require('./addGlobalData')
 const initCreateImage = require('./createImage')
 const initCreateManifest = require('./createManifest')
 const initTileImage = require('./tileImage')
@@ -74,6 +75,12 @@ module.exports = {
       for (const figure of figuresWithChoices) {
         await createManifest(figure, options)
       }
+
+      /**
+       * Must follow creation of manifests
+       * Adds necessary IIIF data for rendering to globalData.figures
+       */
+      addGlobalData(eleventyConfig)
 
       if (debug) {
         console.warn(`[iiif:processImages] Done`)

--- a/packages/11ty/_plugins/shortcodes/canvasPanel.js
+++ b/packages/11ty/_plugins/shortcodes/canvasPanel.js
@@ -5,8 +5,6 @@
 const { html } = require('common-tags')
 
 module.exports = function(eleventyConfig) {
-  const figureIIIF = eleventyConfig.getFilter('figureIIIF')
-
   /**
    * Canvas Panel Shortcode
    * @param  {Object} params `figure` data from `figures.yaml`
@@ -17,13 +15,11 @@ module.exports = function(eleventyConfig) {
    * @property  {String} preset <canvas-panel> preset {@link https://iiif-canvas-panel.netlify.app/docs/examples/responsive-image#presets}
    * @return {String}        <canvas-panel> markup
    */
-  return async function(params) {
-    let { height='', id, iiifContent, manifestId, preset='', region='', virtualSizes='', width='' } = params
+  return function(params) {
+    const { canvas, choiceId, height='', id, iiifContent, manifest, preset='', region='', virtualSizes='', width='' } = params
 
-    const { canvas, choiceId, manifest } = await figureIIIF(params)
-    
     if (!manifest && !iiifContent) {
-      console.error('[shortcodes:canvasPanel] Error fetching manifest for figure id: ', id)
+      console.error(`[shortcodes:canvasPanel] Invalid params for figure "${id}": `, params)
       return ''
     }
 

--- a/packages/11ty/content/_assets/javascript/lit/lightbox.js
+++ b/packages/11ty/content/_assets/javascript/lit/lightbox.js
@@ -252,7 +252,7 @@ class Lightbox extends LitElement {
             imageElement = `<canvas-panel id="${elementId}" data-figure="${id}" canvas-id="${canvasId}" manifest-id="${manifestId}" preset="${preset}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImageService:
-            imageElement = `<image-service id="${elementId}" data-figure="${id}" src="${imageSrc}" width="${this.width}" height="${this.height}" />`;
+            imageElement = `<image-service id="${elementId}" data-figure="${id}" src="${src}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImg:
             imageElement = `<img id="${elementId}" data-figure="${id}" src="${imageSrc}" />`;


### PR DESCRIPTION
I think this will help with the lightbox 💡

Changes:
- Move all vault fetching to `_plugins/iiif/addGlobalData`, which iterates over figures.yaml and adds IIIF `manifest`, `canvas`, `choiceId` and `choices` to `globalData.figures` 