### PR TITLE
Refactor markdownify to render block and inline

### DIFF
--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -54,9 +54,12 @@ module.exports = function(eleventyConfig, options) {
   eleventyConfig.setLibrary('md', markdownLibrary)
 
   /**
-   * Add a universal template filter to render markdown inline
+   * Add a universal template filter to render markdown strings as HTML
+   * @see https://github.com/markdown-it/markdown-it#simple
    */
-  eleventyConfig.addFilter('markdownify', (content) => {
-    return content ? markdownLibrary.renderInline(content) : ''
+  eleventyConfig.addFilter('markdownify', (content = '') => {
+    return !content.match(/\n/)
+      ? markdownLibrary.renderInline(content)
+      : markdownLibrary.render(content)
   })
 }


### PR DESCRIPTION
Refactors the universal template filter `markdownify` to conditionally use the markdown-it `renderInline` method when the markdown string contains new-line characters. This allows yaml values to contain markdown lists as multiline strings, for example an entry in the `objects.yaml` `object_list` with the following key will be rendered as an HTML unordered list by the `tombstone` component.

```yaml
    component: |
      - 82.DG.12.1.a (Liner)
      - 82.DG.12.1.b (Tureen)
      - 82.DG.12.1.c (Stand)
      - 82.DG.12.2.a (Liner)
      - 82.DG.12.2.b (Tureen)
      - 82.DG.12.2.c (Stand)
```