### PR TITLE
Fix/dev 12644 redundant ids

### DIFF
--- a/packages/11ty/_lib/pluralize/index.js
+++ b/packages/11ty/_lib/pluralize/index.js
@@ -1,0 +1,11 @@
+/**
+ * Pluralize a string
+ * @param  {Number} count  number of items
+ * @param  {String} string word to pluralize
+ * @param  {String} pluralized override for pluralized word if irregular, i.e. "mouse" and "mice"
+ * @return {String} pluralized word
+ */
+module.exports = (count, string, pluralized) => {
+  pluralized = pluralized || `${string}s`
+  return count === 1 ? string : pluralized
+}

--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -13,7 +13,6 @@ const sortReferences = require('./sortReferences')
 // string filters
 const capitalize = require('./capitalize')
 const json = require('./json')
-const pluralize = require('./pluralize')
 const removeHTML = require('./removeHTML')
 const titleCase = require('./titleCase')
 
@@ -55,8 +54,6 @@ module.exports = function(eleventyConfig, options) {
   eleventyConfig.addFilter('titleCase', (string) => titleCase(string))
 
   eleventyConfig.addFilter('json', (string) => json(string))
-
-  eleventyConfig.addFilter('pluralize', (string, count) => pluralize(string, count))
 
   eleventyConfig.addFilter('removeHTML', (string) => removeHTML(string))
 }

