### PR TITLE
Add ability to crop during image process

### DIFF
--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -15,24 +15,25 @@ module.exports = (eleventyConfig) => {
   /**
    * Creates an image in the output directory with the name `${name}${ext}`
    *
-   * @param  {String} input Input file path
+   * @param  {Object} figure Figure entry data from `figures.yaml`
    * @param  {Object} transformation A transformation item from `iiif/config.js#imageTransformations`
    * @property  {String} name The name of the file
    * @property  {Object} resize Resize options for `sharp`
    */
-  return async (filename, transformation = {}, options) => {
+  return async (figure, transformation = {}, options) => {
     const { debug, lazy } = options
 
-    const { ext, name } = path.parse(filename)
+    const { region, src } = figure
+    const { ext, name } = path.parse(src)
     const format = formats.find(({ input }) => input.includes(ext))
-    const inputPath = path.join(inputDir, filename)
+    const inputPath = path.join(inputDir, src)
     const outputPath = path.join(outputRoot, outputDir, name, `${transformation.name}${format.output}`)
 
     fs.ensureDirSync(path.parse(outputPath).dir)
 
     if (!lazy || !fs.pathExistsSync(outputPath)) {
       if (debug) {
-        info(`Created ${filename}`)
+        info(`Created ${src}`)
       }
       try {
         return await sharp(inputPath)
@@ -40,7 +41,7 @@ module.exports = (eleventyConfig) => {
           .withMetadata()
           .toFile(outputPath)
       } catch(errorMessage) {
-        error(`${filename} ${errorMessage}`)
+        error(`${src} ${errorMessage}`)
       }
     }
   }

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -37,6 +37,10 @@ module.exports = (eleventyConfig) => {
         info(`Created ${src}`)
       }
       try {
+        /**
+         * Declare a `sharp` service with a `crop` method that can be
+         * called without a region, which the sharp API method `extract` does not allow
+         */
         const service = sharp(inputPath)
         service.crop = function (region) {
           if (!region) return this

--- a/packages/11ty/_plugins/iiif/process/createImage.js
+++ b/packages/11ty/_plugins/iiif/process/createImage.js
@@ -32,19 +32,18 @@ module.exports = (eleventyConfig) => {
 
     fs.ensureDirSync(path.parse(outputPath).dir)
 
-    const service = sharp(inputPath)
-    service.crop = function (region) {
-      if (!region) return this
-      const [ top, left, width, height ] = region.split(',').map((item) => parseFloat(item.trim()))
-      service.extract({ top, left, width, height })
-      return this
-    }
-
     if (!lazy || !fs.pathExistsSync(outputPath)) {
       if (debug) {
         info(`Created ${src}`)
       }
       try {
+        const service = sharp(inputPath)
+        service.crop = function (region) {
+          if (!region) return this
+          const [ top, left, width, height ] = region.split(',').map((item) => parseFloat(item.trim()))
+          service.extract({ top, left, width, height })
+          return this
+        }
         return await service
           .crop(region)
           .resize(resize)

--- a/packages/11ty/_plugins/iiif/process/index.js
+++ b/packages/11ty/_plugins/iiif/process/index.js
@@ -73,19 +73,16 @@ module.exports = {
 
       const promises = []
       figuresToTile.forEach((figure) => {
-        const imagePath = figure.src
-        const id = path.parse(imagePath).name
-
         if (debug) {
-          info(`Tiling ${id}`)
+          info(`Tiling ${figure.id}`)
         }
 
         promises.push(
           imageTransformations.map((transformation) => {
-            return createImage(imagePath, transformation, options);
+            return createImage(figure, transformation, options);
           })
         )
-        promises.push(tileImage(imagePath, options))
+        promises.push(tileImage(figure, options))
       })
 
       const tilingResponses = await Promise.all(promises)

--- a/packages/11ty/_plugins/iiif/process/tileImage.js
+++ b/packages/11ty/_plugins/iiif/process/tileImage.js
@@ -19,14 +19,15 @@ module.exports = (eleventyConfig) => {
 
   /**
    * Tile an image for IIIF image service
-   * @param  {String} filename   filename File name and extension
+   * @param  {String} figure   Figure entry data from `figures.yaml`
    * @param  {Object} options
    */
-  return async function(filename, options = {}) {
+  return async function(figure, options = {}) {
     const { debug, lazy } = options
 
-    const { ext, name } = path.parse(filename)
-    const inputPath = path.join(inputDir, filename)
+    const { src } = figure
+    const { ext, name } = path.parse(src)
+    const inputPath = path.join(inputDir, src)
     const outputPath = path.join(outputRoot, outputDir, name, imageServiceDirectory)
     const format = formats.find(({ input }) => input.includes(ext))
     const supportedImageExtensions = formats.flatMap(( { input }) => input)
@@ -37,7 +38,7 @@ module.exports = (eleventyConfig) => {
       }
       return {
         error: `Image file type is not supported. Supported extensions are: ${supportedImageExtensions.join(', ')}`,
-        filename
+        src
       }
     }
 
@@ -62,7 +63,7 @@ module.exports = (eleventyConfig) => {
         })
         .toFile(outputPath)
     } catch(error) {
-      return { error, filename }
+      return { error, src }
     }
   }
 }


### PR DESCRIPTION
- Refactors `tileImage` and `createImage` to accept `figure` data as a parameter instead of `path` so all image process methods have the same signature (and gives us access to `region`)
- Crops the print and thumbnail images if `figure.region` is specified in `figures.yaml`