### PR TITLE
Filter table of contents items from table of contents list

### DIFF
--- a/packages/11ty/_includes/components/table-of-contents/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/list.js
@@ -16,10 +16,12 @@ module.exports = function(eleventyConfig) {
   const tableOfContentsItem = eleventyConfig.getFilter('tableOfContentsItem')
 
   return function(params) {
-    const { navigation, presentation } = params
+    const { currentPageUrl, navigation, presentation } = params
 
     const filterTableOfContentsPages = (pages) => {
-      return pages.filter(({ data }) => data && data.layout !== 'table-of-contents')
+      return pages.filter((page) => {
+        return page && page.url !== currentPageUrl
+      })
     }
 
     const renderList = (pages) => {

--- a/packages/11ty/_includes/components/table-of-contents/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/list.js
@@ -18,10 +18,15 @@ module.exports = function(eleventyConfig) {
   return function(params) {
     const { navigation, presentation } = params
 
+    const filterTableOfContentsPages = (pages) => {
+      return pages.filter(({ data }) => data && data.layout !== 'table-of-contents')
+    }
+
     const renderList = (pages) => {
+      const contentPages = filterTableOfContentsPages(pages);
       return html`
         <ul>
-          ${pages.map((page) => {
+          ${contentPages.map((page) => {
             if (presentation !== 'brief' && page.children && page.children.length) {
               const children = renderList(page.children)
               return `${tableOfContentsItem({ children, page, presentation })}`

--- a/packages/11ty/_includes/components/table-of-contents/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/list.js
@@ -18,17 +18,17 @@ module.exports = function(eleventyConfig) {
   return function(params) {
     const { currentPageUrl, navigation, presentation } = params
 
-    const filterTableOfContentsPages = (pages) => {
+    const filterCurrentPage = (pages) => {
       return pages.filter((page) => {
         return page && page.url !== currentPageUrl
       })
     }
 
     const renderList = (pages) => {
-      const contentPages = filterTableOfContentsPages(pages);
+      const otherPages = filterCurrentPage(pages);
       return html`
         <ul>
-          ${contentPages.map((page) => {
+          ${otherPages.map((page) => {
             if (presentation !== 'brief' && page.children && page.children.length) {
               const children = renderList(page.children)
               return `${tableOfContentsItem({ children, page, presentation })}`

--- a/packages/11ty/_layouts/table-of-contents.11ty.js
+++ b/packages/11ty/_layouts/table-of-contents.11ty.js
@@ -66,7 +66,7 @@ module.exports = class TableOfContents {
           ${contentElement}
           <div class="container ${containerClass}">
             <div class="quire-contents-list ${presentation}">
-              ${this.tableOfContentsList({ navigation, presentation })}
+              ${this.tableOfContentsList({ navigation, presentation, currentPageUrl: pagination.currentPage.url })}
               <div class="content">
                 {% bibliography %}
               </div>


### PR DESCRIPTION
This update hides the link to only the current TOC page in the table of contents. Previously it was hiding all TOC index pages.