### PR TITLE
DEV-12646: Ensure assets get written with same input directory structure; no hashed filenames

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -171,7 +171,7 @@ module.exports = function(eleventyConfig) {
             }
           }
         },
-        sourcemap: 'true'
+        sourcemap: true'
       },
       /**
        * Set to false to prevent Vite from clearing the terminal screen

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -147,15 +147,31 @@ module.exports = function(eleventyConfig) {
       /**
        * @see https://vitejs.dev/config/#build-options
        */
+      root: '_site',
       build: {
+        assetsDir: '_assets',
         manifest: true,
         mode: 'production',
+        outDir: '_site',
         rollupOptions: {
-          // plugins: [
-          //   scss() // @see https://github.com/thgh/rollup-plugin-scss
-          // ]
+          output: {
+            assetFileNames: ({ name }) => {
+              const fullFilePathSegments = name.split('/').slice(0, -1)
+              let filePath = '_assets/';
+              ['_assets', 'node_modules'].forEach((assetDir) => {
+                if (name.includes(assetDir)) {
+                  filePath +=
+                    fullFilePathSegments
+                      .slice(fullFilePathSegments.indexOf(assetDir) + 1)
+                      .join('/') +
+                    '/'
+                }
+              })
+              return `${filePath}[name][extname]`
+            }
+          }
         },
-        sourcemap: true
+        sourcemap: 'true'
       },
       /**
        * Set to false to prevent Vite from clearing the terminal screen
@@ -175,16 +191,16 @@ module.exports = function(eleventyConfig) {
     }
   })
 
+  // @see https://www.11ty.dev/docs/copy/#passthrough-during-serve
+  // @todo resolve error when set to the default behavior 'passthrough'
+  eleventyConfig.setServerPassthroughCopyBehavior('copy')
+
   /**
    * Copy static assets to the output directory
    * @see https://www.11ty.dev/docs/copy/
    */
   eleventyConfig.addPassthroughCopy('content/_assets')
   eleventyConfig.addPassthroughCopy('public')
-
-  // @see https://www.11ty.dev/docs/copy/#passthrough-during-serve
-  // @todo resolve error when set to the default behavior 'passthrough'
-  eleventyConfig.setServerPassthroughCopyBehavior('copy')
 
   /**
    * Watch the following additional files for changes and live browsersync

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -171,7 +171,7 @@ module.exports = function(eleventyConfig) {
             }
           }
         },
-        sourcemap: true'
+        sourcemap: true
       },
       /**
        * Set to false to prevent Vite from clearing the terminal screen


### PR DESCRIPTION
**Note:** The function passed to `assetFileNames` also bundles assets from `node_modules` into the static build (icon fonts)

Feels a bit hacky to have to manually recreate each asset input filename to preserve the directory structure, but I could not find any other way to do it. I looked into setting `rollupOptions.output.preserveModules` https://rollupjs.org/guide/en/#outputpreservemodules but it did not work for this issue; something else in the vite plugin's defaults was in conflict