### PR TITLE
Render `side-by-side` version of catalogue entry page if `presentation: side-by-side` is included in front matter of content using `layout: entry`

### DIFF
--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -3,7 +3,7 @@ layout: base.11ty.js
 description: Entry layout. This template is intended for use in catalogue-style pages where a single image or object needs to be featured prominently.
 ---
 
-{% assign entryPageSideBySideLayout =  config.params.entryPageSideBySideLayout %}
+{% assign entryPageSideBySideLayout = config.params.entryPageSideBySideLayout %}
 {% assign epub = config.params.epub %}
 {% assign imageDir = config.params.imageDir %}
 {% assign pdf = config.params.pdf %}
@@ -14,8 +14,8 @@ Entry content, including entry image and tombstone data
 {% endcomment %}
 
 <article class="quire-entry" id="main" role="main">
-  <div {% if entryPageSideBySideLayout == true and pdf != true and epub != true %} class="side-by-side" {% endif %} data="{{ zoom }}">
-    
+  <div {% if entryPageSideBySideLayout == true or presentation == 'side-by-side' and pdf != true and epub != true %} class="side-by-side" {% endif %} data="{{ zoom }}">
+
     {% if epub == true %}
     <header class="quire-entry__header">
       <div class="container">

--- a/packages/11ty/content/catalogue/1.md
+++ b/packages/11ty/content/catalogue/1.md
@@ -4,7 +4,7 @@ title: Human Erosion in California / Migrant Mother
 short_title: Migrant Mother
 layout: entry
 order: 101
-class: side-by-side
+presentation: side-by-side
 object:
   - id: 1
 ---


### PR DESCRIPTION
Quick solution for allowing certain catalogue entries to render `side-by-side`, still evaluating refactoring opportunities