### PR TITLE
Set default canvas-panel and image-responsive preset to 'responsive'

### DIFF
--- a/packages/11ty/_includes/components/figure/canvas-panel.js
+++ b/packages/11ty/_includes/components/figure/canvas-panel.js
@@ -19,7 +19,7 @@ module.exports = function(eleventyConfig) {
    * @return {String}        <canvas-panel> markup
    */
   return function(params) {
-    const { height='', id, iiif, preset='', region='', virtualSizes='', width='' } = params
+    const { height='', id, iiif, preset='responsive', region='', virtualSizes='', width='' } = params
     const { canvas, choiceId='', iiifContent='', manifest} = iiif
 
     if (!manifest && !iiifContent) {

--- a/packages/11ty/_includes/components/figure/image-service.js
+++ b/packages/11ty/_includes/components/figure/image-service.js
@@ -9,7 +9,7 @@ const { html } = require('~lib/common-tags')
  * @return     {String}  An <image-service> element
  */
 module.exports = function(eleventyConfig) {
-  return function({ alt='', height='', preset='', region='', iiif, virtualSizes='', width='' }) {
+  return function({ alt='', height='', preset='responsive', region='', iiif, virtualSizes='', width='' }) {
     return html`
       <image-service 
         alt="${alt}"

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -54,7 +54,7 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
-        <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.53"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
 
         ${webComponents()}
 

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -54,7 +54,7 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
-        <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.53"></script>
 
         ${webComponents()}
 

--- a/packages/11ty/content/_assets/styles/components/q-figure.scss
+++ b/packages/11ty/content/_assets/styles/components/q-figure.scss
@@ -18,6 +18,10 @@
 
 // .q-figure
 // -----------------------------------------------------------------------------
+.content .q-figure {
+  text-align: unset; // overwrite bulma
+}
+
 .q-figure {
   --atlas-z-index: 0;
 


### PR DESCRIPTION
Changes:
- Set default preset to `responsive`
- Update canvas-panel to 1.0.53 to include fix to `<image-service preset="responsive" />`
- Overwrite bulma styles messing with alignment of responsive canvas-panel images