### PR TITLE
Increment patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 * `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [0.20.4]
+### Fixed
+- Corrects broken build published to npm
+
+## [0.20.3]
+### Fixed
+- Vimeo `media_id` handling
+- Similar bibliography entries overwriting each other
+
+### Changed
+- Include current page in sidebar menu
+- Process markdown in page titles for `cite-this`
+- Run hugo with `--disableFastRender`
+
 ## [0.20.2]
 - Adds `disableFastRender` option to `quire preview` command
 - Adds `contents-list/file-dir` partial to normalize directories in `contents-list`

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "author": "Getty Digital",
   "license": "J Paul Getty Trust",
   "bugs": {


### PR DESCRIPTION
Increment version to fix broken version published to npm. `0.20.4` has already been published