### PR TITLE
Implement filter to convert strings to title case

### DIFF
--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -1,20 +1,27 @@
-const capitalize = require('./capitalize')
+// Quire data filters
 const figureIIIF = require('./figureIIIF')
 const fullname = require('./fullname')
-const initials = require('./initials')
 const getContributor = require('./getContributor')
 const getFigure = require('./getFigure')
 const getObject = require('./getObject')
 const hasCanvasPanelProps = require('./hasCanvasPanelProps')
+const initials = require('./initials')
 const isImageService = require('./isImageService')
+
+// string filters
+const capitalize = require('./capitalize')
 const json = require('./json')
 const removeHTML = require('./removeHTML')
+const titleCase = require('./titleCase')
 
+/**
+ * Add universal filters for use in templates
+ * @see https://www.11ty.dev/docs/filters/#universal-filters
+ */
 module.exports = function(eleventyConfig, options) {
-  // @see https://www.11ty.dev/docs/filters/#universal-filters
-
-  eleventyConfig.addFilter('capitalize', (string) => capitalize(string))
-
+  /**
+   * Quire data filters
+   */
   eleventyConfig.addFilter('figureIIIF', (figure, options) => figureIIIF(eleventyConfig, figure, options))
 
   eleventyConfig.addFilter('fullname', (person, options) => fullname(person, options))
@@ -32,6 +39,13 @@ module.exports = function(eleventyConfig, options) {
   eleventyConfig.addFilter('isImageService', (figure, options) => isImageService(figure, options))
 
   eleventyConfig.addFilter('keywords', () => keywords(eleventyConfig))
+
+  /**
+   * String manipulation filters
+   */
+  eleventyConfig.addFilter('capitalize', (string) => capitalize(string))
+
+  eleventyConfig.addFilter('titleCase', (string) => titleCase(string))
 
   eleventyConfig.addFilter('json', (string) => json(string))
 

--- a/packages/11ty/_plugins/filters/titleCase.js
+++ b/packages/11ty/_plugins/filters/titleCase.js
@@ -1,0 +1,12 @@
+/**
+ * Convert a string to Title Case formatting
+ *
+ * @param      {String}  A camel case or snake case input string
+ * @return     {String}  The input string converted to title case
+ */
+module.exports = function(string) {
+  return string
+    .split(/(?=[A-Z])|[_\s]/)
+    .map((word) => word.replace(word[0], word[0].toUpperCase()))
+    .join(' ')
+}

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -8,7 +8,7 @@ module.exports = function(eleventyConfig) {
   const { config, objects } = eleventyConfig.globalData
 
   return function (pageObjects) {
-    const capitalize = eleventyConfig.getFilter('capitalize')
+    const titleCase = eleventyConfig.getFilter('titleCase')
     const icon = eleventyConfig.getFilter('icon')
     const markdownify = eleventyConfig.getFilter('markdownify')
     const properties = objects.object_display_order
@@ -18,7 +18,7 @@ module.exports = function(eleventyConfig) {
 
       return html`
         <tr>
-          <td>${capitalize(property)}</td>
+          <td>${titleCase(property)}</td>
           <td>${markdownify(object[property].toString())}</td>
         </tr>
       `


### PR DESCRIPTION
Implements a `titleCase` filter that is used to convert camel case and snake case strings from `objects.yaml` data to title case for display.
