### PR TITLE
Feature: Figure UIDs

### DIFF
--- a/packages/11ty/_includes/components/figure/image.js
+++ b/packages/11ty/_includes/components/figure/image.js
@@ -26,11 +26,11 @@ module.exports = function(eleventyConfig) {
       alt='', 
       caption,
       credit,
-      id,
       label,
-      src='' 
+      src='',
+      uid
     } = figure
-    const labelElement = figurelabel({ caption, id, label })
+    const labelElement = figurelabel({ caption, uid, label })
 
     let choicesElement='', imageElement;
 
@@ -53,8 +53,8 @@ module.exports = function(eleventyConfig) {
      */
     imageElement =
       (figureLabelLocation === 'below')
-        ? figuremodallink({ content: imageElement, id })
-        : figuremodallink({ caption, content: imageElement + labelElement, id })
+        ? figuremodallink({ content: imageElement, uid })
+        : figuremodallink({ caption, content: imageElement + labelElement, uid })
 
     const captionElement =
       (figureLabelLocation === 'below')

--- a/packages/11ty/_includes/components/figure/label.js
+++ b/packages/11ty/_includes/components/figure/label.js
@@ -13,7 +13,7 @@ module.exports = function(eleventyConfig) {
   const { epub } = eleventyConfig.globalData.config
   const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
-  return function({ caption, id, label }) {
+  return function({ caption, uid, label }) {
     let labelElement
 
     if (epub) {
@@ -26,7 +26,7 @@ module.exports = function(eleventyConfig) {
 
       content =
         (modifier === 'below')
-          ? modalLink({ caption, content, id })
+          ? modalLink({ caption, content, uid })
           : content
 
       labelElement = `<span class="q-figure__label q-figure__label--${modifier}">

--- a/packages/11ty/_includes/components/figure/modal-link.js
+++ b/packages/11ty/_includes/components/figure/modal-link.js
@@ -3,10 +3,10 @@ const { html } = require('~lib/common-tags')
 module.exports = function (eleventyConfig) {
   const { figureModal } = eleventyConfig.globalData.config.params
 
-  return function({ content, id }) {
+  return function({ content, uid }) {
     return figureModal
       ? html`<a
-          href="#${id}"
+          href="#${uid}"
           class="q-figure__modal-link"
         >
           ${content}

--- a/packages/11ty/_lib/uid/index.js
+++ b/packages/11ty/_lib/uid/index.js
@@ -1,0 +1,38 @@
+function* UidGenerator() {
+  let i = 0
+  while (true) yield i++
+}
+const generator = UidGenerator()
+const uid = () => generator.next().value
+
+/**
+ * Adds a `uid` property to all objects containing an `id` property
+ * @param {Object|Array} data
+ */
+const addUids = function(data) {
+  if (!data) return
+  if (data.hasOwnProperty('id')) {
+    data.uid = `uid-${uid()}`
+    return data
+  }
+  switch (true) {
+    case Array.isArray(data):
+      data.forEach((item, index) => {
+        data[index] = addUids(item)
+      })
+      break;
+    case typeof data === 'object':
+      Object.keys(data).forEach((key) => {
+        data[key] = addUids(data[key])
+      })
+      break;
+    default:
+      break;
+  }
+  return data;
+}
+
+module.exports = {
+  addUids,
+  uid
+}

--- a/packages/11ty/_plugins/filters/getFigure.js
+++ b/packages/11ty/_plugins/filters/getFigure.js
@@ -5,6 +5,7 @@
  * @return {Object}                figure
  */
 module.exports = function(eleventyConfig, id) {
+  id = id.trim()
   const { figure_list } = eleventyConfig.globalData.figures
   return figure_list.find((item) => item.id === id)
 }

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra')
 const path = require('path')
 const yaml = require('js-yaml')
+const { addUids } = require('~lib/uid')
 
 module.exports = function(eleventyConfig, options) {
   const dataDirectory = path.join('content', '_data')
@@ -22,6 +23,7 @@ module.exports = function(eleventyConfig, options) {
       default:
         return;
     }
+    data = addUids(data)
     eleventyConfig.addGlobalData(name, data)
   })
 }

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -67,7 +67,7 @@ module.exports = function (eleventyConfig, { page }) {
     }
 
     return oneLine`
-      <figure id="${slugify(id)}" class="${['q-figure', ...classes].join(' ')}">
+      <figure id="${figure.uid}" class="${['q-figure', ...classes].join(' ')}" data-figure-id="${id}">
         ${await component(figure)}
       </figure>
     `

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -67,7 +67,7 @@ module.exports = function (eleventyConfig, { page }) {
     }
 
     return oneLine`
-      <figure id="${figure.uid}" class="${['q-figure', ...classes].join(' ')}" data-figure-id="${id}">
+      <figure id="${figure.uid}" class="${['q-figure', ...classes].join(' ')}">
         ${await component(figure)}
       </figure>
     `

--- a/packages/11ty/_plugins/shortcodes/figureRef.js
+++ b/packages/11ty/_plugins/shortcodes/figureRef.js
@@ -22,6 +22,8 @@ const { warn } = chalkFactory('shortcodes:figureRef')
  *   [figs. 4](#fig-4), [5](#fig-5), [6](#fig-6), and [7](#fig-7)
  */
 module.exports = function(eleventyConfig) {
+  const getFigure = eleventyConfig.getFilter('getFigure')
+
   return function (ids) {
     if (!ids.length) {
       warn(`NoId: Figure 'ref' shortcode must include one or more values corresponding to the 'id' of a figure on the page. @example {% ref 'fig-1', 'fig-7', 'fig-11' %}`)
@@ -32,9 +34,10 @@ module.exports = function(eleventyConfig) {
     // transform the array of figure ids into and array of markdown links
     const links = ids.split(',').map((id, index) => {
       id = id.trim()
+      const figure = getFigure(id)
       let text = id.replace(/^fig-/i, '')
       if (index === 0) text = `${label} ${text}`
-      return `[${text}](#${id})`
+      return `[${text}](#${figure.uid})`
     })
 
     return oneLineCommaListsAnd`${links}`

--- a/packages/11ty/content/_assets/javascript/web-components/lightbox/index.js
+++ b/packages/11ty/content/_assets/javascript/web-components/lightbox/index.js
@@ -167,7 +167,7 @@ class Lightbox extends LitElement {
   get currentFigureIndex() {
     if (!this.figures) return;
     if (!this.currentId) return 0;
-    return this.figures.findIndex(({ id }) => id === this.currentId);
+    return this.figures.findIndex(({ uid }) => uid === this.currentId);
   }
 
   get fullscreen() {
@@ -180,13 +180,13 @@ class Lightbox extends LitElement {
 
   next() {
     const nextIndex = this.currentFigureIndex + 1;
-    const nextId = this.figures[nextIndex % this.figures.length].id
+    const nextId = this.figures[nextIndex % this.figures.length].uid
     this.currentId = nextId;
   }
 
   previous() {
     const previousIndex = this.currentFigureIndex - 1;
-    const previousId = this.figures.slice(previousIndex)[0].id;
+    const previousId = this.figures.slice(previousIndex)[0].uid;
     this.currentId = previousId;
   }
 
@@ -218,7 +218,7 @@ class Lightbox extends LitElement {
 
   render() {
     const imageSlides = () => {
-      const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, label, preset, src }, index) => {
+      const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, label, preset, src, uid }, index) => {
         const isCanvasPanel = iiif && !!iiif.canvas && !!iiif.manifest;
         const isImageService = iiif && !!iiif.info;
         const isImg = src && !!src.match(/.+\.(jpe?g|gif|png)$/);
@@ -249,13 +249,13 @@ class Lightbox extends LitElement {
             imageElement = `<div class="q-lightbox__missing-img">Figure '${id}' does not have a valid 'src'</div>`;
             break;
           case isCanvasPanel:
-            imageElement = `<canvas-panel id="${elementId}" data-figure="${id}" canvas-id="${iiif.canvas.id}" manifest-id="${iiif.manifest.id}" preset="${preset}" width="${this.width}" height="${this.height}" />`;
+            imageElement = `<canvas-panel id="${elementId}" data-figure="${uid}" canvas-id="${iiif.canvas.id}" manifest-id="${iiif.manifest.id}" preset="${preset}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImageService:
-            imageElement = `<image-service id="${elementId}" data-figure="${id}" src="${iiif.info}" width="${this.width}" height="${this.height}" />`;
+            imageElement = `<image-service id="${elementId}" data-figure="${uid}" src="${iiif.info}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImg:
-            imageElement = `<img id="${elementId}" data-figure="${id}" src="${imageSrc}" />`;
+            imageElement = `<img id="${elementId}" data-figure="${uid}" src="${imageSrc}" />`;
             break;
         }
 


### PR DESCRIPTION
Changes:
- Adds uid generator to `~lib`
- Adds uid to all data with an `id` property
- Uses `figure.uid` in figure id attribute, figure reference anchor tags, and modal

Fixes:
- Redundant figure id properties for figures used multiple times in one publication