### PR TITLE
DEV-12653: Exclude CSS animations from print media

### DIFF
--- a/packages/11ty/content/_assets/styles/components/quire-citation.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-citation.scss
@@ -69,7 +69,7 @@
     -webkit-box-shadow: 0px 0px 6px 0px $black-semi-transparent;
     -moz-box-shadow: 0px 0px 6px 0px $black-semi-transparent;
     box-shadow: 0px 0px 6px 0px $black-semi-transparent;
-    animation: .25s ease-out 0s 1 fadeIn;
+    @include animation(.25s ease-out 0s 1 fadeIn);
     @media screen and (max-width: $desktop) {
       width: 200px;
       right: 0;

--- a/packages/11ty/content/_assets/styles/components/quire-entry.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-entry.scss
@@ -529,14 +529,14 @@ $image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAABYCAQAAACjBqE3AA
     // }
 
     position: relative;
-    animation: 0.5s ease 0s 1 slideFromRight;
+    @include animation(0.5s ease 0s 1 slideFromRight);
 
     @media screen and (max-width: $tablet) {
       margin-top: -1em;
     }
 
     .quire-page__content {
-      animation: none;
+      @include animation(none);
       .content {
         @media print {
           padding: 0;

--- a/packages/11ty/content/_assets/styles/components/quire-navbar.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-navbar.scss
@@ -82,7 +82,7 @@
     text-align: right;
     padding-right: .5em;
     position: relative;
-    animation: .5s ease-out 0s 1 slideFromLeft;
+    @include animation(.5s ease-out 0s 1 slideFromLeft);
   }
 }
 

--- a/packages/11ty/content/_assets/styles/components/quire-page.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-page.scss
@@ -138,7 +138,7 @@ html {
     padding-top: 0;
     padding-bottom: 0;
     position: relative;
-    animation: 0.5s ease 0s 1 slideFromRight;
+    @include animation(0.5s ease 0s 1 slideFromRight);
     color: background-color-text-classic($content-background-color);
     @media print {
       color: $print-text-color;
@@ -512,15 +512,7 @@ html {
   background-repeat: no-repeat;
   background-position: cover;
   text-align: center;
-  -webkit-animation: fadeIn 2s;
-  /* Safari, Chrome and Opera > 12.1 */
-  -moz-animation: fadeIn 2s;
-  /* Firefox < 16 */
-  -ms-animation: fadeIn 2s;
-  /* Internet Explorer */
-  -o-animation: fadeIn 2s;
-  /* Opera < 12.1 */
-  animation: fadeIn 2s;
+  @include animation(fadeIn 2s);
 
   @media print {
     background-color: transparent;

--- a/packages/11ty/content/_assets/styles/layout.scss
+++ b/packages/11ty/content/_assets/styles/layout.scss
@@ -24,10 +24,12 @@
 
 // .quire
 // -----------------------------------------------------------------------------
+
 [hidden] {
   display: none;
-  animation: 0.25s ease-out 0s 1 fadeOut !important;
+  @include animation(0.25s ease-out 0s 1 fadeOut !important);
 }
+
 .quire {
   width: 100%;
 

--- a/packages/11ty/content/_assets/styles/utilities.scss
+++ b/packages/11ty/content/_assets/styles/utilities.scss
@@ -5,6 +5,20 @@
 // Mixins
 // -----------------------------------------------------------------------------
 // Adjust foreground colors based on an element's background
+@mixin animation($animationProperties) {
+  @media screen {
+    /* Safari, Chrome and Opera > 12.1 */
+    -webkit-animation: $animationProperties;
+    /* Firefox < 16 */
+    -moz-animation: $animationProperties;
+    /* Internet Explorer */
+    -ms-animation: $animationProperties;
+    /* Opera < 12.1 */
+    -o-animation: $animationProperties;
+    animation: $animationProperties;
+  }
+}
+
 @mixin foreground-color($bgcolor, $frcolor) {
   * {
     color: $frcolor;


### PR DESCRIPTION
- Implement `animation` sass mixin to wrap all animations in a `@media screen` query
- Replace all instances of `animation: ...` with `@include animation(...)`
