### PR TITLE
Fix/duplicate weights

### DIFF
--- a/packages/11ty/content/about.md
+++ b/packages/11ty/content/about.md
@@ -1,12 +1,12 @@
 ---
 title: About
-weight: 203
+weight: 503
 layout: page
 ---
 
 This is a starter theme for [Quire](https://gettypubs.github.io/quire/), a multiformat digital publishing framework. Quire can be used to generate a web book, EPUB and MOBI e-books, and a PDF optimized for print; all from a single set of text files. 
 
-This starter theme allows for the quick customization of a few key styles to make you publication project your own. 
+This starter theme allows for the quick customization of a few key styles to make you publication project your own.
 
 - Modern and Classic type styles
 - Cover and splash page images

--- a/packages/11ty/content/abstract.md
+++ b/packages/11ty/content/abstract.md
@@ -2,6 +2,6 @@
 layout: table-of-contents
 search: false
 presentation: abstract
-title: Contents abstract
-weight: 2
+title: Contents Abstract
+weight: 4
 ---

--- a/packages/11ty/content/bibliography.md
+++ b/packages/11ty/content/bibliography.md
@@ -1,5 +1,5 @@
 ---
 title: Bibliography
 layout: bibliography
-weight: 200
+weight: 500
 ---

--- a/packages/11ty/content/brief.md
+++ b/packages/11ty/content/brief.md
@@ -3,5 +3,5 @@ layout: table-of-contents
 search: false
 title: Contents Brief
 presentation: brief
-weight: 2
+weight: 3
 ---

--- a/packages/11ty/content/catalogue/subsection-no-landing/1.md
+++ b/packages/11ty/content/catalogue/subsection-no-landing/1.md
@@ -1,6 +1,6 @@
 ---
 title: Page 1
 layout: essay
-weight: 300
+weight: 301
 ---
 Hiiii!

--- a/packages/11ty/content/catalogue/subsection-no-landing/index.md
+++ b/packages/11ty/content/catalogue/subsection-no-landing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Subsection Without Landing Page
 online: false
+weight: 300
 ---
 
 A section index page md file is REQUIRED but a landing page is not. Set online: false in the frontmatter to include this index in the TOC but have it be unlinked.

--- a/packages/11ty/content/catalogue/subsection/subsubsection/1.md
+++ b/packages/11ty/content/catalogue/subsection/subsubsection/1.md
@@ -1,7 +1,7 @@
 ---
 title: Subsubsection page
 layout: essay
-weight: 201
+weight: 251
 abstract: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non venenatis dui, at fringilla augue. Donec sit amet fringilla nunc, vel dignissim nisi. Fusce at libero quis lectus feugiat facilisis ac vel ante. Nulla facilisi. Aenean sodales nunc non volutpat feugiat. Quisque vestibulum vestibulum dolor a aliquam.
 ---
 Hiiii!

--- a/packages/11ty/content/catalogue/subsection/subsubsection/index.md
+++ b/packages/11ty/content/catalogue/subsection/subsubsection/index.md
@@ -1,7 +1,7 @@
 ---
 title: Subsubsection With Landing Page
 layout: table-of-contents
-weight: 200
+weight: 250
 ---
 
 Hello

--- a/packages/11ty/content/contributors.md
+++ b/packages/11ty/content/contributors.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Contributors
-weight: 201
+weight: 501
 ---
 
 {% contributors contributors=publicationContributors format='bio' %}

--- a/packages/11ty/content/grid.md
+++ b/packages/11ty/content/grid.md
@@ -3,5 +3,5 @@ layout: table-of-contents
 search: false
 title: Contents Grid
 presentation: grid
-weight: 2
+weight: 5
 ---

--- a/packages/11ty/content/iiif-demo.md
+++ b/packages/11ty/content/iiif-demo.md
@@ -1,6 +1,6 @@
 ---
 title: IIIF Demo
-weight: 203
+weight: 510
 layout: essay
 ---
 

--- a/packages/11ty/content/intro.md
+++ b/packages/11ty/content/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 subtitle: A Tale of Two Photographers
-weight: 3
+weight: 10
 layout: splash
 image: figures/lange-house.jpg
 ---

--- a/packages/11ty/content/lightbox-demo.md
+++ b/packages/11ty/content/lightbox-demo.md
@@ -1,6 +1,6 @@
 ---
 title: Lightbox Demo
-weight: 3
+weight: 520
 layout: essay
 ---
 

--- a/packages/11ty/content/section-without-landing-page/a.md
+++ b/packages/11ty/content/section-without-landing-page/a.md
@@ -1,5 +1,5 @@
 ---
 title: Page A
-weight: 301
+weight: 401
 layout: page
 ---

--- a/packages/11ty/content/section-without-landing-page/index.md
+++ b/packages/11ty/content/section-without-landing-page/index.md
@@ -1,5 +1,5 @@
 ---
 title: Section without Landing Page
 online: false
-weight: 300
+weight: 400
 ---


### PR DESCRIPTION
@thegetty/int-dev when I was doing some testing, I noticed that there were quire a few duplicated `weights` in the Markdown pages of the starter content, which made id difficult to test the contents list stuff in particular. I fixed them here.

There was also a test in Hugo that would look for duplicate weights and post a message to users in the Terminal warning them of this and listing the pages in question. It's otherwise an insidious error for the average user to track down. Is this kind of test something we could add into the 11ty version as well.