### PR TITLE
Refactor: page classes & main element

### DIFF
--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -21,9 +21,10 @@ module.exports = function(data) {
           <div class="quire no-js" id="container">
             <div
               aria-expanded="false"
-              class="quire__secondary remove-from-epub"
+              class="quire__secondary"
               id="site-menu"
               role="contentinfo"
+              data-outputs-exclude="epub,pdf"
             >
               ${this.menu({ collections, pageData })}
             </div>

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -7,8 +7,10 @@ const { html } = require('~lib/common-tags')
  * @return     {Function}  Template render function
  */
 module.exports = function(data) {
-  const { collections, content, pageData, publication } = data
+  const { class: classes, collections, content, pageData, publication } = data
   const { outputPath } = pageData || {}
+
+  let pageClasses = Array.isArray(classes) ? classes : [classes]
 
   return this.renderTemplate(
     html`
@@ -21,18 +23,17 @@ module.exports = function(data) {
           <div class="quire no-js" id="container">
             <div
               aria-expanded="false"
-              class="quire__secondary"
+              class="quire__secondary remove-from-epub"
               id="site-menu"
               role="contentinfo"
-              data-outputs-exclude="epub,pdf"
             >
               ${this.menu({ collections, pageData })}
             </div>
             <div class="quire__primary" id="{{ section }}">
               ${this.navigation(data)}
-              <section data-output-path="${outputPath}">
+              <main id="main" class="quire-page ${pageClasses}" data-output-path="${outputPath}">
                 ${content}
-              </section>
+              </main>
             </div>
             {% render 'search' %}
           </div>

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -7,10 +7,14 @@ const { html } = require('~lib/common-tags')
  * @return     {Function}  Template render function
  */
 module.exports = function(data) {
-  const { class: classes, collections, content, pageData, publication } = data
+  const { classes, collections, content, pageData, publication } = data
   const { outputPath } = pageData || {}
 
-  let pageClasses = Array.isArray(classes) ? classes : [classes]
+  const pageIndex = collections.allSorted
+    .findIndex(({ outputPath: x }) => x === outputPath)
+  const pageOneIndex = collections.allSorted
+    .findIndex(({ data }) => data.classes.includes('page-one'))
+  const pageClasses = pageIndex < pageOneIndex ? classes.concat('frontmatter') : classes
 
   return this.renderTemplate(
     html`

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -7,14 +7,8 @@ const { html } = require('~lib/common-tags')
  * @return     {Function}  Template render function
  */
 module.exports = function(data) {
-  const { classes, collections, content, pageData, publication } = data
+  const { pageClasses, collections, content, pageData, publication } = data
   const { outputPath } = pageData || {}
-
-  const pageIndex = collections.allSorted
-    .findIndex(({ outputPath: x }) => x === outputPath)
-  const pageOneIndex = collections.allSorted
-    .findIndex(({ data }) => data.classes.includes('page-one'))
-  const pageClasses = pageIndex < pageOneIndex ? classes.concat('frontmatter') : classes
 
   return this.renderTemplate(
     html`

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -1,4 +1,5 @@
 ---
+class: quire-cover
 description: Quire publication cover page
 layout: base.11ty.js
 ---
@@ -6,59 +7,55 @@ layout: base.11ty.js
 {% assign coverImage = image || publication.promo_image %}
 {% assign imagePath = config.params.imageDir | concat: coverImage | join: '/' %}
 
-<div id="main" class="quire-cover" role="main">
+<section class="quire-cover__hero hero is-fullheight">
+  <div
+    class="quire-cover__overlay"
+    style="background-image: url('{{ imagePath }}');"
+  />
+  <div class="quire-cover__hero-body hero-body">
+    <div class="container is-fluid">
+      <h1 class="title">
+        {{ publication.title | markdownify }}
+        {% if publication.subtitle %}
+          <span class="visually-hidden">: </span>
+          <span class="subtitle">{{ publication.subtitle | markdownify }}</span>
+        {% endif %}
+      </h1>
+      <p class="reading-line">{{ publication.reading_line | markdownify }}</p>
+      <div class="contributor">
+        <span class="visually-hidden">Contributors:&nbsp;</span>
+        <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
+      </div>
+    </div>
+  </div>
+</section>
 
-  <section class="quire-cover__hero hero is-fullheight">
-    <div
-      class="quire-cover__overlay"
-      style="background-image: url('{{ imagePath }}');"
-    />
-    <div class="quire-cover__hero-body hero-body">
-      <div class="container is-fluid">
-        <h1 class="title">
-          {{ publication.title | markdownify }}
-          {% if publication.subtitle %}
-            <span class="visually-hidden">: </span>
-            <span class="subtitle">{{ publication.subtitle | markdownify }}</span>
-          {% endif %}
-        </h1>
-        <p class="reading-line">{{ publication.reading_line | markdownify }}</p>
-        <div class="contributor">
-          <span class="visually-hidden">Contributors:&nbsp;</span>
-          <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
-        </div>
+{% if content != blank %}
+  <section class="quire-cover__more next-page">
+    <div class="quire-cover__more-body hero-more">
+      <a href="#content">
+        {% icon type='down-arrow', description='Scroll down to read more' %}
+      </a>
+    </div>
+  </section>
+
+  <section id="content" class="section quire-page__content">
+    <div class="container is-fluid">
+      <div class="content">
+        {{ content }}
+        {% bibliography pageReferences %}
       </div>
     </div>
   </section>
 
-  {% if content != blank %}
-    <section class="quire-cover__more next-page">
-      <div class="quire-cover__more-body hero-more">
-        <a href="#content">
-          {% icon type='down-arrow', description='Scroll down to read more' %}
-        </a>
-      </div>
-    </section>
+  {% pageButtons pagination=pagination %}
 
-    <section id="content" class="section quire-page__content">
-      <div class="container is-fluid">
-        <div class="content">
-          {{ content }}
-          {% bibliography pageReferences %}
-        </div>
-      </div>
-    </section>
-
-    {% pageButtons pagination=pagination %}
-
-  {% else %}
-    <section class="quire-cover__more">
-      <div class="quire-cover__more-body hero-more next-page">
-        <a href="{{ pagination.nextPage.url }}">
-          {% icon type='down-arrow', description='Scroll down to read more' %}
-        </a>
-      </div>
-    </section>
-  {% endif %}
-
-</div>
+{% else %}
+  <section class="quire-cover__more">
+    <div class="quire-cover__more-body hero-more next-page">
+      <a href="{{ pagination.nextPage.url }}">
+        {% icon type='down-arrow', description='Scroll down to read more' %}
+      </a>
+    </div>
+  </section>
+{% endif %}

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -1,4 +1,5 @@
 ---
+class: quire-entry
 layout: base.11ty.js
 description: Entry layout. This template is intended for use in catalogue-style pages where a single image or object needs to be featured prominently.
 ---
@@ -13,67 +14,65 @@ description: Entry layout. This template is intended for use in catalogue-style 
 Entry content, including entry image and tombstone data
 {% endcomment %}
 
-<article class="quire-entry" id="main" role="main">
-  <div {% if entryPageSideBySideLayout == true or presentation == 'side-by-side' and pdf != true and epub != true %} class="side-by-side" {% endif %} data="{{ zoom }}">
+<div {% if entryPageSideBySideLayout == true or presentation == 'side-by-side' and pdf != true and epub != true %} class="side-by-side" {% endif %} data="{{ zoom }}">
 
-    {% if epub == true %}
-    <header class="quire-entry__header">
-      <div class="container">
-          {% comment %} Title {% endcomment %}
-          <h1 class="quire-page__header__title" id="{{ title | slugify }}">
-            {% pageTitle label=label, title=title, subtitle=subtitle %}
-          </h1>
-      </div>
-    </header>
-    {% endif %}
-
-    {% comment %} Full-width entry image header {% endcomment %}
-    <div class="quire-entry__image-wrap">
-      <div class="quire-entry__lightbox">
-        {% if image %}
-          {% comment %} TODO add `lightbox` when a single `image` is included in front matter {% endcomment %}
-        {% elsif pageObjects %}
-          {% for object in pageObjects %}
-            {% lightbox object.figures %}
-          {% endfor %}
-        {% endif %}
-      </div>
+  {% if epub == true %}
+  <header class="quire-entry__header">
+    <div class="container">
+        {% comment %} Title {% endcomment %}
+        <h1 class="quire-page__header__title" id="{{ title | slugify }}">
+          {% pageTitle label=label, title=title, subtitle=subtitle %}
+        </h1>
     </div>
+  </header>
+  {% endif %}
 
-    <div class="quire-entry__content">
-      {% if epub != true %}
-        <header class="quire-entry__header">
-          <div class="container">
-            <h1 class="quire-page__header__title" id="{{ title | url }}">
-              {% pageTitle label=label, title=title, subtitle=subtitle %}
-            </h1>
-            <div class="quire-page__header__contributor">
-              {% contributors context=pageContributors, format=contributor_byline %}
-            </div>
-          </div>
-        </header>
+  {% comment %} Full-width entry image header {% endcomment %}
+  <div class="quire-entry__image-wrap">
+    <div class="quire-entry__lightbox">
+      {% if image %}
+        {% comment %} TODO add `lightbox` when a single `image` is included in front matter {% endcomment %}
+      {% elsif pageObjects %}
+        {% for object in pageObjects %}
+          {% lightbox object.figures %}
+        {% endfor %}
       {% endif %}
-
-      {% tombstone pageObjects %}
-
-      {% if abstract %}
-        {% abstract abstract=abstract %}
-      {% endif %}
-
-      <section class="section quire-page__content" id="content">
-        <div class="container">
-          <div class="content">
-            {{ content }}
-            {% bibliography pageReferences %}
-          </div>
-        </div>
-      </section>
-
-      <section class="section quire-page__content">
-        <div class="container">
-          {% pageButtons pagination=pagination %}
-        </div>
-      </section>
     </div>
   </div>
-</article>
+
+  <div class="quire-entry__content">
+    {% if epub != true %}
+      <header class="quire-entry__header">
+        <div class="container">
+          <h1 class="quire-page__header__title" id="{{ title | url }}">
+            {% pageTitle label=label, title=title, subtitle=subtitle %}
+          </h1>
+          <div class="quire-page__header__contributor">
+            {% contributors context=pageContributors, format=contributor_byline %}
+          </div>
+        </div>
+      </header>
+    {% endif %}
+
+    {% tombstone pageObjects %}
+
+    {% if abstract %}
+      {% abstract abstract=abstract %}
+    {% endif %}
+
+    <section class="section quire-page__content" id="content">
+      <div class="container">
+        <div class="content">
+          {{ content }}
+          {% bibliography pageReferences %}
+        </div>
+      </div>
+    </section>
+
+    <section class="section quire-page__content">
+      <div class="container">
+        {% pageButtons pagination=pagination %}
+      </div>
+    </section>
+  </div>
+</div>

--- a/packages/11ty/_layouts/essay.liquid
+++ b/packages/11ty/_layouts/essay.liquid
@@ -1,27 +1,27 @@
 ---
+class: quire-essay
 layout: base.11ty.js
 description: Essay layout. This layout describes a single-page template that has been augmented with the ability to display a frontmatter-defined abstract (in markdown format) as well as bibliography references.
 ---
-<article class="quire-essay" id="main" role="main">
-  {% pageHeader
-    contributor_byline=contributor_byline,
-    image=image,
-    label=label,
-    pageContributors=pageContributors,
-    subtitle=subtitle,
-    title=title
-  %}
 
-  <section id="content" class="section quire-page__content">
-    {% if abstract %}
-      {% abstract abstract=abstract %}
-    {% endif %}
-    <div class="container">
-      <div class="content">
-        {{ content }}
-        {% bibliography pageReferences %}
-      </div>
-      {% pageButtons pagination=pagination %}
+{% pageHeader
+  contributor_byline=contributor_byline,
+  image=image,
+  label=label,
+  pageContributors=pageContributors,
+  subtitle=subtitle,
+  title=title
+%}
+
+<section id="content" class="section quire-page__content">
+  {% if abstract %}
+    {% abstract abstract=abstract %}
+  {% endif %}
+  <div class="container">
+    <div class="content">
+      {{ content }}
+      {% bibliography pageReferences %}
     </div>
-  </section>
-</article>
+    {% pageButtons pagination=pagination %}
+  </div>
+</section>

--- a/packages/11ty/_layouts/page.liquid
+++ b/packages/11ty/_layouts/page.liquid
@@ -1,30 +1,29 @@
 ---
+class: quire-page
 layout: base.11ty.js
 description: Single page default template
 ---
 
-<article class="quire-page" id="main" role="main">
-  {% pageHeader
-    contributor_byline=contributor_byline,
-    image=image,
-    label=label,
-    pageContributors=pageContributors,
-    subtitle=subtitle,
-    title=title
-  %}
-  {% if content %}
-  <section class="section quire-page__content" id="content">
-    <div class="container">
-      <div class="content">
-        {{ content }}
-        {% bibliography pageReferences %}
-      </div>
+{% pageHeader
+  contributor_byline=contributor_byline,
+  image=image,
+  label=label,
+  pageContributors=pageContributors,
+  subtitle=subtitle,
+  title=title
+%}
+{% if content %}
+<section class="section quire-page__content" id="content">
+  <div class="container">
+    <div class="content">
+      {{ content }}
+      {% bibliography pageReferences %}
     </div>
-  </section>
-  {% endif %}
-  <section class="section quire-page__content">
-    <div class="container">
-      {% pageButtons pagination=pagination %}
-    </div>
-  </section>
-</article>
+  </div>
+</section>
+{% endif %}
+<section class="section quire-page__content">
+  <div class="container">
+    {% pageButtons pagination=pagination %}
+  </div>
+</section>

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -1,4 +1,5 @@
 ---
+class: quire-splash
 layout: base
 description: splash page layout
 ---
@@ -6,37 +7,35 @@ description: splash page layout
   {% assign imagePath = config.params.imageDir | append: '/' | append: image %}
 {% endif %}
 
-<article class="quire-splash" id="main" role="main">
-  <section class="{% if title == "title page" or title == "half title page" %} is-screen-only {% endif %} quire-page__header hero {% if content %}{% else %}quire-page__header--full-height{% endif %} {% if image %}hero-image{% endif %}" {% if image %}style="background-image: url('{{ imagePath }}');"{% endif %}>
-    <div class="hero-body">
-      <h1 class="quire-page__header__title" id="{{ title | slugify }}">
-        {% if label %}<span class="label">{{ label }}<span class="visually-hidden">{{ config.params.pageLabelDivider }}</span></span>{% endif %}
-        {%- pageTitle title=title, subtitle=subtitle -%}
-      </h1>
-      {% if pageContributors %}
-        <div class="quire-page__header__contributor">
-          {% contributors context=pageContributors, format=contributor_byline %}
-        </div>
-      {% endif %}
+<section class="{% if title == "title page" or title == "half title page" %} is-screen-only {% endif %} quire-page__header hero {% if content %}{% else %}quire-page__header--full-height{% endif %} {% if image %}hero-image{% endif %}" {% if image %}style="background-image: url('{{ imagePath }}');"{% endif %}>
+  <div class="hero-body">
+    <h1 class="quire-page__header__title" id="{{ title | slugify }}">
+      {% if label %}<span class="label">{{ label }}<span class="visually-hidden">{{ config.params.pageLabelDivider }}</span></span>{% endif %}
+      {%- pageTitle title=title, subtitle=subtitle -%}
+    </h1>
+    {% if pageContributors %}
+      <div class="quire-page__header__contributor">
+        {% contributors context=pageContributors, format=contributor_byline %}
+      </div>
+    {% endif %}
+  </div>
+</section>
+
+{% if content %}
+  <section id="content" class="section quire-page__content">
+    {% if abstract %}
+      {% abstract abstract=abstract %}
+    {% endif %}
+    <div class="container">
+      <div class="content{% if image %}{% else %} no-image-above{% endif %}">
+        {{ content }}
+        {% bibliography pageReferences %}
+      </div>
+      {% pageButtons pagination=pagination %}
     </div>
   </section>
-  
-  {% if content %}
-    <section id="content" class="section quire-page__content">
-      {% if abstract %}
-        {% abstract abstract=abstract %}
-      {% endif %}
-      <div class="container">
-        <div class="content{% if image %}{% else %} no-image-above{% endif %}">
-          {{ content }}
-          {% bibliography pageReferences %}
-        </div>
-        {% pageButtons pagination=pagination %}
-      </div>
-    </section>
-  {% else %}
-    <div class="quire-contents-buttons--fixed" data-outputs-exclude="epub,pdf">
-    {% pageButtons pagination=pagination %}
-    </div>
-  {% endif %}
-</article>
+{% else %}
+  <div class="quire-contents-buttons--fixed" data-outputs-exclude="epub,pdf">
+  {% pageButtons pagination=pagination %}
+  </div>
+{% endif %}

--- a/packages/11ty/_layouts/table-of-contents.11ty.js
+++ b/packages/11ty/_layouts/table-of-contents.11ty.js
@@ -9,6 +9,7 @@
 module.exports = class TableOfContents {
   data() {
     return {
+      class: 'quire-contents',
       layout: 'base'
     }
   }
@@ -53,28 +54,26 @@ module.exports = class TableOfContents {
       : this.eleventyNavigation(collections.tableOfContents)
 
     return this.renderTemplate(
-      `<div class="quire-contents" id="main" role="main">
-        {% pageHeader
-          contributor_byline=contributor_byline,
-          image=image,
-          label=label,
-          pageContributors=pageContributors,
-          subtitle=subtitle,
-          title=title
-        %}
-        <section class="section quire-page__content" id="content">
-          ${contentElement}
-          <div class="container ${containerClass}">
-            <div class="quire-contents-list ${presentation}">
-              ${this.tableOfContentsList({ navigation, presentation, currentPageUrl: pagination.currentPage.url })}
-              <div class="content">
-                {% bibliography pageReferences %}
-              </div>
+      `{% pageHeader
+        contributor_byline=contributor_byline,
+        image=image,
+        label=label,
+        pageContributors=pageContributors,
+        subtitle=subtitle,
+        title=title
+      %}
+      <section class="section quire-page__content" id="content">
+        ${contentElement}
+        <div class="container ${containerClass}">
+          <div class="quire-contents-list ${presentation}">
+            ${this.tableOfContentsList({ navigation, presentation, currentPageUrl: pagination.currentPage.url })}
+            <div class="content">
+              {% bibliography pageReferences %}
             </div>
-            ${this.pageButtons({ pagination })}
           </div>
-        </section>
-      </div>`,
+          ${this.pageButtons({ pagination })}
+        </div>
+      </section>`,
       'liquid',
       data
     )

--- a/packages/11ty/_plugins/collections/index.js
+++ b/packages/11ty/_plugins/collections/index.js
@@ -16,6 +16,13 @@ module.exports = function (eleventyConfig, options = {}) {
   let collections = {}
 
   /**
+   * Add sorted "all" collection
+   */
+  eleventyConfig.addCollection('allSorted', function (collectionApi) {
+    return collectionApi.getAll().sort(sortCollection)
+  })
+
+  /**
    * Add eleventy-generated collections to collections object
    */
   eleventyConfig.addCollection('temp', function (collectionApi) {

--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -4,16 +4,6 @@ const filterOutputs = require('../filter.js')
 const writeOutput = require('./write')
 
 /**
- * Get the page `section` element
- * @param  {String} content Page HTML
- * @return {Object}
- */
-const getSectionElement = (content) => {
-  const { document } = new JSDOM(content).window
-  return document.querySelector('section[data-output-path]')
-}
-
-/**
  * Transform relative links to anchor links
  *
  * @param      {HTMLElement}  element
@@ -39,11 +29,16 @@ module.exports = function(eleventyConfig, collections, content) {
 
   if (pdfPages.includes(this.outputPath)) {
     const pageIndex = pdfPages.findIndex((path) => path === this.outputPath)
-    const sectionElement = getSectionElement(content)
+    const { document } = new JSDOM(content).window
+    const mainElement = document.querySelector('main[data-output-path]')
 
-    if (sectionElement) {
+    if (mainElement) {
       if (pageIndex !== -1) {
-        delete sectionElement.dataset.outputPath
+        const sectionElement = document.createElement('section')
+        sectionElement.innerHTML = mainElement.innerHTML
+        for (className of mainElement.classList) {
+          sectionElement.classList.add(className)
+        }
 
         const pageLabelDivider = eleventyConfig.globalData.config.params
         const { label, title } = collections.pdf[pageIndex].data

--- a/packages/11ty/content/_assets/styles/components/quire-page.scss
+++ b/packages/11ty/content/_assets/styles/components/quire-page.scss
@@ -491,7 +491,7 @@ html {
     }
   }
 
-  &--frontmatter {
+  &.frontmatter {
     @media print {
       background-color: transparent;
     }

--- a/packages/11ty/content/_assets/styles/print.scss
+++ b/packages/11ty/content/_assets/styles/print.scss
@@ -216,18 +216,18 @@ $print-trim: $print-bleed * 2;
 
 // Assigning page types
 // -----------------------------------------------------------------------------
-  .quire-page--page-one {
+  .page-one {
     page: page-one;
     counter-reset: page 1;
     page-break-before: right;
   }
 
-  .quire-page--frontmatter {
+  .frontmatter {
     page: frontmatter;
   }
   
-  #half-title .quire-page--frontmatter,
-  #title .quire-page--frontmatter {
+  #half-title .frontmatter,
+  #title .frontmatter {
     page: no-footer;
   }
   
@@ -246,7 +246,7 @@ $print-trim: $print-bleed * 2;
     }
   }
   
-  .quire-splash.quire-page--frontmatter {
+  .quire-splash.frontmatter {
     page: frontmatter-splash;
   }
 

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -8,13 +8,6 @@ const { warn } = chalkFactory('eleventyComputed')
  */
 module.exports = {
   canonicalURL: ({ config, page }) => page.url && path.join(config.baseURL, page.url),
-  /**
-   * Frontmatter `class` property, normalized to an array
-   */
-  classes: ({ class: classes }) => {
-    if (!classes) return []
-    return Array.isArray(classes) ? classes : [classes]
-  },
   eleventyNavigation: {
     /**
      * Explicitly define page data properties used in the TOC
@@ -51,6 +44,20 @@ module.exports = {
     },
     url: (data) => data.page.url,
     title: (data) => data.title
+  },
+  /**
+   * Classes applied to <main> page element
+   */
+  pageClasses: ({ collections, class: classes, layout, page }) => {
+    const pageClasses = []
+    // Add computed frontmatter and page-one classes
+    const pageIndex = collections.allSorted.findIndex(({ outputPath }) => outputPath === page.outputPath)
+    const pageOneIndex = collections.allSorted.findIndex(({ data }) => data.class && data.class.includes('page-one'))
+    if (pageIndex < pageOneIndex) {
+      pageClasses.push('frontmatter')
+    }
+    // add custom classes from page frontmatter
+    return classes ? pageClasses.concat(classes) : pageClasses
   },
   pageContributors: ({ contributor, contributor_as_it_appears }) => {
     if (!contributor) return

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -8,6 +8,13 @@ const { warn } = chalkFactory('eleventyComputed')
  */
 module.exports = {
   canonicalURL: ({ config, page }) => page.url && path.join(config.baseURL, page.url),
+  /**
+   * Frontmatter `class` property, normalized to an array
+   */
+  classes: ({ class: classes }) => {
+    if (!classes) return []
+    return Array.isArray(classes) ? classes : [classes]
+  },
   eleventyNavigation: {
     /**
      * Explicitly define page data properties used in the TOC

--- a/packages/11ty/content/essay.md
+++ b/packages/11ty/content/essay.md
@@ -1,4 +1,5 @@
 ---
+class: page-one
 label: I
 title: American Photographs
 subtitle: Evans in Middletown


### PR DESCRIPTION
Changes:
- Moves `<main>` element into `base` layout
- Add page classes to frontmatter `class` property, which will be applied to `<main>` in the `base` layout
- Replaces `main` with `section` tag for pdf output

Fixes:
- Defining page classes in frontmatter
- Adds `page-one` and `frontmatter` (the other kind of frontmatter) classes to correct pages
- Redundant wrapper `section` tag on pages in pdf output

Note: the liquid layout diffs look more diff-ed than they are, I just removed the wrapper element and moved the page class into the frontmatter