### PR TITLE
Fix: IIIF choices

### DIFF
--- a/packages/11ty/_includes/components/figure/choices.js
+++ b/packages/11ty/_includes/components/figure/choices.js
@@ -1,6 +1,6 @@
 module.exports = function(eleventyConfig) {
   return function(figure) {
-    const { choiceId, choices } = figure
+    const { choiceId, choices } = figure.iiif
     if (!choices || !choices.length) return
     return choices.map((item, index) => {
       const classes = ['canvas-choice']


### PR DESCRIPTION
Previously forgot to update destructuring of iiif data in `choices` component when the `iiif` property was added to figures