### PR TITLE
Fix: Conditional rendering bugs

### DIFF
--- a/packages/11ty/_plugins/transforms/format/index.js
+++ b/packages/11ty/_plugins/transforms/format/index.js
@@ -16,7 +16,7 @@ module.exports = function (content) {
   try {
     result = prettier.format(content, { filepath: this.outputPath })
   } catch (errorMessage) {
-    error(`Eleventy transform error formatting output for ${this.outputPath}.\n`, errorMessage)
+    error(`Eleventy transform error formatting output for ${this.outputPath}.\n${errorMessage}`)
   }
   return result || content
 }

--- a/packages/11ty/_plugins/transforms/outputs/render.js
+++ b/packages/11ty/_plugins/transforms/outputs/render.js
@@ -24,17 +24,14 @@ module.exports = async function (eleventyConfig, dir, params) {
     })
   )
 
-  const content = renderFns.map((renderFn, index) => {
+  const content = renderFns.flatMap((renderFn, index) => {
     const fragment = JSDOM.fragment(renderFn(params))
-    for (child of fragment.children) {
+    return [...fragment.children].map((child) => {
       const fileName = path.parse(filePaths[index]).name
-      const output = fileName === 'print'
-        ? 'epub,pdf'
-        : fileName
+      const output = fileName === 'print' ? 'epub,pdf' : fileName
       child.setAttribute('data-outputs-include', output)
-    }
-    return fragment.firstChild.outerHTML
+      return child.outerHTML
+    })
   })
-  
   return html`${content}`
 }

--- a/packages/11ty/_plugins/transforms/outputs/render.js
+++ b/packages/11ty/_plugins/transforms/outputs/render.js
@@ -28,8 +28,8 @@ module.exports = async function (eleventyConfig, dir, params) {
     const fragment = JSDOM.fragment(renderFn(params))
     return [...fragment.children].map((child) => {
       const fileName = path.parse(filePaths[index]).name
-      const output = fileName === 'print' ? 'epub,pdf' : fileName
-      child.setAttribute('data-outputs-include', output)
+      const outputs = fileName === 'print' ? 'epub,pdf' : fileName
+      child.setAttribute('data-outputs-include', outputs)
       return child.outerHTML
     })
   })


### PR DESCRIPTION
Fixes two issues I noticed while testing a different issue:
- Include `prettier` error in error messaging
- Render all root elements of multi-root shortcode