### PR TITLE
Clean Up globalData

### DIFF
--- a/packages/11ty/_includes/components/copyright/index.js
+++ b/packages/11ty/_includes/components/copyright/index.js
@@ -9,10 +9,9 @@ const path = require('path')
 module.exports = function(eleventyConfig) {
   const copyrightLicensing = eleventyConfig.getFilter('copyrightLicensing')
   const markdownify = eleventyConfig.getFilter('markdownify')
+  const { config, publication } = eleventyConfig.globalData
 
   return function (params) {
-    const { config, publication } = eleventyConfig.globalData
-
     const publisherImages = publication.publisher.filter((item) => item.logo).map(({ logo }) => {
       return `<img src="${ path.join(config.params.imageDir, logo) }" class="quire-copyright__icon__logo" alt="logo" />`
     }).join('')

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -11,9 +11,7 @@ module.exports = function(eleventyConfig) {
   const twitterCard = eleventyConfig.getFilter('twitterCard')
   const webComponents = eleventyConfig.getFilter('webComponents')
 
-  const { config, publication } = eleventyConfig.globalData
-
-  const { imageDir } = config.params
+  const { publication } = eleventyConfig.globalData
 
   /**
    * @param  {Object} params The Whole Dang Data Object, from base.11ty.js

--- a/packages/11ty/_includes/components/icon.js
+++ b/packages/11ty/_includes/components/icon.js
@@ -13,7 +13,7 @@ const path = require('path')
  * {% icon type="link", description="Open in new window" %}
  */
 module.exports = function(eleventyConfig) {
-  const imageDir = eleventyConfig.globalData.config.params.imageDir
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function (params) {
     const { description, type } = params

--- a/packages/11ty/_includes/components/menu/index.js
+++ b/packages/11ty/_includes/components/menu/index.js
@@ -3,7 +3,7 @@ const { html } = require('common-tags')
 /**
  * Menu
  * 
- * This controlls the global table of contents for the publication, which is
+ * This controls the global table of contents for the publication, which is
  * available on all pages. For users with Javascript enabled, this menu is hidden
  * by default. Users with JS disabled will alwasy see the menu in its expanded state.
  *
@@ -19,8 +19,7 @@ module.exports = function(eleventyConfig) {
   const menuList = eleventyConfig.getFilter('menuList')
   const menuResources = eleventyConfig.getFilter('menuResources')
 
-  const { config, publication } = eleventyConfig.globalData
-  const { resource_link: resourceLinks } = publication
+  const { resource_link: resourceLinks } = eleventyConfig.globalData.publication
 
   return function(params) {
     const { collections, pageData } = params
@@ -63,7 +62,7 @@ module.exports = function(eleventyConfig) {
         </div>
 
         <footer class="quire-menu__footer" role="contentinfo">
-          ${copyright({ config })}
+          ${copyright()}
           ${linkList({ links: footerLinks, classes: ["menu-list"]}) }
         </footer>
       </div>

--- a/packages/11ty/_includes/components/menu/list.js
+++ b/packages/11ty/_includes/components/menu/list.js
@@ -19,7 +19,7 @@ module.exports = function(eleventyConfig) {
           return `<li class="page-item">${menuItem(item)}</li>`
         } else {
           listItem += `<li class="section-item">${menuItem(item)}`
-          if (config.params.tocType === 'full') {
+          if (config.params.menuType !== 'brief') {
             listItem += `<ul>${renderList(item.children)}</ul>`
           }
           listItem += '</li>'

--- a/packages/11ty/_includes/components/menu/resources.js
+++ b/packages/11ty/_includes/components/menu/resources.js
@@ -7,11 +7,9 @@ const { html } = require('common-tags')
  * @param      {Object}  params
  */
 module.exports = function(eleventyConfig) {
-  const { publication } = eleventyConfig.globalData
-  const { resource_link: resourceLinks } = publication
+  const { resource_link: resourceLinks } = eleventyConfig.globalData.publication
 
   return function() {
-
     if (!Array.isArray(resourceLinks)) return ''
 
     const linkList = eleventyConfig.getFilter('linkList')

--- a/packages/11ty/_includes/components/navigation.js
+++ b/packages/11ty/_includes/components/navigation.js
@@ -15,11 +15,10 @@ const { html } = require('common-tags');
 module.exports = function(eleventyConfig) {
   const eleventyNavigation = eleventyConfig.getFilter('eleventyNavigation')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
-  const { config } = eleventyConfig.globalData
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function (params) {
-    const { collections, pages, pagination, title } = params
-    const { imageDir, pageLabelDivider } = config.params
+    const { pages, pagination, title } = params
     const { currentPage, currentPageIndex, nextPage, previousPage } = pagination
     const home = '/'
     const isHomePage = currentPage.url === home

--- a/packages/11ty/_includes/components/table-of-contents/grid-item.js
+++ b/packages/11ty/_includes/components/table-of-contents/grid-item.js
@@ -40,8 +40,7 @@ module.exports = function (eleventyConfig) {
       short_title,
       subtitle,
       summary,
-      title,
-      weight
+      title
     } = page.data
 
     const isOnline = online !== false

--- a/packages/11ty/_includes/components/table-of-contents/list-item.js
+++ b/packages/11ty/_includes/components/table-of-contents/list-item.js
@@ -36,8 +36,7 @@ module.exports = function (eleventyConfig) {
       short_title,
       subtitle,
       summary,
-      title,
-      weight
+      title
     } = page.data
 
     const isOnline = online !== false

--- a/packages/11ty/_includes/debug-content.liquid
+++ b/packages/11ty/_includes/debug-content.liquid
@@ -1,4 +1,4 @@
-{% assign pageList = site.pages | where: page.weight >= 0 %}
+{% assign pageList = site.pages | where: page.order >= 0 %}
 <ul>
   <li><strong>[ kind: type ] Title URL</strong></li>
   {% for page in pageList %}

--- a/packages/11ty/_layouts/README.md
+++ b/packages/11ty/_layouts/README.md
@@ -14,7 +14,7 @@ todo
 ---
 title: Works Cited
 layout: bibliography
-weight: 200
+order: 200
 ---
 ```
 

--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -5,10 +5,9 @@ const { html } = require('common-tags')
  * @param      {Object}  eleventyConfig
  */
 module.exports = function (eleventyConfig, { page }) {
-  const biblioHeading = eleventyConfig.globalData.config.params.biblioHeading
-  const displayBiblioShort = eleventyConfig.globalData.config.params.displayBiblioShort
   const markdownify = eleventyConfig.getFilter('markdownify')
   const slugify = eleventyConfig.getFilter('slugify')
+  const { biblioHeading, displayBiblioShort } = eleventyConfig.globalData.config.params
 
   /**
    * @property  {Array}  citations  computed data citations array

--- a/packages/11ty/_plugins/shortcodes/title.js
+++ b/packages/11ty/_plugins/shortcodes/title.js
@@ -6,19 +6,19 @@ const { oneLine } = require('common-tags')
  */
 module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
-  const { publication } = eleventyConfig.globalData
+  const { subtitle, title } = eleventyConfig.globalData.publication
 
   return function(params) {
-    const seperator = publication.title.slice(-1).match(/[a-zA-Z]/)
+    const separator = title.slice(-1).match(/[a-zA-Z]/)
       ? `<span class="visually-hidden">:</span>`
       : ''
 
-    const subtitle = publication.subtitle
-      ? `<span class="subtitle">${markdownify(publication.subtitle)}</span>`
+    const subtitleElement = subtitle
+      ? `<span class="subtitle">${markdownify(subtitle)}</span>`
       : ''
 
-    const title = `<span class="title">${markdownify(publication.title)}</span>`
+    const titleElement = `<span class="title">${markdownify(title)}</span>`
 
-    return oneLine`${title}${seperator}&#32;${subtitle}`
+    return oneLine`${titleElement}${separator}&#32;${subtitleElement}`
   }
 }

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -20,11 +20,11 @@ module.exports = {
         layout: data.layout,
         object: data.object,
         online: data.online,
+        order: data.order,
         short_title: data.short_title,
         subtitle: data.subtitle,
         summary: data.summary,
-        title: data.title,
-        weight: data.weight
+        title: data.title
       }
     },
     key: (data) => {
@@ -32,7 +32,7 @@ module.exports = {
       const key = segments.slice(1, segments.length - 1).join('/')
       return data.key || key
     },
-    order: (data) => data.order || data.weight,
+    order: (data) => data.order,
     parent: (data) => {
       const segments = data.page.url.split('/')
       const parent = segments.slice(1, segments.length - 2).join('/')
@@ -98,7 +98,7 @@ module.exports = {
           type !== 'data'
         )
       })
-      .sort((a, b) => parseInt(a.data.weight) - parseInt(b.data.weight))
+      .sort((a, b) => parseInt(a.data.order) - parseInt(b.data.order))
   },
   pagination: ({ page, pages }) => {
     if (!page || !pages) return {}
@@ -115,8 +115,8 @@ module.exports = {
    */
   publicationContributors: ({ config, publication, pages }) => {
     const { contributor, contributor_as_it_appears } = publication
-    return contributor_as_it_appears 
-      ? contributor_as_it_appears 
+    return contributor_as_it_appears
+      ? contributor_as_it_appears
       : contributor
       /**
        * Filtering because there are duplicate contributors here

--- a/packages/11ty/content/about.md
+++ b/packages/11ty/content/about.md
@@ -1,7 +1,7 @@
 ---
 title: About
-weight: 503
 layout: page
+order: 503
 ---
 
 This is a starter theme for [Quire](https://gettypubs.github.io/quire/), a multiformat digital publishing framework. Quire can be used to generate a web book, EPUB and MOBI e-books, and a PDF optimized for print; all from a single set of text files. 

--- a/packages/11ty/content/abstract.md
+++ b/packages/11ty/content/abstract.md
@@ -3,5 +3,5 @@ layout: table-of-contents
 search: false
 presentation: abstract
 title: Contents Abstract
-weight: 4
+order: 4
 ---

--- a/packages/11ty/content/bibliography.md
+++ b/packages/11ty/content/bibliography.md
@@ -1,5 +1,5 @@
 ---
 title: Bibliography
 layout: bibliography
-weight: 500
+order: 500
 ---

--- a/packages/11ty/content/brief.md
+++ b/packages/11ty/content/brief.md
@@ -3,5 +3,5 @@ layout: table-of-contents
 search: false
 title: Contents Brief
 presentation: brief
-weight: 3
+order: 3
 ---

--- a/packages/11ty/content/catalogue/1.md
+++ b/packages/11ty/content/catalogue/1.md
@@ -3,7 +3,7 @@ label: Cat. 1
 title: Human Erosion in California / Migrant Mother
 short_title: Migrant Mother
 layout: entry
-weight: 101
+order: 101
 class: side-by-side
 object:
   - id: 1

--- a/packages/11ty/content/catalogue/2.md
+++ b/packages/11ty/content/catalogue/2.md
@@ -3,7 +3,7 @@ label: Cat. 2
 title: Pea Pickers, Nipomo, California
 short_title: Pea Pickers
 layout: entry
-weight: 102
+order: 102
 object:
   - id: 2
 ---

--- a/packages/11ty/content/catalogue/3.md
+++ b/packages/11ty/content/catalogue/3.md
@@ -2,7 +2,7 @@
 label: Cat. 3
 title: Bud Fields with His Wife Ivy, and His Daughter Ellen, Hale County, Alabama
 short_title: The Fields Family
-weight: 103
+order: 103
 object:
   - id: 3
 layout: entry

--- a/packages/11ty/content/catalogue/4.md
+++ b/packages/11ty/content/catalogue/4.md
@@ -2,7 +2,7 @@
 label: Cat. 4
 title: Burrough’s Family, Hale County, Alabama
 short_title: Burrough’s Family
-weight: 104
+order: 104
 object:
   - id: 4
 layout: entry

--- a/packages/11ty/content/catalogue/index.md
+++ b/packages/11ty/content/catalogue/index.md
@@ -3,5 +3,5 @@ epub: false
 title: Catalogue
 layout: table-of-contents
 presentation: grid
-weight: 100
+order: 100
 ---

--- a/packages/11ty/content/catalogue/subsection-no-landing/1.md
+++ b/packages/11ty/content/catalogue/subsection-no-landing/1.md
@@ -1,6 +1,6 @@
 ---
 title: Page 1
 layout: essay
-weight: 301
+order: 301
 ---
 Hiiii!

--- a/packages/11ty/content/catalogue/subsection-no-landing/index.md
+++ b/packages/11ty/content/catalogue/subsection-no-landing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Subsection Without Landing Page
 online: false
-weight: 300
+order: 300
 ---
 
 A section index page md file is REQUIRED but a landing page is not. Set online: false in the frontmatter to include this index in the TOC but have it be unlinked.

--- a/packages/11ty/content/catalogue/subsection/1.md
+++ b/packages/11ty/content/catalogue/subsection/1.md
@@ -1,7 +1,7 @@
 ---
 title: Page A
 layout: essay
-weight: 201
+order: 201
 abstract: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non venenatis dui, at fringilla augue. Donec sit amet fringilla nunc, vel dignissim nisi. Fusce at libero quis lectus feugiat facilisis ac vel ante. Nulla facilisi. Aenean sodales nunc non volutpat feugiat. Quisque vestibulum vestibulum dolor a aliquam.
 ---
 Hiiii!

--- a/packages/11ty/content/catalogue/subsection/2.md
+++ b/packages/11ty/content/catalogue/subsection/2.md
@@ -1,6 +1,6 @@
 ---
 title: Page B
 layout: essay
-weight: 202
+order: 202
 abstract: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non venenatis dui, at fringilla augue. Donec sit amet fringilla nunc, vel dignissim nisi. Fusce at libero quis lectus feugiat facilisis ac vel ante. Nulla facilisi. Aenean sodales nunc non volutpat feugiat. Quisque vestibulum vestibulum dolor a aliquam.
 ---

--- a/packages/11ty/content/catalogue/subsection/index.md
+++ b/packages/11ty/content/catalogue/subsection/index.md
@@ -1,7 +1,7 @@
 ---
 title: Subsection With Landing Page
 layout: table-of-contents
-weight: 200
+order: 200
 ---
 
 Hello

--- a/packages/11ty/content/catalogue/subsection/subsubsection/1.md
+++ b/packages/11ty/content/catalogue/subsection/subsubsection/1.md
@@ -1,7 +1,7 @@
 ---
 title: Subsubsection page
 layout: essay
-weight: 251
+order: 251
 abstract: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non venenatis dui, at fringilla augue. Donec sit amet fringilla nunc, vel dignissim nisi. Fusce at libero quis lectus feugiat facilisis ac vel ante. Nulla facilisi. Aenean sodales nunc non volutpat feugiat. Quisque vestibulum vestibulum dolor a aliquam.
 ---
 Hiiii!

--- a/packages/11ty/content/catalogue/subsection/subsubsection/index.md
+++ b/packages/11ty/content/catalogue/subsection/subsubsection/index.md
@@ -1,7 +1,7 @@
 ---
 title: Subsubsection With Landing Page
 layout: table-of-contents
-weight: 250
+order: 250
 ---
 
 Hello

--- a/packages/11ty/content/contents.md
+++ b/packages/11ty/content/contents.md
@@ -3,5 +3,5 @@ layout: table-of-contents
 search: false
 title: Contents
 presentation: list
-weight: 2
+order: 2
 ---

--- a/packages/11ty/content/contributors.md
+++ b/packages/11ty/content/contributors.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Contributors
-weight: 501
+order: 501
 ---
 
 {% contributors context=publicationContributors format='bio' %}

--- a/packages/11ty/content/cover.md
+++ b/packages/11ty/content/cover.md
@@ -1,6 +1,6 @@
 ---
 title: Cover
-weight: 1
+order: 1
 layout: cover
 menu: false
 permalink: index.html

--- a/packages/11ty/content/essay.md
+++ b/packages/11ty/content/essay.md
@@ -2,7 +2,7 @@
 label: I
 title: American Photographs
 subtitle: Evans in Middletown
-weight: 30
+order: 30
 layout: essay
 contributor:
   - id: jkeller

--- a/packages/11ty/content/grid.md
+++ b/packages/11ty/content/grid.md
@@ -3,5 +3,5 @@ layout: table-of-contents
 search: false
 title: Contents Grid
 presentation: grid
-weight: 5
+order: 5
 ---

--- a/packages/11ty/content/iiif-demo.md
+++ b/packages/11ty/content/iiif-demo.md
@@ -1,6 +1,6 @@
 ---
 title: IIIF Demo
-weight: 510
+order: 510
 layout: essay
 ---
 

--- a/packages/11ty/content/intro.md
+++ b/packages/11ty/content/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 subtitle: A Tale of Two Photographers
-weight: 10
+order: 10
 layout: splash
 image: figures/lange-house.jpg
 ---

--- a/packages/11ty/content/lightbox-demo.md
+++ b/packages/11ty/content/lightbox-demo.md
@@ -1,6 +1,6 @@
 ---
 title: Lightbox Demo
-weight: 520
+order: 520
 layout: essay
 ---
 

--- a/packages/11ty/content/section-without-landing-page/a.md
+++ b/packages/11ty/content/section-without-landing-page/a.md
@@ -1,5 +1,5 @@
 ---
 title: Page A
-weight: 401
+order: 401
 layout: page
 ---

--- a/packages/11ty/content/section-without-landing-page/index.md
+++ b/packages/11ty/content/section-without-landing-page/index.md
@@ -1,5 +1,5 @@
 ---
 title: Section without Landing Page
 online: false
-weight: 400
+order: 400
 ---


### PR DESCRIPTION
Cleans up global data destructuring to be more consistent and concise across shortcodes and comopnents
Remove `weight` fallback frontmatter property in favor of `order`