### PR TITLE
Fix: Load to assets/application.scss to resolve build failure

### DIFF
--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -71,8 +71,8 @@ module.exports = function(eleventyConfig) {
         <script type="application/ld+json">${jsonld({ canonicalURL, page })}</script>
 
         <link rel="icon" href="/_assets/images/icons/favicon.ico" />
+        <link rel="stylesheet" href="/_assets/styles/application.scss" />
         <link rel="stylesheet" href="/_assets/styles/custom.css" />
-        <link rel="stylesheet" href="/_assets/styles/application.css" />
 
         <!-- {% render 'polyfills/template.html' %} -->
 


### PR DESCRIPTION
Correcting the file extension to load the `application.scss` (before `custom.css`) allows the `build` to succeed though rollup is throwing a non-haulting error on the `search-index.json` file that still needs to be resolved.