### PR TITLE
Refactor: IIIF Output

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -179,7 +179,7 @@ module.exports = function(eleventyConfig) {
    * @see {@link https://www.11ty.dev/docs/copy/ Passthrough copy in 11ty}
    */
   eleventyConfig.addPassthroughCopy('content/_assets')
-  eleventyConfig.addPassthroughCopy('content/_iiif')
+  eleventyConfig.addPassthroughCopy('_iiif')
 
   /**
    * Watch the following additional files for changes and live browsersync

--- a/packages/11ty/.gitignore
+++ b/packages/11ty/.gitignore
@@ -1,7 +1,7 @@
 # Eleventy build artifacts
 _site/
 _temp/
-content/_iiif/
+_iiif/
 
 # EleventFetch cache directory
 .cache

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -45,9 +45,11 @@ Entry content, including entry image and tombstone data
         {% elsif pageObjects %}
           {% for object in pageObjects %}
             <div class="quire-entry__image__group-container">
-              {% for objectFigure in object.figures %}
-                {% render "entry-figure", epub: epub, pdf: pdf, zoom: zoom, imageDir: imageDir, figure: objectFigure %}
-              {% endfor %}
+              {% comment %}
+                {% for objectFigure in object.figures %}
+                  {% render "entry-figure", epub: epub, pdf: pdf, zoom: zoom, imageDir: imageDir, figure: objectFigure %}
+                {% endfor %}
+              {% endcomment %}
             </div>
           {% endfor %}
         {% endif %}

--- a/packages/11ty/_plugins/filters/getFigure.js
+++ b/packages/11ty/_plugins/filters/getFigure.js
@@ -6,10 +6,5 @@
  */
 module.exports = function(eleventyConfig, id) {
   const { figure_list } = eleventyConfig.globalData.figures
-  const figure = figure_list.find((item) => item.id === id)
-  if (!figure) {
-    console.warn(`Error: the id '${id}' was not found in 'figures.yaml'`)
-    return ''
-  }
-  return figure
+  return figure_list.find((item) => item.id === id)
 }

--- a/packages/11ty/_plugins/iiif/config.js
+++ b/packages/11ty/_plugins/iiif/config.js
@@ -29,6 +29,7 @@ module.exports = (eleventyConfig) => {
      * Generated manifest locale
      * @type {String}
      */
+    inputDir: path.join('content', '_assets', 'images', 'figures'),
     locale: 'en',
     /**
      * Generated manifest file name

--- a/packages/11ty/_plugins/iiif/config.js
+++ b/packages/11ty/_plugins/iiif/config.js
@@ -29,7 +29,7 @@ module.exports = (eleventyConfig) => {
      * Generated manifest locale
      * @type {String}
      */
-    inputDir: path.join('content', '_assets', 'images', 'figures'),
+    inputDir: path.join('content', '_assets', 'images'),
     locale: 'en',
     /**
      * Generated manifest file name

--- a/packages/11ty/_plugins/iiif/config.js
+++ b/packages/11ty/_plugins/iiif/config.js
@@ -1,7 +1,6 @@
 const path = require('path')
 
 module.exports = (eleventyConfig) => {
-  const root = eleventyConfig.dir.input
   return {
     baseURL: eleventyConfig.globalData.config.baseURL || eleventyConfig.globalData.env.URL,
     /**
@@ -40,11 +39,7 @@ module.exports = (eleventyConfig) => {
      * Output directory
      * @type {String}
      */
-    output: path.join('_iiif'),
-    /**
-     * The eleventy project directory
-     */
-    root,
+    outputDir: path.join('_iiif'),
     /**
      * Image extensions that can be processed
      * @type {Array}

--- a/packages/11ty/_plugins/iiif/process/addGlobalData.js
+++ b/packages/11ty/_plugins/iiif/process/addGlobalData.js
@@ -11,7 +11,7 @@ module.exports = async (eleventyConfig) => {
   const isImageService = eleventyConfig.getFilter('isImageService');
   const hasCanvasPanelProps = eleventyConfig.getFilter('hasCanvasPanelProps');
   const { figures, iiifConfig } = eleventyConfig.globalData;
-  const { imageServiceDirectory, output } = iiifConfig;
+  const { imageServiceDirectory, outputDir } = iiifConfig;
 
   for (const [index, figure] of figures.figure_list.entries()) {
     switch (true) {
@@ -20,7 +20,7 @@ module.exports = async (eleventyConfig) => {
           ? figure.src
           : path.join(
               '/',
-              output,
+              outputDir,
               path.parse(figure.src).name,
               imageServiceDirectory,
               'info.json'

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -24,7 +24,7 @@ module.exports = (eleventyConfig) => {
     const ext = path.parse(filename).ext
     const id = path.parse(filename).name
     const inputPath = path.join(inputDir, filename)
-    const outputPath = path.join(outputDir, id, filename)
+    const outputPath = path.join(outputDir, id, `${name}${ext}`)
 
     fs.ensureDirSync(path.join(outputDir, id))
 

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -19,28 +19,26 @@ module.exports = (eleventyConfig) => {
    */
   return async (filename, transformation = {}, options) => {
     const { debug, lazy } = options
-    const { name, resize } = transformation
 
-    const ext = path.parse(filename).ext
-    const id = path.parse(filename).name
+    const { ext, name } = path.parse(filename)
     const inputPath = path.join(inputDir, filename)
-    const outputPath = path.join(outputDir, id, `${name}${ext}`)
+    const outputPath = path.join(outputDir, name, `${transformation.name}${ext}`)
 
-    fs.ensureDirSync(path.join(outputDir, id))
+    fs.ensureDirSync(path.join(outputDir, name))
 
     if (!lazy || !fs.pathExistsSync(outputPath)) {
       await sharp(inputPath)
-        .resize(resize)
+        .resize(transformation.resize)
         .withMetadata()
         .toFile(outputPath)
 
       if (debug) {
-        console.warn(`[iiif:createImage:${id}] Created ${filename}`)
+        console.warn(`[iiif:createImage:${name}] Created ${filename}`)
       }
     } else {
       if (debug) {
         console.warn(
-          `[iiif:createImage:${id}] ${filename} already exists, skipping`
+          `[iiif:createImage:${name}] ${filename} already exists, skipping`
         )
       }
     }

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -7,7 +7,7 @@ const sharp = require('sharp')
  * @return {Function}      createImage()
  */
 module.exports = (eleventyConfig) => {
-  const { outputDir } = eleventyConfig.globalData.iiifConfig
+  const { inputDir, outputDir } = eleventyConfig.globalData.iiifConfig
 
   /**
    * Creates an image in the output directory with the name `${name}${ext}`
@@ -17,22 +17,22 @@ module.exports = (eleventyConfig) => {
    * @property  {String} name The name of the file
    * @property  {Object} resize Resize options for `sharp`
    */
-  return async (input, transformation = {}, options) => {
+  return async (filename, transformation = {}, options) => {
     const { debug, lazy } = options
     const { name, resize } = transformation
 
-    const ext = path.parse(input).ext
-    const id = path.parse(input).name
-    const filename = `${name}${ext}`
+    const ext = path.parse(filename).ext
+    const id = path.parse(filename).name
+    const inputPath = path.join(inputDir, filename)
+    const outputPath = path.join(outputDir, id, filename)
 
     fs.ensureDirSync(path.join(outputDir, id))
-    const fileOutput = path.join(outputDir, id, filename)
 
-    if (!lazy || !fs.pathExistsSync(fileOutput)) {
-      await sharp(input)
+    if (!lazy || !fs.pathExistsSync(outputPath)) {
+      await sharp(inputPath)
         .resize(resize)
         .withMetadata()
-        .toFile(fileOutput)
+        .toFile(outputPath)
 
       if (debug) {
         console.warn(`[iiif:createImage:${id}] Created ${filename}`)

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -7,10 +7,7 @@ const sharp = require('sharp')
  * @return {Function}      createImage()
  */
 module.exports = (eleventyConfig) => {
-  const {
-    output, 
-    root
-  } = eleventyConfig.globalData.iiifConfig
+  const { outputDir } = eleventyConfig.globalData.iiifConfig
 
   /**
    * Creates an image in the output directory with the name `${name}${ext}`
@@ -23,7 +20,6 @@ module.exports = (eleventyConfig) => {
   return async (input, transformation = {}, options) => {
     const { debug, lazy } = options
     const { name, resize } = transformation
-    const outputDir = path.join(root, output)
 
     const ext = path.parse(input).ext
     const id = path.parse(input).name

--- a/packages/11ty/_plugins/iiif/process/createManifest.js
+++ b/packages/11ty/_plugins/iiif/process/createManifest.js
@@ -20,8 +20,7 @@ module.exports = (eleventyConfig) => {
     imageServiceDirectory,
     locale,
     manifestFilename,
-    output: defaultOutput,
-    root
+    outputDir: defaultOutput
   } = eleventyConfig.globalData.iiifConfig
   const { imageDir } = eleventyConfig.globalData.config.params
 
@@ -32,15 +31,17 @@ module.exports = (eleventyConfig) => {
    *
    * @param  {Object} figure Figure data from figures.yaml
    * @param  {Object} options
-   * @property  {String} output (optional) overwrite default output
+   * @property  {Boolean} debug Default false
+   * @property  {Boolean} lazy Default true
+   * @property  {String} outputDir (optional) overwrite default output
    */
   return async (figure, options={}) => {
-    const { debug, lazy, output } = options
+    const { debug, lazy } = options
     const { id, label, choiceId, choices, preset } = figure
 
-    const outputDir = output || defaultOutput
+    const outputDir = options.outputDir || defaultOutput
     const iiifId = [process.env.URL, outputDir, id].join('/')
-    const manifestOutput = path.join(root, outputDir, id, manifestFilename)
+    const manifestOutput = path.join(outputDir, id, manifestFilename)
 
     if (debug) {
       console.warn(`[iiif:lib:createManifest:${id}] Creating manifest`)
@@ -54,7 +55,7 @@ module.exports = (eleventyConfig) => {
 
     const imagePath = choiceId
       ? choiceId
-      : path.join(root, imageDir, defaultChoice.src)
+      : path.join(eleventyConfig.dir.input, imageDir, defaultChoice.src)
 
     const { height, width } = await sharp(imagePath).metadata()
     const manifest = builder.createManifest(manifestId, (manifest) => {
@@ -103,7 +104,7 @@ module.exports = (eleventyConfig) => {
 
     const jsonManifest = builder.toPresentation3(manifest)
 
-    fs.ensureDirSync(path.join(root, outputDir, id))
+    fs.ensureDirSync(path.join(outputDir, id))
     fs.writeJsonSync(manifestOutput, jsonManifest)
 
     eleventyConfig.addGlobalData('iiifManifests', {

--- a/packages/11ty/_plugins/iiif/process/createManifest.js
+++ b/packages/11ty/_plugins/iiif/process/createManifest.js
@@ -18,9 +18,10 @@ require('dotenv').config()
 module.exports = (eleventyConfig) => {
   const {
     imageServiceDirectory,
+    inputDir,
     locale,
     manifestFilename,
-    outputDir: defaultOutput
+    outputDir
   } = eleventyConfig.globalData.iiifConfig
   const { imageDir } = eleventyConfig.globalData.config.params
 
@@ -33,13 +34,11 @@ module.exports = (eleventyConfig) => {
    * @param  {Object} options
    * @property  {Boolean} debug Default false
    * @property  {Boolean} lazy Default true
-   * @property  {String} outputDir (optional) overwrite default output
    */
   return async (figure, options={}) => {
     const { debug, lazy } = options
     const { id, label, choiceId, choices, preset } = figure
 
-    const outputDir = options.outputDir || defaultOutput
     const iiifId = [process.env.URL, outputDir, id].join('/')
     const manifestOutput = path.join(outputDir, id, manifestFilename)
 
@@ -55,7 +54,7 @@ module.exports = (eleventyConfig) => {
 
     const imagePath = choiceId
       ? choiceId
-      : path.join(eleventyConfig.dir.input, imageDir, defaultChoice.src)
+      : path.join(inputDir, defaultChoice.src)
 
     const { height, width } = await sharp(imagePath).metadata()
     const manifest = builder.createManifest(manifestId, (manifest) => {

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -47,7 +47,7 @@ module.exports = {
 
       const promises = []
       figuresToTile.forEach((figure) => {
-        const imagePath = path.join(eleventyConfig.dir.input, imageDir, figure.src)
+        const imagePath = figure.src
         const id = path.parse(imagePath).name
 
         if (debug) {

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -20,10 +20,7 @@ module.exports = {
      * IIIF config
      */
     const { config, iiifConfig, figures } = eleventyConfig.globalData
-    const {
-      imageTransformations,
-      root
-    } = iiifConfig
+    const { imageTransformations } = iiifConfig
     const { imageDir } = config.params
 
     const createImage = initCreateImage(eleventyConfig)
@@ -50,7 +47,7 @@ module.exports = {
 
       const promises = []
       figuresToTile.forEach((figure) => {
-        const imagePath = path.join(root, imageDir, figure.src)
+        const imagePath = path.join(eleventyConfig.dir.input, imageDir, figure.src)
         const id = path.parse(imagePath).name
 
         if (debug) {

--- a/packages/11ty/_plugins/iiif/process/tileImage.js
+++ b/packages/11ty/_plugins/iiif/process/tileImage.js
@@ -10,8 +10,7 @@ module.exports = (eleventyConfig) => {
   const {
     baseURL,
     imageServiceDirectory,
-    output,
-    root,
+    outputDir,
     supportedImageExtensions,
     tileSize
   } = eleventyConfig.globalData.iiifConfig
@@ -31,7 +30,6 @@ module.exports = (eleventyConfig) => {
       return;
     }
 
-    const outputDir = path.join(root, output)
     const tileDirectory = path.join(outputDir, name, imageServiceDirectory)
 
     if (fs.pathExistsSync(tileDirectory) && lazy && debug) {

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -34,7 +34,11 @@ module.exports = function (eleventyConfig, { page }) {
     /**
      * Merge figures.yaml data and additional params
      */
-    let figure = id ? getFigure(id) : {}
+    let figure = getFigure(id)
+    if (!figure) {
+      console.warn(`Warning: The figure id "${id}" was found in the template "${page.inputPath}", but is not defined in "figures.yaml"`)
+      return ''
+    }
     figure = { ...figure, ...arguments }
     if (!page.figures) page.figures = [];
     page.figures.push(figure);


### PR DESCRIPTION
Fixes:
Slow preview with many IIIF images by making it possible to specify a IIIF input directory other than `_assets/images/figures` for IIIF images, and outputting IIIF images to a directory outside content so that images aren't watched. For an image directory to not be watched, it needs to be outside the `content` directory.

Changes:
- Move IIIF output directory to root level
- Add `inputDir` to `iiif/config.js`
- Add template path to the error message for when a figure id is not found in `figures.yaml`
- Rename `iiif/config.js#output` -> `iiif/config.js#outputDir`
- Refactor all IIIF processing methods to expect `filename` and use `iiifConfig.inputDir` and `iiifConfig.outputDir`

Note: 
Commenting out the `entry-figure` template, which needs to be refactored to use the figure shortcode.