### PR TITLE
Prevent build from failing when `publication.reading_line` is null

### DIFF
--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -57,7 +57,9 @@ module.exports = function(eleventyConfig, options) {
    * Add a universal template filter to render markdown strings as HTML
    * @see https://github.com/markdown-it/markdown-it#simple
    */
-  eleventyConfig.addFilter('markdownify', (content = '') => {
+  eleventyConfig.addFilter('markdownify', (content) => {
+    if (!content) return ''
+
     return !content.match(/\n/)
       ? markdownLibrary.renderInline(content)
       : markdownLibrary.render(content)


### PR DESCRIPTION
Not sure if anyone else was getting this error on the most recent `feature/11ty`, but I was and this fix seems to fix it, I thought assigning a default value to function args worked if the arg was `null` as well as `undefined`?

```
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] 1. Having trouble writing to "_site/index.html" from "./content/cover.md" (via EleventyTemplateError)
[11ty] 2. Cannot read properties of null (reading 'match'), file:./_layouts/cover.liquid, line:21, col:33 (via RenderError)
[11ty] 3. Cannot read properties of null (reading 'match') (via TypeError)
[11ty] 
[11ty] Original error stack trace: TypeError: Cannot read properties of null (reading 'match')
[11ty]     at Object.<anonymous> (/Users/apollack/Code/getty/quire/packages/11ty/_plugins/markdown/index.js:61:21)
```