### PR TITLE
DEV-12785: Ensure modal link wraps image no matter if `figureLabelLocation` is `below` or `on-top`

### DIFF
--- a/packages/11ty/_includes/components/figure/image.js
+++ b/packages/11ty/_includes/components/figure/image.js
@@ -52,13 +52,14 @@ module.exports = function(eleventyConfig) {
      * Wrap image in modal link
      */
     imageElement =
-      (figureLabelLocation === 'on-top')
-        ? figuremodallink({ caption, content: imageElement + labelElement, id })
-        : figuremodallink({ content: imageElement, id })
+      (figureLabelLocation === 'below')
+        ? figuremodallink({ content: imageElement, id })
+        : figuremodallink({ caption, content: imageElement + labelElement, id })
 
-    const captionElement = (figureLabelLocation === 'below')
-      ? figurecaption({ caption, content: labelElement, credit })
-      : figurecaption({ caption, credit })
+    const captionElement =
+      (figureLabelLocation === 'below')
+        ? figurecaption({ caption, content: labelElement, credit })
+        : figurecaption({ caption, credit })
 
     return html`
       ${imageElement}

--- a/packages/11ty/_includes/components/figure/image.js
+++ b/packages/11ty/_includes/components/figure/image.js
@@ -54,7 +54,7 @@ module.exports = function(eleventyConfig) {
     imageElement =
       (figureLabelLocation === 'on-top')
         ? figuremodallink({ caption, content: imageElement + labelElement, id })
-        : imageElement
+        : figuremodallink({ content: imageElement, id })
 
     const captionElement = (figureLabelLocation === 'below')
       ? figurecaption({ caption, content: labelElement, credit })

--- a/packages/11ty/_includes/components/figure/label.js
+++ b/packages/11ty/_includes/components/figure/label.js
@@ -21,9 +21,7 @@ module.exports = function(eleventyConfig) {
     } else {
       const modifier = figureLabelLocation || ''
 
-      let content = figureLabelLocation === 'on-top'
-      ? `<span class="q-figure__label-icon">${icon({ type: 'fullscreen', description: 'Expand' })}</span>`
-      : ''
+      let content = `<span class="q-figure__label-icon">${icon({ type: 'fullscreen', description: 'Expand' })}</span>`
       content += `<span class="q-figure__label-text">${markdownify(label || '')}</span>`
 
       content = modifier === 'below' ? modalLink({ caption, content, id }) : content

--- a/packages/11ty/_includes/components/figure/label.js
+++ b/packages/11ty/_includes/components/figure/label.js
@@ -24,7 +24,10 @@ module.exports = function(eleventyConfig) {
       let content = `<span class="q-figure__label-icon">${icon({ type: 'fullscreen', description: 'Expand' })}</span>`
       content += `<span class="q-figure__label-text">${markdownify(label || '')}</span>`
 
-      content = modifier === 'below' ? modalLink({ caption, content, id }) : content
+      content =
+        (modifier === 'below')
+          ? modalLink({ caption, content, id })
+          : content
 
       labelElement = `<span class="q-figure__label q-figure__label--${modifier}">
         ${content}

--- a/packages/11ty/_includes/components/figure/modal-link.js
+++ b/packages/11ty/_includes/components/figure/modal-link.js
@@ -1,23 +1,14 @@
 const { html } = require('~lib/common-tags')
 
 module.exports = function (eleventyConfig) {
-  const icon = eleventyConfig.getFilter('icon')
-  const markdownify = eleventyConfig.getFilter('markdownify')
+  const { figureModal } = eleventyConfig.globalData.config.params
 
-  const { figureLabelLocation, figureModal } = eleventyConfig.globalData.config.params
-
-  return function({ caption, content, id }) {
-
-    const iconElement = figureLabelLocation === 'below'
-      ? icon({ type: 'fullscreen', description: 'Expand' })
-      : ''
-
+  return function({ content, id }) {
     return figureModal
       ? html`<a
           href="#${id}"
           class="q-figure__modal-link"
         >
-          <span class="q-figure__label-icon">${iconElement}</span>
           ${content}
         </a>`
       : content


### PR DESCRIPTION
display of `fullscreen` icon is now the concern of `figure/label.js`