### PR TITLE
Roll `eleventy-plugin-vite` back to 1.0.0-canary.1 to fix passthrough copy error

### DIFF
--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -22,7 +22,7 @@
         "@11ty/eleventy-navigation": "^0.3.3",
         "@11ty/eleventy-plugin-directory-output": "^1.0.1",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
-        "@11ty/eleventy-plugin-vite": "^1.0.0-canary.2",
+        "@11ty/eleventy-plugin-vite": "^1.0.0-canary.1",
         "@iiif/parser": "^1.0.10",
         "@iiif/vault": "^0.9.19",
         "chalk": "^4.1.2",
@@ -224,13 +224,13 @@
       }
     },
     "node_modules/@11ty/eleventy-plugin-vite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-vite/-/eleventy-plugin-vite-1.0.0.tgz",
-      "integrity": "sha512-iU2qOFLiwCxHN5GnAkJx29tY9fEJS+w6QHLPnxep3jrtnPlLJl1Jr6DPxclMUVBFJZUrnzZDSUbeiwz20/ffdQ==",
+      "version": "1.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-vite/-/eleventy-plugin-vite-1.0.0-canary.1.tgz",
+      "integrity": "sha512-qUK/UqRlmLOoRLTzME75m/wii+m1Yanu4OPC/WzRhSnOguoos/oylmByYKWOeGyvlFwtA180XMketfvVGNvsTQ==",
       "dev": true,
       "dependencies": {
         "lodash.merge": "^4.6.2",
-        "vite": "^2.9.14"
+        "vite": "^2.8.6"
       },
       "engines": {
         "node": ">=12"
@@ -7595,13 +7595,13 @@
       }
     },
     "@11ty/eleventy-plugin-vite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-vite/-/eleventy-plugin-vite-1.0.0.tgz",
-      "integrity": "sha512-iU2qOFLiwCxHN5GnAkJx29tY9fEJS+w6QHLPnxep3jrtnPlLJl1Jr6DPxclMUVBFJZUrnzZDSUbeiwz20/ffdQ==",
+      "version": "1.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-vite/-/eleventy-plugin-vite-1.0.0-canary.1.tgz",
+      "integrity": "sha512-qUK/UqRlmLOoRLTzME75m/wii+m1Yanu4OPC/WzRhSnOguoos/oylmByYKWOeGyvlFwtA180XMketfvVGNvsTQ==",
       "dev": true,
       "requires": {
         "lodash.merge": "^4.6.2",
-        "vite": "^2.9.14"
+        "vite": "^2.8.6"
       }
     },
     "@11ty/eleventy-utils": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -30,7 +30,7 @@
     "@11ty/eleventy-navigation": "^0.3.3",
     "@11ty/eleventy-plugin-directory-output": "^1.0.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
-    "@11ty/eleventy-plugin-vite": "^1.0.0-canary.2",
+    "@11ty/eleventy-plugin-vite": "^1.0.0-canary.1",
     "@iiif/parser": "^1.0.10",
     "@iiif/vault": "^0.9.19",
     "chalk": "^4.1.2",


### PR DESCRIPTION
This should fix the following error while running `npm run dev`/`npm run build`:

```
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] 1. Having trouble copying (via EleventyPassthroughCopyError)
[11ty] 2. Having trouble copying './public/**' (via TemplatePassthroughManagerCopyError)
[11ty] 3. Multiple passthrough copy files are trying to write to the same output file (_site/default.jpg). public/iiif/mother/tiles/0,0,512,512/256,/0/default.jpg and public/iiif/mother/tiles/0,0,1024,1024/256,/0/default.jpg (via TemplatePassthroughManagerCopyError)
[11ty] 
[11ty] Original error stack trace: TemplatePassthroughManagerCopyError: Multiple passthrough copy files are trying to write to the same output file (_site/default.jpg). public/iiif/mother/tiles/0,0,512,512/256,/0/default.jpg and public/iiif/mother/tiles/0,0,1024,1024/256,/0/default.jpg
[11ty]     at /Users/apollack/Code/getty/quire/packages/11ty/node_modules/@11ty/eleventy/src/TemplatePassthroughManager.js:153:21
[11ty]     at async Promise.all (index 3)
[11ty]     at async Promise.all (index 0)
[11ty]     at async Eleventy.executeBuild (/Users/apollack/Code/getty/quire/packages/11ty/node_modules/@11ty/eleventy/src/Eleventy.js:1108:13)
[11ty]     at async Eleventy.watch (/Users/apollack/Code/getty/quire/packages/11ty/node_modules/@11ty/eleventy/src/Eleventy.js:924:18)
```

**NOTE:** you may have to delete all `node_modules` and `npm install` again to actually roll this back

We tried installing multiple recent versions of `eleventy-plugin-vite`, all yielding the same behavior:
- 2.0.0-canary.1
- 1.0.0-canary.3 / 1.0.0
- 1.0.0-canary.2