### PR TITLE
Document working with data in development

### DIFF
--- a/packages/11ty/content/_data/README.md
+++ b/packages/11ty/content/_data/README.md
@@ -1,15 +1,15 @@
-## Global Data
+# Global Data
 
-### Data Files
+## Data Files
 
 Data files included in the `_data` directory will be added to the project's global data using [Eleventy's configuration API](https://www.11ty.dev/docs/data-global-custom/), which allows the data to be universally accessed from Quire shortcodes and components.
 
-### Computed Data
+## Computed Data
 Data properties that are computed from other global data values are set in `eleventyComputed`. These values are directly available only in layouts and templates; **computed data properties must be explicitly passed to shortcodes and components.**
 
 Computed data, data files, and frontmatter will be combined into a single object and merged according to the [Eleventy data cascade](https://www.11ty.dev/docs/data-cascade/).
 
-### IDs
+## IDs
 
 In all data that contains an `id` property, the `id` must be unique and may only be rendered once in the publication. For example, if you have an image that is displayed multiple times throughout a publication, that entry will need to be copied and have a different id each time it's rendered.
 
@@ -24,3 +24,7 @@ figure_list:
   - id: `fig.2.5`
     src: images/image.jpg
 ```
+
+## Working with data in development
+
+Eleventy does not fully reprocess the data cascade if a data property changes while the development server is running. As a result, it's safest to restart the server with any change to a global or computed data property. However, changes to template content or front matter (whether in a template or layout) do _not_ require a server start.


### PR DESCRIPTION
After some testing, I figured out that the case where you need to restart the server is when changing computed properties that rely on a global property. I still think this is odd, and even tried calling the global data plugin again in  `eleventy.beforeWatch` but the computed properties still do not recompute. 

For now, adding documentation to guide users as to what's going on. If this ends up being really annoying to users we can investigate more later and/or open an issue with eleventy.