### PR TITLE
DEV-12329: Ensure `layout: entry` pages without `object` or `object.id` will still render

### DIFF
--- a/packages/11ty/_plugins/shortcodes/index.js
+++ b/packages/11ty/_plugins/shortcodes/index.js
@@ -46,6 +46,6 @@ module.exports = function(eleventyConfig, options) {
   })
 
   eleventyConfig.addShortcode('tombstone', function(...args) {
-    return tombstone(eleventyConfig)(...args)
+    return tombstone(eleventyConfig, { page: this.page })(...args)
   })
 }

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -7,7 +7,7 @@ const path = require('path')
 module.exports = function(eleventyConfig) {
   const { config, objects } = eleventyConfig.globalData
 
-  return function (pageObjects) {
+  return function (pageObjects = []) {
     const titleCase = eleventyConfig.getFilter('titleCase')
     const icon = eleventyConfig.getFilter('icon')
     const markdownify = eleventyConfig.getFilter('markdownify')

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -43,7 +43,7 @@ module.exports = function(eleventyConfig) {
         </div>
       </section>
     `
-
+    if (!pageObjects.length) console.warn('Warning: one or more entry pages does not have any object ids');
     return pageObjects.map((object) => table(object)).join('')
   }
 }

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -4,7 +4,7 @@ const path = require('path')
 /**
  * A shortcode for tombstone display of object data on an entry page
  */
-module.exports = function(eleventyConfig) {
+module.exports = function(eleventyConfig, { page }) {
   const { config, objects } = eleventyConfig.globalData
 
   return function (pageObjects = []) {
@@ -43,7 +43,7 @@ module.exports = function(eleventyConfig) {
         </div>
       </section>
     `
-    if (!pageObjects.length) console.warn('Warning: one or more entry pages does not have any object ids');
+    if (!pageObjects.length) console.warn(`Warning: ${page.inputPath} does not have any object ids`);
     return pageObjects.map((object) => table(object)).join('')
   }
 }


### PR DESCRIPTION
- Ensure `layout: entry` pages without `object` or `object.id` will still render
- Add warning if an entry page is missing an object id