### PR TITLE
DEV-12335: Ensure publication still builds with missing or erroneous data in `object` front matter and figure data in `objects.yaml`

### DIFF
--- a/packages/11ty/_includes/components/lightbox/index.js
+++ b/packages/11ty/_includes/components/lightbox/index.js
@@ -17,10 +17,15 @@ module.exports = function (eleventyConfig, { page }) {
   return function (figures=page.figures) {
     if (!figures) return;
     const figuresWithMarkdownifiedCaptions =
-      figures.map((figure) => ({
-        ...figure,
-        caption: figure.caption ? markdownify(figure.caption) : null
-      }));
+      figures.reduce((validFigures, figure) => {
+        if (figure) {
+          validFigures.push({
+            ...figure,
+            caption: figure.caption ? markdownify(figure.caption) : null
+          })
+        }
+        return validFigures
+      }, []);
     const serializedFigures = stringifyData(figuresWithMarkdownifiedCaptions);
     return html`
       <q-lightbox figures="${serializedFigures}" image-dir=${imageDir}></q-lightbox>

--- a/packages/11ty/_includes/components/table-of-contents/grid-item.js
+++ b/packages/11ty/_includes/components/table-of-contents/grid-item.js
@@ -76,7 +76,7 @@ module.exports = function (eleventyConfig) {
       case !!pageObject:
         const firstObjectId = pageObject[0].id
         const object = getObject(firstObjectId)
-        const firstObjectFigure = object ? getFigure(object.figure[0].id) : null
+        const firstObjectFigure = object && object.figure ? getFigure(object.figure[0].id) : null
         imageElement = firstObjectFigure ? tableOfContentsImage({ imageDir, src: firstObjectFigure.src }) : ''
         break
       default:

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -43,7 +43,6 @@ module.exports = function(eleventyConfig, { page }) {
         </div>
       </section>
     `
-    if (!pageObjects.length) console.warn(`Warning: ${page.inputPath} does not have any object ids`);
     return pageObjects.map((object) => table(object)).join('')
   }
 }

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -72,21 +72,31 @@ module.exports = {
   pageObjects: ({ figures, object, objects }) => {
     if (!object || !object.length) return
     return object
-      .map((item) => {
+      .reduce((validObjects, item) => {
+        if (!item.id) {
+          console.warn('Error: eleventyComputed: pageObjects: object item does not have an id')
+        }
+
         const objectData = objects.object_list.find(({ id }) => id === item.id)
         if (!objectData) {
           console.warn(`Error: eleventyComputed: pageObjects: no object found with id ${item.id}`)
-          return
         }
-        objectData.figures = objectData.figure.map((figure) => {
-          if (figure.id) {
-            return figures.figure_list.find((item) => item.id === figure.id)
-          } else {
-            return figure
-          }
-        })
-        return objectData
-      })
+
+        if (!objectData.figure) {
+          console.warn(`Error: eleventyComputed: pageObjects: object id ${objectData.id} has no figure data`)
+        } else {
+          objectData.figures = objectData.figure.map((figure) => {
+            if (figure.id) {
+              return figures.figure_list.find((item) => item.id === figure.id)
+            } else {
+              return figure
+            }
+          })
+          validObjects.push(objectData)
+        }
+
+        return validObjects
+      }, [])
   },
   pages: ({ collections, config }) => {
     if (!collections.current) return [];

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -73,13 +73,10 @@ module.exports = {
     if (!object || !object.length) return
     return object
       .reduce((validObjects, item) => {
-        if (!item.id) {
-          console.warn('Error: eleventyComputed: pageObjects: object item does not have an id')
-        }
-
         const objectData = objects.object_list.find(({ id }) => id === item.id)
         if (!objectData) {
           console.warn(`Error: eleventyComputed: pageObjects: no object found with id ${item.id}`)
+          return validObjects
         }
 
         if (!objectData.figure) {


### PR DESCRIPTION
- Provide `eleventyComputed` with better error messages for `pageObjects`, render catalogue entry pages if objects are missing / have no figures
- Remove unreachable error condition
- Ensure entry pages still build when object figure data is missing or garbled

This PR adds a few extra error messages for when object/figure data is missing or points nowhere to aid in debugging