### PR TITLE
Add `modal` shortcode to entry page template to display modal lightbox for any figures in entry content

### DIFF
--- a/packages/11ty/.eleventyignore
+++ b/packages/11ty/.eleventyignore
@@ -1,2 +1,3 @@
 _site/
 _iiif/
+public/

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -35,6 +35,7 @@ module.exports = function(data) {
             </div>
             {% render 'search' %}
           </div>
+          ${this.modal()}
           ${this.scripts()}
         </body>
       </html>

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -77,3 +77,4 @@ Entry content, including entry image and tombstone data
     </div>
   </div>
 </article>
+{% modal %}

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -77,4 +77,3 @@ Entry content, including entry image and tombstone data
     </div>
   </div>
 </article>
-{% modal %}

--- a/packages/11ty/_layouts/essay.liquid
+++ b/packages/11ty/_layouts/essay.liquid
@@ -25,4 +25,3 @@ description: Essay layout. This layout describes a single-page template that has
     </div>
   </section>
 </article>
-{% modal %}


### PR DESCRIPTION
Any `{% figure .. %}` added to catalogue entry page content should open in a modal now