### PR TITLE
Fixes: IIIF

### DIFF
--- a/packages/11ty/_plugins/iiif/config.js
+++ b/packages/11ty/_plugins/iiif/config.js
@@ -54,6 +54,7 @@ module.exports = (eleventyConfig) => {
       '.svg',
       '.tif',
       '.tiff'
-    ]
+    ],
+    tileSize: 256
   }
 }

--- a/packages/11ty/_plugins/iiif/index.js
+++ b/packages/11ty/_plugins/iiif/index.js
@@ -8,5 +8,4 @@ module.exports = function (eleventyConfig, options = {}) {
     const processImages = iiifProcess.init(eleventyConfig)
     await processImages(options.processImages)
   })
-  // eleventyConfig.on('eleventy.after', () => {})
 }

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -44,15 +44,15 @@ module.exports = {
       .filter((figure) => isImageService(figure) && !figure.src.startsWith('http'))
       .filter(({ src }) => !tiledImages.includes(path.parse(src).name))
 
+    if (tiledImages) {
+      info(`Skipping ${tiledImages.length} previously tiled ${pluralize('image', tiledImages)}.`)
+    }
+
     if (figuresToTile.length) {
-      info(`Generating IIIF image tiles may take a while depending on the size of each image file.`)
       info(`Tiling ${figuresToTile.length} ${pluralize('image', figuresToTile.length)}...`)
+      info(`Generating IIIF image tiles may take a while depending on the size of each image file.`)
     } else {
-      const skipped = tiledImages.length - figuresToTile.length
-      const skipMessage = skipped > 0 
-        ? ` Skipped ${skipped} previously tiled ${pluralize('image', skipped)}.`
-        : ''
-      info(`No ${skipMessage ? 'new ' : ''}images to tile found in figures.yaml.${skipMessage}`)
+      info(`No new images to tile found in figures.yaml.`)
     }
 
     /**
@@ -110,7 +110,6 @@ module.exports = {
               return fs.readdirSync(path.join(outputPath, dir)).includes('manifest.json')
             })
           : []
-
         info(`Generating ${figuresWithChoices.length} ${pluralize('manifest', figuresWithChoices.length)}.`)
         for (const figure of figuresWithChoices) {
           await createManifest(figure, options)

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -25,17 +25,17 @@ module.exports = {
      * IIIF config
      */
     const { config, iiifConfig, figures } = eleventyConfig.globalData
-    const { imageServiceDirectory, imageTransformations, outputDir } = iiifConfig
+    const { imageServiceDirectory, imageTransformations, outputDir, outputRoot } = iiifConfig
     const { imageDir } = config.params
 
     const createImage = initCreateImage(eleventyConfig)
     const createManifest = initCreateManifest(eleventyConfig)
     const tileImage = initTileImage(eleventyConfig)
-
-    const processedFiles = fs.existsSync(outputDir) && fs.readdirSync(outputDir)
+    const outputPath = path.join(outputRoot, outputDir)
+    const processedFiles = fs.existsSync(outputPath) && fs.readdirSync(outputPath)
     const tiledImages = processedFiles
       ? processedFiles.filter((dir) => {
-          return fs.readdirSync(path.join(outputDir, dir)).includes(imageServiceDirectory)
+          return fs.readdirSync(path.join(outputPath, dir)).includes(imageServiceDirectory)
         })
       : []
 
@@ -107,7 +107,7 @@ module.exports = {
       if (figuresWithChoices.length) {
         const manifests = processedFiles
           ? processedFiles.filter((dir) => {
-              return fs.readdirSync(path.join(outputDir, dir)).includes('manifest.json')
+              return fs.readdirSync(path.join(outputPath, dir)).includes('manifest.json')
             })
           : []
 

--- a/packages/11ty/_plugins/iiif/process/tileImage.js
+++ b/packages/11ty/_plugins/iiif/process/tileImage.js
@@ -55,7 +55,7 @@ module.exports = (eleventyConfig) => {
         .tile({
           id: iiifId,
           layout: 'iiif',
-          size: 512
+          size: tileSize
         })
         .toFile(outputPath)
     } catch(error) {


### PR DESCRIPTION
Changes:
- Include `public` (outputRoot) directory in path checked for processed images
- Change tile size from 512 -> 256
- Move messaging about skipped images before tiling messages