### PR TITLE
Feature: Insert word breaks into linked URL strings

### DIFF
--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -51,7 +51,7 @@ module.exports = function(eleventyConfig, options) {
    * Override the default linkify normalizer
    * @see https://github.com/markdown-it/linkify-it
    *
-   * Insert word break opportunites into an URL string using HTML <wbr> elements
+   * Insert word break opportunites, HTML <wbr> elements, into link text URL strings
    * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element
    *
    * The Chicago Manual of Style recommends URLs be broken onto multiple lines
@@ -77,11 +77,11 @@ module.exports = function(eleventyConfig, options) {
     }
 
     if (!match.schema) {
-      match.url = insertWordBreaks(`https://${match.url}`)
+      match.text = insertWordBreaks(`https://${match.url}`)
     }
 
     if (['https:', 'http:', 'ftp:', '//'].includes(match.schema)) {
-      match.url = insertWordBreaks(match.url)
+      match.text = insertWordBreaks(match.url)
     }
   }
 

--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -54,6 +54,8 @@ module.exports = function(eleventyConfig, options) {
    * Insert word break opportunites, HTML <wbr> elements, into link text URL strings
    * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element
    *
+   * Based on the work of Reuben L. Lillie
+   *
    * The Chicago Manual of Style recommends URLs be broken onto multiple lines
    * based on punctuation in the following places:
    * - After a colon (:) or a double slash (//)
@@ -63,6 +65,7 @@ module.exports = function(eleventyConfig, options) {
    * - Before or after an equals sign (=) or an ampersand (&)
    *
    * @see https://www.chicagomanualofstyle.org/book/ed17/part3/ch14/psec018.html
+   *
    */
   markdownLibrary.linkify.normalize = function (match) {
     const insertWordBreaks = (string) => {

--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -48,6 +48,44 @@ module.exports = function(eleventyConfig, options) {
   markdownLibrary.linkify.set({ fuzzyLink: false })
 
   /**
+   * Override the default linkify normalizer
+   * @see https://github.com/markdown-it/linkify-it
+   *
+   * Insert word break opportunites into an URL string using HTML <wbr> elements
+   * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element
+   *
+   * The Chicago Manual of Style recommends URLs be broken onto multiple lines
+   * based on punctuation in the following places:
+   * - After a colon (:) or a double slash (//)
+   * - Before a single slash (/), a tilde (~), a period (.), a comma (,),
+   *   a hyphen (-), an underline (aka an underscore, _), a question mark (?),
+   *   a number sign (#), or a percent symbol (%).
+   * - Before or after an equals sign (=) or an ampersand (&)
+   *
+   * @see https://www.chicagomanualofstyle.org/book/ed17/part3/ch14/psec018.html
+   */
+  markdownLibrary.linkify.normalize = function (match) {
+    const insertWordBreaks = (string) => {
+      const [ schema, url ] = string.split('//')
+      return `${schema}<wbr>//<wbr>${url}` + url
+        // after a colon
+        .replace(/(?<after>:)/giu, '$1<wbr>')
+        // before a single slash, tilde, period, comma, hyphen, underline, question mark, number sign, or percent symbol
+        .replace(/(?<before>[/~.,\-_?#%])/giu, '<wbr>$1')
+        // before and after an equal sign or an ampersand
+        .replace(/(?<beforeAndAfter>[=&])/giu, '<wbr>$1<wbr>')
+    }
+
+    if (!match.schema) {
+      match.url = insertWordBreaks(`https://${match.url}`)
+    }
+
+    if (['https:', 'http:', 'ftp:', '//'].includes(match.schema)) {
+      match.url = insertWordBreaks(match.url)
+    }
+  }
+
+  /**
    * Configure renderer to exclude brakcets from footnotes
    */
   markdownLibrary.renderer.rules.footnote_caption = (tokens, idx) => {

--- a/packages/11ty/content/_assets/styles/print.scss
+++ b/packages/11ty/content/_assets/styles/print.scss
@@ -7,6 +7,15 @@
 // component level. This stylesheet is for overrides and other special-case
 // rules which don't properly fit anywhere else and only show up in print.
 
+/**
+ * IE 8–11 and Prince do not recognize the <wbr> element,
+ * to achieve the same effect in IE 9+ and Prince
+ * this pseudo-element adds a Unicode zero width space before any <wbr> element
+ */
+wbr:before {
+  content: "\200B";
+  white-space: normal;
+}
 
 // Variables (others in the variables.scss file)
 // -----------------------------------------------------------------------------

--- a/packages/11ty/content/_assets/styles/print.scss
+++ b/packages/11ty/content/_assets/styles/print.scss
@@ -9,8 +9,8 @@
 
 /**
  * IE 8–11 and Prince do not recognize the <wbr> element,
- * to achieve the same effect in IE 9+ and Prince
- * this pseudo-element adds a Unicode zero width space before any <wbr> element
+ * this pseudo-element achieves the same effect in IE 9+ and Prince
+ * by adding a Unicode zero width space before any <wbr> element
  */
 wbr:before {
   content: "\200B";


### PR DESCRIPTION
Override the `markdown-it/linkify` normalizer to insert HTML word break elements (`<wbr>`) into link URL strings according to _The Chicago Manual of Style_, specifying opportunities where an HTML renderer (screen or print) should wrap long URLs onto multiple lines.

