### PR TITLE
DEV-12753: Improve `chalk` warning/error legibility

### DIFF
--- a/packages/11ty/_lib/chalk/index.js
+++ b/packages/11ty/_lib/chalk/index.js
@@ -12,9 +12,9 @@ module.exports = function (prefix='') {
    * @see https://github.com/chalk/chalk/tree/v4.1.2#usage
    */
   const styles = {
-    error: chalk.bold.red,
+    error: chalk.inverse.redBright,
     info: chalk.magenta,
-    warn: chalk.bold.keyword('yellow')
+    warn: chalk.inverse.yellow
   }
 
   const logFn = (type) => {


### PR DESCRIPTION
I put warnings on yellow background, inverted text and errors on bright red background, inverted text. Seems to work well in a variety of terminals (slightly less good if it is red, but that seems like not our problem):
<img width="1611" alt="Screen Shot 2022-07-19 at 7 30 03 PM" src="https://user-images.githubusercontent.com/7109269/179883719-b99ac4c5-5c72-4013-bf47-86eeddb648c2.png">
<img width="682" alt="Screen Shot 2022-07-19 at 7 37 49 PM" src="https://user-images.githubusercontent.com/7109269/179884117-3d335ff4-30b6-4edf-a474-6382bf1091fc.png">

