### PR TITLE
Refactor: Use media_type: iiif to specify image service

### DIFF
--- a/packages/11ty/_plugins/filters/isImageService.js
+++ b/packages/11ty/_plugins/filters/isImageService.js
@@ -1,9 +1,11 @@
+const path = require('path')
 /**
  * Check if a figure is an image service
  * @param  {Object} figure
  * @return {Boolean}
  */
 module.exports = function(figure) {
-  const { iiifContent, manifestId, media_type: mediaType, preset } = figure
-  return mediaType === 'imageservice' || (preset === 'zoom' && !iiifContent && !manifestId)
+  const { iiifContent, manifestId, media_type: mediaType, src='' } = figure
+  const { base } = path.parse(src)
+  return base === 'info.json' || (mediaType === 'iiif' && !iiifContent && !manifestId)
 }

--- a/packages/11ty/content/_data/figures.yaml
+++ b/packages/11ty/content/_data/figures.yaml
@@ -8,17 +8,15 @@ figure_list:
         label: "Choice #2"
   - id: "example-image-service"
     label: "Figure 1"
-    media_type: "imageservice"
-    src: https://iiif.wellcomecollection.org/image/b18035723_0001.JP2
+    src: https://iiif.wellcomecollection.org/image/b18035723_0001.JP2/info.json
     caption: "This is a caption"
   - id: "example-image-service-2"
     label: "Figure 2"
     src: figures/mother.jpg
-    preset: zoom
+    media_type: iiif
   - id: "example-image-service-3"
     label: "Figure 3"
-    media_type: "imageservice"
-    src: https://iiif.wellcomecollection.org/image/b18035723_0010.JP2
+    src: https://iiif.wellcomecollection.org/image/b18035723_0010.JP2/info.json
   - id: "example-external-manifest"
     label: "Figure 4"
     canvasId: https://preview.iiif.io/cookbook/3333-choice/recipe/0036-composition-from-multiple-images/canvas/p1

--- a/packages/11ty/content/iiif-demo.md
+++ b/packages/11ty/content/iiif-demo.md
@@ -7,9 +7,9 @@ layout: essay
 The following examples demonstrate basic usage of when the `figure` shortcode renders `<canvas-panel>` and `<image-service>` web components.
 
 ## Image Service
-Images in `figures.yaml` with `preset=zoom` or `media_type="imageservice"` will be tiled and rendered using the `<image-service />` web component.
+Images in `figures.yaml` with `media_type="iiif"` will be tiled and rendered using the `<image-service />` web component.
 
-The tiler output can be found in `content/_assets/_iiif/<image-name>/`
+The tiler output can be found in `public/_iiif/<image-name>/`
 
 Example:
 
@@ -17,7 +17,7 @@ _figures.yaml_
 ```yaml
   - id: "example-image-service-2"
     src: figures/mother.jpg
-    preset: zoom
+    media_type: iiif
 ```
 
 {% figure "example-image-service-2" %}


### PR DESCRIPTION
Changes:
- Use `figure.media_type` is `iiif` to determine if a figure is an image service
- For external image services, check `src` for `info.json` 