### PR TITLE
Feature: IIIF Output to `public` directory

### DIFF
--- a/packages/11ty/_plugins/iiif/config.js
+++ b/packages/11ty/_plugins/iiif/config.js
@@ -40,7 +40,8 @@ module.exports = (eleventyConfig) => {
      * Output directory
      * @type {String}
      */
-    outputDir: path.join('_iiif'),
+    outputDir: '_iiif',
+    outputRoot: 'public',
     /**
      * Image extensions that can be processed
      * @type {Array}

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -7,7 +7,7 @@ const sharp = require('sharp')
  * @return {Function}      createImage()
  */
 module.exports = (eleventyConfig) => {
-  const { inputDir, outputDir } = eleventyConfig.globalData.iiifConfig
+  const { inputDir, outputDir, outputRoot } = eleventyConfig.globalData.iiifConfig
 
   /**
    * Creates an image in the output directory with the name `${name}${ext}`
@@ -22,9 +22,9 @@ module.exports = (eleventyConfig) => {
 
     const { ext, name } = path.parse(filename)
     const inputPath = path.join(inputDir, filename)
-    const outputPath = path.join(outputDir, name, `${transformation.name}${ext}`)
+    const outputPath = path.join(outputRoot, outputDir, name, `${transformation.name}${ext}`)
 
-    fs.ensureDirSync(path.join(outputDir, name))
+    fs.ensureDirSync(path.parse(outputPath).dir)
 
     if (!lazy || !fs.pathExistsSync(outputPath)) {
       await sharp(inputPath)

--- a/packages/11ty/_plugins/iiif/process/createManifest.js
+++ b/packages/11ty/_plugins/iiif/process/createManifest.js
@@ -21,7 +21,8 @@ module.exports = (eleventyConfig) => {
     inputDir,
     locale,
     manifestFilename,
-    outputDir
+    outputDir,
+    outputRoot
   } = eleventyConfig.globalData.iiifConfig
   const { imageDir } = eleventyConfig.globalData.config.params
 
@@ -40,7 +41,7 @@ module.exports = (eleventyConfig) => {
     const { id, label, choiceId, choices, preset } = figure
 
     const iiifId = [process.env.URL, outputDir, id].join('/')
-    const manifestOutput = path.join(outputDir, id, manifestFilename)
+    const manifestOutput = path.join(outputRoot, outputDir, id, manifestFilename)
 
     if (debug) {
       console.warn(`[iiif:lib:createManifest:${id}] Creating manifest`)
@@ -103,7 +104,7 @@ module.exports = (eleventyConfig) => {
 
     const jsonManifest = builder.toPresentation3(manifest)
 
-    fs.ensureDirSync(path.join(outputDir, id))
+    fs.ensureDirSync(path.parse(manifestOutput).dir)
     fs.writeJsonSync(manifestOutput, jsonManifest)
 
     eleventyConfig.addGlobalData('iiifManifests', {

--- a/packages/11ty/_plugins/iiif/process/tileImage.js
+++ b/packages/11ty/_plugins/iiif/process/tileImage.js
@@ -12,6 +12,7 @@ module.exports = (eleventyConfig) => {
     imageServiceDirectory,
     inputDir,
     outputDir,
+    outputRoot,
     supportedImageExtensions,
     tileSize
   } = eleventyConfig.globalData.iiifConfig
@@ -26,7 +27,7 @@ module.exports = (eleventyConfig) => {
 
     const { ext, name } = path.parse(filename)
     const inputPath = path.join(inputDir, filename)
-    const outputPath = path.join(outputDir, name, imageServiceDirectory)
+    const outputPath = path.join(outputRoot, outputDir, name, imageServiceDirectory)
 
     if (!supportedImageExtensions.includes(ext)) {
       if (debug) {


### PR DESCRIPTION
Changes:
- Changes IIIF process output directory to `public/_iiif` so it will be copied through to the build. See: https://vitejs.dev/guide/assets.html#the-public-directory