### PR TITLE
Set input & output image formats in iiif config

### DIFF
--- a/packages/11ty/_plugins/iiif/config.js
+++ b/packages/11ty/_plugins/iiif/config.js
@@ -4,6 +4,20 @@ module.exports = (eleventyConfig) => {
   return {
     baseURL: eleventyConfig.globalData.config.baseURL || eleventyConfig.globalData.env.URL,
     /**
+     * Input and output of processable image formats
+     * @type {Array<Object>}
+     */
+    formats: [
+     {
+      input: ['.png', '.svg'],
+      output: '.png'
+     },
+     {
+      input: ['.jp2', '.jpg', '.jpeg', '.tif', '.tiff'],
+      output: '.jpg'
+     }
+    ],
+    /**
      * Transformations to apply to each image
      * Each item is output as a separate file
      *
@@ -42,19 +56,6 @@ module.exports = (eleventyConfig) => {
      */
     outputDir: 'iiif',
     outputRoot: 'public',
-    /**
-     * Image extensions that can be processed
-     * @type {Array}
-     */
-    supportedImageExtensions: [
-      '.jp2',
-      '.jpg',
-      '.jpeg',
-      '.png',
-      '.svg',
-      '.tif',
-      '.tiff'
-    ],
     tileSize: 256
   }
 }

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -10,7 +10,7 @@ const { info, error } = chalkFactory('plugins:iiif:createImage')
  * @return {Function}      createImage()
  */
 module.exports = (eleventyConfig) => {
-  const { inputDir, outputDir, outputRoot } = eleventyConfig.globalData.iiifConfig
+  const { formats, inputDir, outputDir, outputRoot } = eleventyConfig.globalData.iiifConfig
 
   /**
    * Creates an image in the output directory with the name `${name}${ext}`
@@ -24,8 +24,9 @@ module.exports = (eleventyConfig) => {
     const { debug, lazy } = options
 
     const { ext, name } = path.parse(filename)
+    const format = formats.find(({ input }) => input.includes(ext))
     const inputPath = path.join(inputDir, filename)
-    const outputPath = path.join(outputRoot, outputDir, name, `${transformation.name}${ext}`)
+    const outputPath = path.join(outputRoot, outputDir, name, `${transformation.name}${format.output}`)
 
     fs.ensureDirSync(path.parse(outputPath).dir)
 

--- a/packages/11ty/_plugins/iiif/process/tileImage.js
+++ b/packages/11ty/_plugins/iiif/process/tileImage.js
@@ -9,11 +9,11 @@ const sharp = require('sharp')
 module.exports = (eleventyConfig) => {
   const {
     baseURL,
+    formats,
     imageServiceDirectory,
     inputDir,
     outputDir,
     outputRoot,
-    supportedImageExtensions,
     tileSize
   } = eleventyConfig.globalData.iiifConfig
 
@@ -28,6 +28,8 @@ module.exports = (eleventyConfig) => {
     const { ext, name } = path.parse(filename)
     const inputPath = path.join(inputDir, filename)
     const outputPath = path.join(outputRoot, outputDir, name, imageServiceDirectory)
+    const format = formats.find(({ input }) => input.includes(ext))
+    const supportedImageExtensions = formats.flatMap(( { input }) => input)
 
     if (!supportedImageExtensions.includes(ext)) {
       if (debug) {
@@ -52,6 +54,7 @@ module.exports = (eleventyConfig) => {
         console.log(`tileImage`, inputPath)
       }
       return await sharp(inputPath)
+        .toFormat(format.output.replace('.', ''))
         .tile({
           id: iiifId,
           layout: 'iiif',


### PR DESCRIPTION
Changes:
- Specify input/output types in `iiif/config.js` and process using `toFormat` sharp method