### PR TITLE
DEV-12164: Set publication full description to an empty string if it is not defined in  `publication.yml`

### DIFF
--- a/packages/11ty/_includes/components/head-tags/jsonld.js
+++ b/packages/11ty/_includes/components/head-tags/jsonld.js
@@ -39,7 +39,7 @@ module.exports = function(eleventyConfig) {
       })
 
     const isbn = publication.identifier.isbn
-    const publicationDescription = publication.description.full
+    const publicationDescription = publication.description.full || ''
 
     const Book = {
       type: 'Book',


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [ ] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [ ] I have made my changes in a new branch and not directly in the main branch

- [ ] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?



### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.


### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

