### PR TITLE
Ensure `isImageService` is not truthy for figures with static images

### DIFF
--- a/packages/11ty/_includes/web-components/lightbox/index.js
+++ b/packages/11ty/_includes/web-components/lightbox/index.js
@@ -75,9 +75,7 @@ class Lightbox extends LitElement {
 
   render() {
     const imageSlides = () => {
-      const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, label, preset, src }, index) => {
-        const isCanvasPanel = iiif && !!iiif.canvas && !!iiif.manifest;
-        const isImageService = iiif && !!iiif.info;
+      const imagesWithCaptions = this.figures.map(({ caption, credit, id, iiif, isCanvas, isImageService, label, preset, src }, index) => {
         const isImg = src && !!src.match(/.+\.(jpe?g|gif|png)$/);
         const labelSpan = label
           ? `<span class="q-lightbox__caption-label">${label}</span>`
@@ -105,7 +103,7 @@ class Lightbox extends LitElement {
           default:
             imageElement = `<div class="q-lightbox__missing-img">Figure '${id}' does not have a valid 'src'</div>`;
             break;
-          case isCanvasPanel:
+          case isCanvas:
             imageElement = `<canvas-panel id="${elementId}" data-figure="${id}" canvas-id="${iiif.canvas.id}" manifest-id="${iiif.manifest.id}" preset="${preset}" width="${this.width}" height="${this.height}" />`;
             break;
           case isImageService:

--- a/packages/11ty/_plugins/iiif/helpers/get-image-service.js
+++ b/packages/11ty/_plugins/iiif/helpers/get-image-service.js
@@ -12,6 +12,7 @@ module.exports = (eleventyConfig, figure) => {
 
   const { imageServiceDirectory, outputDir } = eleventyConfig.globalData.iiifConfig
   const { src } = figure
+  if (!src) return
   const { name } = path.parse(src)
   return src.startsWith('http')
     ? src

--- a/packages/11ty/_plugins/iiif/helpers/get-image-service.js
+++ b/packages/11ty/_plugins/iiif/helpers/get-image-service.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const isImageService = require('./is-image-service')
 /**
  * Return path to a figure entry's `info.json`
  * 
@@ -7,9 +8,10 @@ const path = require('path')
  * @return {String}            Path to figure's `info.json`
  */
 module.exports = (eleventyConfig, figure) => {
+  if (!isImageService(figure)) return
+
   const { imageServiceDirectory, outputDir } = eleventyConfig.globalData.iiifConfig
   const { src } = figure
-  if (!src) return
   const { name } = path.parse(src)
   return src.startsWith('http')
     ? src

--- a/packages/11ty/_plugins/iiif/process/addGlobalData.js
+++ b/packages/11ty/_plugins/iiif/process/addGlobalData.js
@@ -24,7 +24,7 @@ module.exports = async (eleventyConfig) => {
     const info = getImageService(eleventyConfig, figure)
     Object.assign(eleventyConfig.globalData.figures.figure_list[index], {
       isCanvas: !!iiif.canvas,
-      isImageService: info || false,
+      isImageService: !!info,
       iiif: {
         ...iiif,
         info

--- a/packages/11ty/_plugins/iiif/process/addGlobalData.js
+++ b/packages/11ty/_plugins/iiif/process/addGlobalData.js
@@ -24,7 +24,7 @@ module.exports = async (eleventyConfig) => {
     const info = getImageService(eleventyConfig, figure)
     Object.assign(eleventyConfig.globalData.figures.figure_list[index], {
       isCanvas: !!iiif.canvas,
-      isImageService: !!info,
+      isImageService: info || false,
       iiif: {
         ...iiif,
         info


### PR DESCRIPTION
Weird thing -- I noticed that non-image service figures weren't rendering on `intro` and `essay`, which is real weird because the `!!info` should handle when `getImageService()` returns `undefined`, but it was setting `figure.isImageService` to `true` on my end?? Evaluating `!!undefined` should be `false`...

This also fixes an issue where static images where not rendering in the lightbox