### PR TITLE
Use citation `id` as the short label in `bibliography` shortcode to match current Hugo Quire

### DIFF
--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -22,7 +22,7 @@ module.exports = function (eleventyConfig, { page }) {
     const definitionList = html`
       <dl>
         ${page.citations.map((citation) => `
-          <dt><span id="${slugify(citation.id)}">${markdownify(citation.short)}</span></dt>
+          <dt><span id="${slugify(citation.id)}">${markdownify(citation.id)}</span></dt>
           <dd>${markdownify(citation.full)}</dd>
           `
         )}

--- a/packages/11ty/_plugins/shortcodes/cite.js
+++ b/packages/11ty/_plugins/shortcodes/cite.js
@@ -43,7 +43,7 @@ module.exports = function(eleventyConfig, { page }) {
     }
 
     references = Object.fromEntries(
-      references.entries.map(({ id, full, short }) => [id, { full, short }])
+      references.entries.map(({ id, full, short }) => [id, { full, short, id }])
     )
 
     const citation = references[id]


### PR DESCRIPTION
I think this was just a translation oversight? not entirely sure where `short` is supposed to be available / used now though