--- a/packages/11ty/_plugins/filters/pluralize.js
+++ b/packages/11ty/_plugins/filters/pluralize.js
@@ -1,3 +1,0 @@
-module.exports = (string, count) => {
-  return count === 1 ? string : `${string}s`
-}

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -6,9 +6,8 @@ const chalkFactory = require('~lib/chalk')
 const { error } = chalkFactory('_plugins:globalData')
 
 /**
- * 
- * @param  {[type]} data [description]
- * @return {[type]}      [description]
+ * Throws error if data contains duplicate ids
+ * @param  {Object|Array} data
  */
 const checkForDuplicateIDs = function(data) {
   if (!data) return

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -1,13 +1,46 @@
 const fs = require('fs-extra')
 const path = require('path')
+const pluralize = require('~lib/pluralize')
 const yaml = require('js-yaml')
+const chalkFactory = require('~lib/chalk')
+const { error } = chalkFactory('_plugins:globalData')
+
+/**
+ * 
+ * @param  {[type]} data [description]
+ * @return {[type]}      [description]
+ */
+const checkForDuplicateIDs = function(data) {
+  if (!data) return
+  switch (true) {
+    case Array.isArray(data):
+      if (data.every((item) => item.hasOwnProperty('id'))) {
+        const duplicates = data.filter((a, index) => {
+          return data.findIndex((b) => b.id === a.id) !== index
+        })
+        if (duplicates.length) {
+          throw new Error(
+            `Found entries with duplicate IDs. ${pluralize(duplicates.length, 'ID')}: ${duplicates.map((item) => item.id).join(', ')}`
+          )
+        }
+      }
+      break;
+    case typeof data === 'object':
+      Object.keys(data).forEach((key) => {
+        checkForDuplicateIDs(data[key])
+      })
+      break;
+    default:
+      break;
+  }
+}
 
 module.exports = function(eleventyConfig, options) {
   const dataDirectory = path.join('content', '_data')
   const filenames = fs.readdirSync(dataDirectory)
-  filenames.forEach((item) => {
-    const { base, ext, name } = path.parse(item)
-    const filePath = path.join(dataDirectory, item)
+  filenames.forEach((filename) => {
+    const { base, ext, name } = path.parse(filename)
+    const filePath = path.join(dataDirectory, filename)
 
     let data;
     switch(ext) {
@@ -22,6 +55,11 @@ module.exports = function(eleventyConfig, options) {
       default:
         return;
     }
-    eleventyConfig.addGlobalData(name, data)
+    try {
+      checkForDuplicateIDs(data)
+      eleventyConfig.addGlobalData(name, data)
+    } catch(errorMessage) {
+      error(`${filename} contains multiple entries with the same ID. IDs must be unique. ${errorMessage}`)
+    }
   })
 }

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -1,10 +1,11 @@
 const fs = require('fs-extra')
 const path = require('path')
 const addGlobalData = require('./addGlobalData')
+const chalkFactory = require('~lib/chalk')
 const initCreateImage = require('./createImage')
 const initCreateManifest = require('./createManifest')
-const chalkFactory = require('~lib/chalk')
 const initTileImage = require('./tileImage')
+const pluralize = require('~lib/pluralize')
 
 const { info, error } = chalkFactory('plugins:iiif')
 
@@ -20,7 +21,6 @@ module.exports = {
   init: (eleventyConfig) => {
     info('Processing project image resources for IIIF.')
     const isImageService = eleventyConfig.getFilter('isImageService')
-    const pluralize = eleventyConfig.getFilter('pluralize')
     /**
      * IIIF config
      */
@@ -47,11 +47,11 @@ module.exports = {
       .filter(({ src }) => !tiledImages.includes(path.parse(src).name))
 
     if (tiledImages.length) {
-      info(`Skipping ${tiledImages.length} previously tiled ${pluralize('image', tiledImages.length)}.`)
+      info(`Skipping ${tiledImages.length} previously tiled ${pluralize(tiledImages.length, 'image')}.`)
     }
 
     if (figuresToTile.length) {
-      info(`Tiling ${figuresToTile.length} ${pluralize('image', figuresToTile.length)}...`)
+      info(`Tiling ${figuresToTile.length} ${pluralize(figuresToTile.length), 'image'}...`)
       info(`Generating IIIF image tiles may take a while depending on the size of each image file.`)
     } else {
       info(`No new images to tile found in figures.yaml.`)
@@ -92,8 +92,8 @@ module.exports = {
       const errors = tilingResponses.filter(({ error }) => error)
 
       if (figuresToTile.length) {
-        const errorMessage = errors.length ? ` with ${errors.length} ${pluralize('error', errors.length)}` : ''
-        info(`Completed tiling ${figuresToTile.length} ${pluralize('image', figuresToTile.length)}${errorMessage}`)
+        const errorMessage = errors.length ? ` with ${errors.length} ${pluralize(errors.length, 'error')}` : ''
+        info(`Completed tiling ${figuresToTile.length} ${pluralize(figuresToTile.length, 'image')}${errorMessage}`)
       }
 
       if (errors.length) {
@@ -110,7 +110,7 @@ module.exports = {
         const manifests = processedFiles.filter((dir) => {
           return fs.readdirSync(path.join(outputPath, dir)).includes('manifest.json')
         })
-        info(`Generating ${figuresWithChoices.length} ${pluralize('manifest', figuresWithChoices.length)}.`)
+        info(`Generating ${figuresWithChoices.length} ${pluralize(figuresWithChoices.length, 'manifest')}.`)
         for (const figure of figuresWithChoices) {
           await createManifest(figure, options)
         }

--- a/packages/11ty/content/_data/README.md
+++ b/packages/11ty/content/_data/README.md
@@ -8,3 +8,19 @@ Data files included in the `_data` directory will be added to the project's glob
 Data properties that are computed from other global data values are set in `eleventyComputed`. These values are directly available only in layouts and templates; **computed data properties must be explicitly passed to shortcodes and components.**
 
 Computed data, data files, and frontmatter will be combined into a single object and merged according to the [Eleventy data cascade](https://www.11ty.dev/docs/data-cascade/).
+
+### IDs
+
+In all data that contains an `id` property, the `id` must be unique and may only be rendered once in the publication. For example, if you have an image that is displayed multiple times throughout a publication, that entry will need to be copied and have a different id each time it's rendered.
+
+For example, if the same image is referenced in chapter 1 and chapter 2, you could structure your figures as:
+
+**figures.yaml**
+
+```yaml
+figure_list:
+  - id: `fig.1.1`
+    src: images/image.jpg
+  - id: `fig.2.5`
+    src: images/image.jpg
+```


### PR DESCRIPTION
Changes:
- Refactors `pluralize` to handle irregular plurals (ended up not needing this, but it's still nice)
- Move pluralize out of eleventy filters into `~lib`
- Log error if duplicate ids are found in yaml data