### PR TITLE
Fix: use locale sort for bibliography references

### DIFF
--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -45,7 +45,7 @@ module.exports = function(eleventyConfig, options) {
 
   eleventyConfig.addFilter('sortContributors', (contributors) => sortContributors(eleventyConfig, contributors))
 
-  eleventyConfig.addFilter('sortReferences', (items) => sortReferences(items))
+  eleventyConfig.addFilter('sortReferences', (items) => sortReferences(eleventyConfig, items))
 
   /**
    * String manipulation filters

--- a/packages/11ty/_plugins/filters/sortReferences.js
+++ b/packages/11ty/_plugins/filters/sortReferences.js
@@ -7,20 +7,35 @@
  * @param  {Array} items References
  * @return {Array} sorted references
  */
-module.exports = function (items) {
+module.exports = function (eleventyConfig, items) {
   if (!items || !Array.isArray(items)) return null
 
-  return items.sort((a, b) => {
-    const sortA = a.sort_as || a.full
-    const sortB = b.sort_as || b.full
+  const removeMarkdown = eleventyConfig.getFilter('removeMarkdown')
 
-    switch (true) {
-      case (sortA < sortB):
-        return -1
-      case (sortA > sortB):
-        return 1
-      default:
-        return 0
-    }
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#locales
+   * @todo set locale using publication `config.languageCode`
+   */
+  const locales = 'en'
+
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options
+   */
+  const options = {
+    caseFirst: 'upper',
+    ignorePunctuation: false,
+    localeMatcher: 'best fit',
+    numeric: true,
+    sensitivity: 'variant',
+    usage: 'sort'
+  }
+
+  return items.sort((itemA, itemB) => {
+    const sortById = eleventyConfig.globalData.config.params.displayBiblioShort
+    let a = sortById ? itemA.id : itemA.sort_as || itemA.full
+    let b = sortById ? itemB.id : itemB.sort_as || itemB.full
+    a = removeMarkdown(a)
+    b = removeMarkdown(b)
+    return a.localeCompare(b, locales, options)
   })
 }

--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -1,10 +1,11 @@
 const MarkdownIt = require('markdown-it')
-const anchors = require('markdown-it-anchor')
-const attributes = require('markdown-it-attrs')
-const bracketedSpans = require('markdown-it-bracketed-spans')
+const anchorsPlugin = require('markdown-it-anchor')
+const attributesPlugin = require('markdown-it-attrs')
+const bracketedSpansPlugin = require('markdown-it-bracketed-spans')
 const defaults = require('./defaults')
-const deflist = require('markdown-it-deflist')
-const footnotes = require('markdown-it-footnote')
+const deflistPlugin = require('markdown-it-deflist')
+const footnotePlugin = require('markdown-it-footnote')
+const removeMarkdown = require('remove-markdown')
 
 /**
  * An Eleventy plugin to configure the markdown library
@@ -34,11 +35,11 @@ module.exports = function(eleventyConfig, options) {
   }
 
   const markdownLibrary = MarkdownIt(Object.assign(defaults, options))
-    .use(anchors, anchorOptions)
-    .use(attributes, attributesOptions)
-    .use(bracketedSpans)
-    .use(deflist)
-    .use(footnotes)
+    .use(anchorsPlugin, anchorOptions)
+    .use(attributesPlugin, attributesOptions)
+    .use(bracketedSpansPlugin)
+    .use(deflistPlugin)
+    .use(footnotePlugin)
 
   /**
    * Configure renderer to exclude brakcets from footnotes
@@ -63,5 +64,13 @@ module.exports = function(eleventyConfig, options) {
     return !content.match(/\n/)
       ? markdownLibrary.renderInline(content)
       : markdownLibrary.render(content)
+  })
+
+  /**
+   * Add a universal template filter to remove markdown from a string
+   * @see
+   */
+  eleventyConfig.addFilter('removeMarkdown', (content) => {
+    return content ? removeMarkdown(content) : ''
   })
 }

--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -38,7 +38,9 @@ module.exports = function (eleventyConfig, { page }) {
      */
     referenceIds.forEach((id) => {
       const entry = entries.find((entry) => entry.id === id)
-      page.citations[id] ??= { ...entry, short: entry.short || entry.id }
+      if (entry) {
+        page.citations[id] ??= { ...entry, short: entry.short || entry.id }
+      }
     })
 
     const bibliographyItems = sortReferences(Object.values(page.citations))

--- a/packages/11ty/_plugins/shortcodes/cite.js
+++ b/packages/11ty/_plugins/shortcodes/cite.js
@@ -81,7 +81,7 @@ module.exports = function(eleventyConfig, { page }) {
       })
 
       return entry
-        ? { ...entry, short: entry.short || id }
+        ? { ...entry, short: entry.short || entry.id }
         : warn(stripIndent`
             references entry not found ${page.inputPath}
               cite id '${id}' does not match an entry in the project references data
@@ -97,7 +97,7 @@ module.exports = function(eleventyConfig, { page }) {
 
     page.citations[id] = citation
 
-    let buttonText = (text) ? text : citation.short || id
+    let buttonText = (text) ? text : citation.short
 
     if (pageNumber) buttonText += divider + pageNumber
 

--- a/packages/11ty/_plugins/shortcodes/cite.js
+++ b/packages/11ty/_plugins/shortcodes/cite.js
@@ -43,28 +43,54 @@ module.exports = function(eleventyConfig, { page }) {
   return function(id, pageNumber, text) {
     if (!id) {
       warn(stripIndent`
-        missing shortcode parameters
+        missing shortcode parameters ${page.inputPath}
 
-          {% cite id pages text %}
+          Usage:
+            {% cite id pages text %}
 
-          The 'id' parameter is required and should match an entry in the project 'references.yaml' data file.
-          The 'pages' parameter is an optional page number or range of page numbers.
-          The 'text' parameter is optional text for the link in place of the full or short form of the reference.
+            The 'id' parameter is required and should match an entry in the project 'references.yaml' data file.
+            The 'pages' parameter is an optional page number or range of page numbers.
+            The 'text' parameter is optional text for the link in place of the full or short form of the reference.
 
-          @example {% cite \"Faure 1909\" \"304\" \"1909\" %}
+          Example:
+            {% cite \"Faure 1909\" \"304\" \"1909\" %}
       `)
       return ''
     }
 
 
     const findCitationReference = (id) => {
-      const entry = entries.find((entry) => entry.id === id)
+      /**
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#locales
+       * @todo set locale using publication `config.languageCode`
+       */
+      const locales = 'en'
+
+      /**
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options
+       */
+      const options = {
+        ignorePunctuation: true,
+        numeric: true,
+        sensitivity: 'base',
+        usage: 'search'
+      }
+
+      const entry = entries.find((entry) => {
+        return entry.id.localeCompare(id, locales, options) === 0
+      })
+
       return entry
         ? { ...entry, short: entry.short || id }
-        : warn(`the cite id '${id}' does not match an entry in the project references data`)
+        : warn(stripIndent`
+            references entry not found ${page.inputPath}
+              cite id '${id}' does not match an entry in the project references data
+          `)
     }
 
     const citation = findCitationReference(id)
+
+    if (!citation) return
 
     // ensure that the page citations object exists
     if (!page.citations) page.citations = {}
@@ -91,7 +117,7 @@ module.exports = function(eleventyConfig, { page }) {
     return renderOneLine`
       <cite class="quire-citation expandable">
         ${button}
-        <span hidden class="quire-citation__content">
+        <span class="quire-citation__content" hidden>
           ${markdownify(citation.full)}
         </span>
       </cite>

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -48,6 +48,7 @@
         "mime-types": "^2.1.35",
         "path": "^0.12.7",
         "prettier": "2.7.0",
+        "remove-markdown": "^0.5.0",
         "rollup-plugin-scss": "^3.0.0",
         "sass": "^1.53.0",
         "sharp": "^0.30.7",
@@ -4282,6 +4283,12 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/remove-markdown": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.0.tgz",
+      "integrity": "sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "dev": true,
@@ -8078,6 +8085,12 @@
     },
     "regexpp": {
       "version": "3.2.0",
+      "dev": true
+    },
+    "remove-markdown": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.0.tgz",
+      "integrity": "sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg==",
       "dev": true
     },
     "resolve": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -52,6 +52,7 @@
     "mime-types": "^2.1.35",
     "path": "^0.12.7",
     "prettier": "2.7.0",
+    "remove-markdown": "^0.5.0",
     "rollup-plugin-scss": "^3.0.0",
     "sass": "^1.53.0",
     "sharp": "^0.30.7",


### PR DESCRIPTION
## Added

- Universal template filter `removeMarkdown`


## Changes

- Use `String.prototype.localeCompare` to find entries in `references.yaml` data, this allows the `cite` shortcode to omit markdown that may be included in the entry `id` property.
- Use `String.prototype.localeCompare` to sort bibliography references, removing markdown when sorting references yet preserves markdown for display.


## Fixes

- Prevent error when reference entry is not found


