### PR TITLE
Fix: Contributor shortcode

### DIFF
--- a/packages/11ty/_includes/components/menu/header.js
+++ b/packages/11ty/_includes/components/menu/header.js
@@ -12,18 +12,19 @@ module.exports = function(eleventyConfig) {
   const contributors = eleventyConfig.getFilter('contributors')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const siteTitle = eleventyConfig.getFilter('siteTitle')
+  const { publication } = eleventyConfig.globalData
 
   return function(params) {
-    const { currentURL, publicationContributors } = params
+    const { currentURL } = params
     const isHomePage = currentURL === '/'
 
     const homePageLinkOpenTag = isHomePage ? `<a class="quire-menu__header__title-link" href="/">` : ''
     const homePageLinkCloseTag = isHomePage ? `</a>` : ''
 
-    const contributorElement = publicationContributors 
+    const contributorElement = publication.contributor 
       ? `
         <span class="visually-hidden">Contributors: </span>
-        ${contributors({ context: publicationContributors, type: 'primary' })}
+        ${contributors({ context: publication.contributor, format: 'string', type: 'primary' })}
       `
       : ''
 

--- a/packages/11ty/_includes/components/menu/header.js
+++ b/packages/11ty/_includes/components/menu/header.js
@@ -23,7 +23,7 @@ module.exports = function(eleventyConfig) {
     const contributorElement = publicationContributors 
       ? `
         <span class="visually-hidden">Contributors: </span>
-        ${contributors({ contributors: publicationContributors, type: 'primary' })}
+        ${contributors({ context: publicationContributors, type: 'primary' })}
       `
       : ''
 

--- a/packages/11ty/_includes/components/menu/index.js
+++ b/packages/11ty/_includes/components/menu/index.js
@@ -23,7 +23,7 @@ module.exports = function(eleventyConfig) {
   const { resource_link: resourceLinks } = publication
 
   return function(params) {
-    const { collections, pageData, publicationContributors } = params
+    const { collections, pageData } = params
 
     const footerLinks = resourceLinks.filter(({ type }) => type === 'footer-link')
 
@@ -33,7 +33,7 @@ module.exports = function(eleventyConfig) {
         role="banner"
         id="site-menu__inner"
       >
-        ${menuHeader({ currentURL: pageData.url, publicationContributors })}
+        ${menuHeader({ currentURL: pageData.url })}
         <nav id="nav" class="quire-menu__list menu-list" role="navigation" aria-label="full">
           <h3 class="visually-hidden">Table of Contents</h3>
           <ul>${menuList({ navigation: eleventyNavigation(collections.menu) })}</ul>

--- a/packages/11ty/_includes/components/page-header.js
+++ b/packages/11ty/_includes/components/page-header.js
@@ -47,7 +47,7 @@ module.exports = function(eleventyConfig) {
     const contributorsElement = pageContributors
       ? html`
           <div class="quire-page__header__contributor">
-            ${contributors({ contributors: pageContributors, format: contributor_byline })}
+            ${contributors({ context: pageContributors, format: contributor_byline })}
           </div>
         `
       : ''

--- a/packages/11ty/_includes/components/table-of-contents/grid-item.js
+++ b/packages/11ty/_includes/components/table-of-contents/grid-item.js
@@ -47,7 +47,7 @@ module.exports = function (eleventyConfig) {
     const isOnline = online !== false
 
     const pageContributorsElement = pageContributors
-      ? `<span class="contributor"> — ${contributors({ contributors: pageContributors, format: 'string' })}</span>`
+      ? `<span class="contributor"> — ${contributors({ context: pageContributors, format: 'string' })}</span>`
       : ''
     const pageTitleElement = oneLine`${pageTitle({ label, subtitle, title })}${pageContributorsElement}`
     const arrowIcon = `<span class="arrow remove-from-epub">&nbsp${icon({ type: 'arrow-forward', description: '' })}</span>`

--- a/packages/11ty/_includes/components/table-of-contents/list-item.js
+++ b/packages/11ty/_includes/components/table-of-contents/list-item.js
@@ -43,7 +43,7 @@ module.exports = function (eleventyConfig) {
     const isOnline = online !== false
 
     const pageContributorsElement = pageContributors
-      ? `<span class="contributor"> — ${contributors({ contributors: pageContributors, format: 'string' })}</span>`
+      ? `<span class="contributor"> — ${contributors({ context: pageContributors, format: 'string' })}</span>`
       : ''
 
     let pageTitleElement

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -27,7 +27,7 @@ module.exports = function(data) {
             aria-expanded="false"
             role="contentinfo"
           >
-            ${this.menu({ collections, pageData, publication })}
+            ${this.menu({ collections, pageData })}
           </div>
 
           <div class="quire__primary" id="{{ section }}">

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -26,7 +26,7 @@ layout: base.11ty.js
         <div class="contributor">
           {{ publication.contributor_as_it_appears }}
           <span class="visually-hidden">Contributors:&nbsp;</span>
-          <em>{% contributors context=publicationContributors, type='primary' %}</em>
+          <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
         </div>
       </div>
     </div>

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -26,7 +26,7 @@ layout: base.11ty.js
         <div class="contributor">
           {{ publication.contributor_as_it_appears }}
           <span class="visually-hidden">Contributors:&nbsp;</span>
-          <em>{% contributors contributors=publicationContributors, type='primary' %}</em>
+          <em>{% contributors context=publicationContributors, type='primary' %}</em>
         </div>
       </div>
     </div>

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -24,7 +24,6 @@ layout: base.11ty.js
         </h1>
         <p class="reading-line">{{ publication.reading_line | markdownify }}</p>
         <div class="contributor">
-          {{ publication.contributor_as_it_appears }}
           <span class="visually-hidden">Contributors:&nbsp;</span>
           <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
         </div>

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -77,7 +77,7 @@ Entry content, including entry image and tombstone data
               {% pageTitle label=label, title=title, subtitle=subtitle %}
             </h1>
             <div class="quire-page__header__contributor">
-              {% contributors contributors=pageContributors, format=contributor_byline %}
+              {% contributors context=pageContributors, format=contributor_byline %}
             </div>
           </div>
         </header>

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -15,7 +15,7 @@ description: splash page layout
       </h1>
       {% if pageContributors %}
         <div class="quire-page__header__contributor">
-          {% contributors contributors=pageContributors, format=contributor_byline %}
+          {% contributors context=pageContributors, format=contributor_byline %}
         </div>
       {% endif %}
     </div>

--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -1,6 +1,7 @@
 const capitalize = require('./capitalize')
 const figureIIIF = require('./figureIIIF')
 const fullname = require('./fullname')
+const initials = require('./initials')
 const getContributor = require('./getContributor')
 const getFigure = require('./getFigure')
 const getObject = require('./getObject')
@@ -17,6 +18,8 @@ module.exports = function(eleventyConfig, options) {
   eleventyConfig.addFilter('figureIIIF', (figure, options) => figureIIIF(eleventyConfig, figure, options))
 
   eleventyConfig.addFilter('fullname', (person, options) => fullname(person, options))
+
+  eleventyConfig.addFilter('initials', (person, options) => initials(person, options))
 
   eleventyConfig.addFilter('getContributor', (id) => getContributor(eleventyConfig, id))
 

--- a/packages/11ty/_plugins/filters/initials.js
+++ b/packages/11ty/_plugins/filters/initials.js
@@ -21,5 +21,5 @@ module.exports = (person, options) => {
   } else if (fullName) {
     nameParts.push(...fullName.split(' '))
   }
-  return nameParts.map(name => `${name.charAt(0).toUpperCase()}.`).join('')
+  return nameParts.map((name) => `${name.charAt(0).toUpperCase()}.`).join('')
 }

--- a/packages/11ty/_plugins/filters/initials.js
+++ b/packages/11ty/_plugins/filters/initials.js
@@ -1,0 +1,25 @@
+/**
+ * @param     {Object} person or array of people
+ * @property  {Object} first_name
+ * @property  {Object} full_name
+ * @property  {Object} last_name
+ * @param     {Object} options
+ *
+ * @return {String} First letter of first and last name
+ * @example "H.B."
+ */
+
+module.exports = (person, options) => {
+  const { 
+    first_name: firstName,
+    full_name: fullName,
+    last_name: lastName
+  } = person
+  const nameParts = [];
+  if (firstName && lastName) {
+    nameParts.push(firstName, lastName)
+  } else if (fullName) {
+    nameParts.push(...fullName.split(' '))
+  }
+  return nameParts.map(name => `${name.charAt(0).toUpperCase()}.`).join('')
+}

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -14,6 +14,7 @@ module.exports = function (eleventyConfig) {
   const contributorBio = eleventyConfig.getFilter('contributorBio');
   const fullname = eleventyConfig.getFilter('fullname');
   const getContributor = eleventyConfig.getFilter('getContributor');
+  const initials = eleventyConfig.getFilter('initials');
   const markdownify = eleventyConfig.getFilter('markdownify')
 
   const { contributorByline: defaultFormat } = eleventyConfig.globalData.config.params
@@ -57,6 +58,16 @@ module.exports = function (eleventyConfig) {
           </ul>
         `
         break;
+      case 'initials': {
+        const contributorInitials = contributorList.map((item) => initials(item))
+        const last = contributorInitials.pop()
+        const nameString =
+          contributorInitials.length >= 1
+            ? contributorInitials.join(', ') + ' and ' + last
+            : last;
+          contributorsElement = `<span class="quire-contributor">${nameString}</span>`
+        break;
+      }
       case 'name-title':
       case 'name-title-block':
         const separator = (format === 'name-title') ? ', ' : ''
@@ -79,7 +90,7 @@ module.exports = function (eleventyConfig) {
       case 'string':
         const last = contributorNames.pop();
         const namesString =
-          contributorNames.length > 1
+          contributorNames.length >= 1
             ? contributorNames.join(', ') + ' and ' + last
             : last;
         contributorsElement = `<span class='quire-contributor'>${namesString}</span>`;

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -16,6 +16,7 @@ module.exports = function (eleventyConfig) {
   const getContributor = eleventyConfig.getFilter('getContributor');
   const initials = eleventyConfig.getFilter('initials');
   const markdownify = eleventyConfig.getFilter('markdownify')
+  const slugify = eleventyConfig.getFilter('slugify')
 
   const { contributorByline: defaultFormat } = eleventyConfig.globalData.config.params
 
@@ -88,7 +89,9 @@ module.exports = function (eleventyConfig) {
                 `<span class="quire-contributor__affiliation">${ contributor.affiliation }</span>`
               )
             : null
-          return `<li class="quire-contributor">${contributorParts.join(separator)}</li>`;
+          return `
+            <li class="quire-contributor" id="${slugify(contributor.id)}">${contributorParts.join(separator)}</li>
+          `
         });
         contributorsElement = `
           <ul class="quire-contributors-list ${format} align-${align}">

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -22,6 +22,15 @@ module.exports = function (eleventyConfig) {
   return function (params) {
     const { align='left', context: contributors, type = 'all', format = defaultFormat } = params;
 
+    const formats = ['bio', 'initials', 'name', 'name-title', 'name-title-block', 'string']
+
+    if (!formats.includes(format)) {
+      console.error(
+        `Unrecognized contributors shortcode format "${format}". Supported format values are: ${formats.join(', ')}`
+      )
+      return ''
+    }
+
     if (!contributors) return ''
 
     if (typeof contributors === 'string') return markdownify(contributors)

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -60,13 +60,6 @@ module.exports = function (eleventyConfig) {
           </ul>
         `
         break;
-      case 'name':
-        contributorsElement = `
-          <ul>
-            ${contributorNames.map((name) => `<li>${name}</li>`).join('')}
-          </ul>
-        `
-        break;
       case 'initials': {
         const contributorInitials = contributorList.map(initials)
         const last = contributorInitials.pop()
@@ -77,21 +70,28 @@ module.exports = function (eleventyConfig) {
           contributorsElement = `<span class="quire-contributor">${nameString}</span>`
         break;
       }
+      case 'name':
       case 'name-title':
       case 'name-title-block':
         const separator = (format === 'name-title') ? ', ' : ''
         const listItems = contributorList.map((contributor) => {
-          const contributorParts = [fullname(contributor)]
-          contributor.title 
-            ? contributorParts.push(`<span class="quire-contributor__title">${ contributor.title }</span>`)
+          const contributorParts = [
+            `<span class="quire-contributor__name">${fullname(contributor)}</span>`
+          ]
+          contributor.title && format !== 'name'
+            ? contributorParts.push(
+                `<span class="quire-contributor__title">${ contributor.title }</span>`
+              )
             : null
-          contributor.affiliation 
-            ? contributorParts.push(`<span class="quire-contributor__affiliation">${ contributor.affiliation }</span>`)
+          contributor.affiliation && format !== 'name'
+            ? contributorParts.push(
+                `<span class="quire-contributor__affiliation">${ contributor.affiliation }</span>`
+              )
             : null
-          return `<li class='quire-contributor'>${contributorParts.join(separator)}</li>`;
+          return `<li class="quire-contributor">${contributorParts.join(separator)}</li>`;
         });
         contributorsElement = `
-          <ul class='quire-contributors-list ${format} align-${align}'>
+          <ul class="quire-contributors-list ${format} align-${align}">
             ${listItems.join('')}
           </ul>
         `

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -3,7 +3,7 @@ const { html } = require('common-tags');
  * Contributor shortcode
  * Renders a list of contributors
  * 
- * @param  {Array|String}  contributors Array of contributor objects OR string override
+ * @param  {Array|String} context Array of contributor objects OR string override
  * @param  {String} align How to align the text (name-title-block and bio only) Values: 'left' (default), 'center', 'right'
  * @param  {String} type The contributor type to render. Values: 'all' (default), 'primary', 'secondary'
  * @param  {String} format How to display the contributors. Values: 'string', 'bio', 'name', 'name-title', 'name-title-block'. Default set in config.params.contributorByline
@@ -20,7 +20,7 @@ module.exports = function (eleventyConfig) {
   const { contributorByline: defaultFormat } = eleventyConfig.globalData.config.params
 
   return function (params) {
-    const { align='left', contributors, type = 'all', format = defaultFormat } = params;
+    const { align='left', context: contributors, type = 'all', format = defaultFormat } = params;
 
     if (!contributors) return ''
 

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -59,7 +59,7 @@ module.exports = function (eleventyConfig) {
         `
         break;
       case 'initials': {
-        const contributorInitials = contributorList.map((item) => initials(item))
+        const contributorInitials = contributorList.map(initials)
         const last = contributorInitials.pop()
         const nameString =
           contributorInitials.length >= 1

--- a/packages/11ty/content/contributors.md
+++ b/packages/11ty/content/contributors.md
@@ -4,4 +4,4 @@ title: Contributors
 weight: 501
 ---
 
-{% contributors contributors=publicationContributors format='bio' %}
+{% contributors context=publicationContributors format='bio' %}


### PR DESCRIPTION
Changes:
- Add `initials` format [DEV-12202](https://jira.getty.edu/browse/DEV-12202)
- Rename `contributors` argument `context`  [DEV-12203](https://jira.getty.edu/browse/DEV-12203)
- Add publication contributors with `string` format to cover layout and menu [DEV-12196](https://jira.getty.edu/browse/DEV-12196)
- Remove duplicate contributor override [DEV-12197](https://jira.getty.edu/browse/DEV-12197)
- Log error if unsupported format passed to contributors shortcode [DEV-12204](https://jira.getty.edu/browse/DEV-12204)
- Add id and fix classes on contributor `name` format [DEV-12207](https://jira.getty.edu/browse/DEV-12207)