### PR TITLE
Move IIIF-related figure properties to `figure.iiif`

### DIFF
--- a/packages/11ty/_includes/components/figure/imageservice.js
+++ b/packages/11ty/_includes/components/figure/imageservice.js
@@ -9,7 +9,7 @@ const { html } = require('common-tags')
  * @return     {String}  An <image-service> element
  */
 module.exports = function(eleventyConfig) {
-  return function({ alt='', height='', preset='', region='', src, virtualSizes='', width='' }) {
+  return function({ alt='', height='', preset='', region='', iiif, virtualSizes='', width='' }) {
     return html`
       <image-service 
         alt="${alt}"
@@ -17,7 +17,7 @@ module.exports = function(eleventyConfig) {
         height="${height}"
         preset="${preset}"
         region="${region}"
-        src="${src}"
+        src="${iiif.info}"
         virtual-sizes="${virtualSizes}"
         width="${width}">
       </image-service>`

--- a/packages/11ty/_plugins/iiif/process/createManifest.js
+++ b/packages/11ty/_plugins/iiif/process/createManifest.js
@@ -35,8 +35,8 @@ module.exports = (eleventyConfig) => {
    * @property  {String} output (optional) overwrite default output
    */
   return async (figure, options={}) => {
-    const { debug, output } = options
-    const { id, label, choices, preset } = figure
+    const { debug, lazy, output } = options
+    const { id, label, choiceId, choices, preset } = figure
 
     const outputDir = output || defaultOutput
     const iiifId = [process.env.URL, outputDir, id].join('/')
@@ -51,11 +51,11 @@ module.exports = (eleventyConfig) => {
 
     const defaultChoice =
       choices.find(({ default: defaultChoice }) => defaultChoice) || choices[0]
-    const imagePath = path.join(
-      root,
-      imageDir,
-      defaultChoice.src
-    )
+
+    const imagePath = choiceId
+      ? choiceId
+      : path.join(root, imageDir, defaultChoice.src)
+
     const { height, width } = await sharp(imagePath).metadata()
     const manifest = builder.createManifest(manifestId, (manifest) => {
       manifest.addLabel(label, locale)

--- a/packages/11ty/_plugins/shortcodes/canvasPanel.js
+++ b/packages/11ty/_plugins/shortcodes/canvasPanel.js
@@ -16,7 +16,8 @@ module.exports = function(eleventyConfig) {
    * @return {String}        <canvas-panel> markup
    */
   return function(params) {
-    const { canvas, choiceId, height='', id, iiifContent, manifest, preset='', region='', virtualSizes='', width='' } = params
+    const { height='', id, iiif, preset='', region='', virtualSizes='', width='' } = params
+    const { canvas, choiceId='', iiifContent='', manifest} = iiif
 
     if (!manifest && !iiifContent) {
       console.error(`[shortcodes:canvasPanel] Invalid params for figure "${id}": `, params)

--- a/packages/11ty/content/_assets/javascript/lit/lightbox.js
+++ b/packages/11ty/content/_assets/javascript/lit/lightbox.js
@@ -218,9 +218,9 @@ class Lightbox extends LitElement {
 
   render() {
     const imageSlides = () => {
-      const imagesWithCaptions = this.figures.map(({ canvasId, caption, credit, id, label, manifestId, preset, src }, index) => {
-        const isCanvasPanel = !!canvasId && !!manifestId;
-        const isImageService = src && !src.match(/.+\.(jpe?g|gif|png)$/);
+      const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, label, preset, src }, index) => {
+        const isCanvasPanel = iiif && !!iiif.canvas.id && !!iiif.manifest.id;
+        const isImageService = iiif && !!iiif.info;
         const isImg = src && !!src.match(/.+\.(jpe?g|gif|png)$/);
         const labelSpan = label
           ? `<span class="q-lightbox__caption-label">${label}</span>`
@@ -249,10 +249,10 @@ class Lightbox extends LitElement {
             imageElement = `<div class="q-lightbox__missing-img">Figure '${id}' does not have a valid 'src'</div>`;
             break;
           case isCanvasPanel:
-            imageElement = `<canvas-panel id="${elementId}" data-figure="${id}" canvas-id="${canvasId}" manifest-id="${manifestId}" preset="${preset}" width="${this.width}" height="${this.height}" />`;
+            imageElement = `<canvas-panel id="${elementId}" data-figure="${id}" canvas-id="${iiif.canvas.id}" manifest-id="${iiif.manifest.id}" preset="${preset}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImageService:
-            imageElement = `<image-service id="${elementId}" data-figure="${id}" src="${src}" width="${this.width}" height="${this.height}" />`;
+            imageElement = `<image-service id="${elementId}" data-figure="${id}" src="${iiif.info}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImg:
             imageElement = `<img id="${elementId}" data-figure="${id}" src="${imageSrc}" />`;

--- a/packages/11ty/content/_assets/javascript/lit/lightbox.js
+++ b/packages/11ty/content/_assets/javascript/lit/lightbox.js
@@ -219,7 +219,8 @@ class Lightbox extends LitElement {
   render() {
     const imageSlides = () => {
       const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, label, preset, src }, index) => {
-        const isCanvasPanel = iiif && !!iiif.canvas.id && !!iiif.manifest.id;
+        console.warn(iiif)
+        const isCanvasPanel = iiif && !!iiif.canvas && !!iiif.manifest;
         const isImageService = iiif && !!iiif.info;
         const isImg = src && !!src.match(/.+\.(jpe?g|gif|png)$/);
         const labelSpan = label

--- a/packages/11ty/content/_assets/javascript/lit/lightbox.js
+++ b/packages/11ty/content/_assets/javascript/lit/lightbox.js
@@ -219,7 +219,6 @@ class Lightbox extends LitElement {
   render() {
     const imageSlides = () => {
       const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, label, preset, src }, index) => {
-        console.warn(iiif)
         const isCanvasPanel = iiif && !!iiif.canvas && !!iiif.manifest;
         const isImageService = iiif && !!iiif.info;
         const isImg = src && !!src.match(/.+\.(jpe?g|gif|png)$/);


### PR DESCRIPTION
Refactors the iiif `addGlobalData` method to assign IIIF properties to `figure.iiif` to prevent collisions with existing figures.yaml. Previously was rewriting the `src` attribute on image service figures, and `choices`. This change allows access to all the data all the time.