### PR TITLE
Fix lightbox slides not advancing / not opening from specific figure

### DIFF
--- a/packages/11ty/_includes/components/figure/video/html.js
+++ b/packages/11ty/_includes/components/figure/video/html.js
@@ -1,16 +1,23 @@
 const { html } = require('~lib/common-tags')
+const chalkFactory = require('~lib/chalk')
 const path = require('path')
 
+const { warn, error } = chalkFactory('Figure Video')
+
 const videoElement = {
-  video({ src }) {
+  video({ id, poster='', src }) {
     if (!src) {
-      console.warn(`Error: Cannot render Video without 'src'. Check that figures data for id: ${id} has a valid 'src'`)
+      error(`Cannot render Video without 'src'. Check that figures data for id: ${id} has a valid 'src'`)
       return ''
+    }
+
+    if (!poster) {
+      warn(`figure "${id}" does not have a 'poster' property. It will not render a poster image`)
     }
 
     const unsupported = 'Sorry, your browser does not support embedded videos.'
     return html`
-      <video controls class="q-figure__media">
+      <video controls poster="${poster}" class="q-figure__media">
         <source src="${src}" type="video/mp4"/>
         ${unsupported}
       </video>

--- a/packages/11ty/_includes/components/figure/video/print.js
+++ b/packages/11ty/_includes/components/figure/video/print.js
@@ -2,6 +2,8 @@ const { html } = require('~lib/common-tags')
 const chalkFactory = require('~lib/chalk')
 const path = require('path')
 
+const { warn } = chalkFactory('Figure Video')
+
 /**
  * Renders an image instead of a video player
  *
@@ -16,7 +18,9 @@ module.exports = function(eleventyConfig) {
   const { figureLabelLocation, imageDir } = eleventyConfig.globalData.config.params
 
   return function({ aspect_ratio: aspectRatio, caption, credit, id, label, mediaType, poster=''}) {
-    const isEmbed = mediaType === 'vimeo' || mediaType === 'youtube'
+    if (!poster) {
+      warn(`figure "${id}" does not have a 'poster' property. It will not render a poster image`)
+    }
 
     const posterSrc = poster.startsWith('http')
       ? poster

--- a/packages/11ty/_includes/components/figure/video/print.js
+++ b/packages/11ty/_includes/components/figure/video/print.js
@@ -15,7 +15,7 @@ module.exports = function(eleventyConfig) {
 
   const { figureLabelLocation, imageDir } = eleventyConfig.globalData.config.params
 
-  return function({ aspect_ratio: aspectRatio, caption, credit, id, label, mediaType, poster}) {
+  return function({ aspect_ratio: aspectRatio, caption, credit, id, label, mediaType, poster=''}) {
     const isEmbed = mediaType === 'vimeo' || mediaType === 'youtube'
 
     const posterSrc = poster.startsWith('http')

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -15,7 +15,7 @@ module.exports = function(eleventyConfig) {
   return function(figures) {
     if (!figures) return ''
 
-    const slideElement = (fgure) => {
+    const slideElement = (figure) => {
       const {
         caption,
         credit,

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -48,7 +48,7 @@ module.exports = function(eleventyConfig) {
       return html`
         <div
           class="q-lightbox-slides__slide"
-          data-lightbox-slide
+          data-lightbox-slide="${id}"
         >
           <div class="q-lightbox-slides__image">
             ${figureImageElement(figure)}

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -48,7 +48,8 @@ module.exports = function(eleventyConfig) {
       return html`
         <div
           class="q-lightbox-slides__slide"
-          data-lightbox-slide="${id}"
+          data-lightbox-slide
+          data-lightbox-slide-id="${id}"
         >
           <div class="q-lightbox-slides__image">
             ${figureImageElement(figure)}

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -27,7 +27,8 @@ module.exports = function(eleventyConfig) {
         src
       } = figure
 
-      if (mediaType === 'video' || mediaType === 'audio') return slides;
+      const unsupportedMediaTypes = ['soundcloud', 'video', 'vimeo', 'youtube']
+      if (unsupportedMediaTypes.includes(mediaType)) return '';
 
       const labelSpan = label
         ? html`<span class="q-lightbox-slides__caption-label">${label}</span>`

--- a/packages/11ty/_includes/web-components/lightbox/README.md
+++ b/packages/11ty/_includes/web-components/lightbox/README.md
@@ -2,7 +2,7 @@
 
 This component renders image slides with navigation UI. It provides a default slot for passing markup to render.
 
-To display an element as a slide, provide it with a `data-lightbox-slide` attribute set to a unique string (in our case, the figure id)
+To display a child element of the slot as a slide, provide it with a `data-lightbox-slide` attribute set to a unique string (in our case, the figure id). **Note:** the value of `data-lightbox-slide` only needs to be unique among other slot children with `data-lightbox-slide` set
 
 This lightbox provides access to controls with the following data attributes:
 - `data-lightbox-fullscreen` triggers fullscreen on click and indicates status

--- a/packages/11ty/_includes/web-components/lightbox/README.md
+++ b/packages/11ty/_includes/web-components/lightbox/README.md
@@ -2,7 +2,7 @@
 
 This component renders image slides with navigation UI. It provides a default slot for passing markup to render.
 
-To display an element as a slide, provide it with a `data-lightbox-slide` attribute set to any value
+To display an element as a slide, provide it with a `data-lightbox-slide` attribute set to a unique string (in our case, the figure id)
 
 This lightbox provides access to controls with the following data attributes:
 - `data-lightbox-fullscreen` triggers fullscreen on click and indicates status

--- a/packages/11ty/_includes/web-components/lightbox/README.md
+++ b/packages/11ty/_includes/web-components/lightbox/README.md
@@ -2,7 +2,8 @@
 
 This component renders image slides with navigation UI. It provides a default slot for passing markup to render.
 
-To display a child element of the slot as a slide, provide it with a `data-lightbox-slide` attribute set to a unique string (in our case, the figure id). **Note:** the value of `data-lightbox-slide` only needs to be unique among other slot children with `data-lightbox-slide` set
+To display a child element of the slot as a slide, provide it with a `data-lightbox-slide` attribute set to anything and a `data-lightbox-slide-id`
+set to a unique string (in our case, the figure id). **Note:** the value of `data-lightbox-slide-id` only needs to be unique among other slot children with `data-lightbox-slide` set
 
 This lightbox provides access to controls with the following data attributes:
 - `data-lightbox-fullscreen` triggers fullscreen on click and indicates status

--- a/packages/11ty/_includes/web-components/lightbox/index.js
+++ b/packages/11ty/_includes/web-components/lightbox/index.js
@@ -8,7 +8,7 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
  * It provides a default slot for passing markup to render:
  *
  * To display an element as a slide, provide it with a
- * `data-lightbox-slide` attribute set to any value
+ * `data-lightbox-slide` attribute set to a unique id string
  *
  * This lightbox provides access to controls with the following data attributes:
  * - `data-lightbox-fullscreen` triggers fullscreen on click and indicates status
@@ -58,7 +58,7 @@ class Lightbox extends LitElement {
   get slideIds() {
     return Array
       .from(this.slides)
-      .map((slide) => slide.dataset.lightboxId)
+      .map((slide) => slide.dataset.lightboxSlide)
   }
 
   get currentSlide() {
@@ -154,7 +154,7 @@ class Lightbox extends LitElement {
     if (!this.currentSlide) return;
 
     this.slides.forEach((slide) => {
-      if (slide.dataset.lightboxId !== this.currentId)
+      if (slide.dataset.lightboxSlide !== this.currentId)
         delete slide.dataset.lightboxCurrent;
     })
     this.currentSlide.dataset.lightboxCurrent = true

--- a/packages/11ty/_includes/web-components/lightbox/index.js
+++ b/packages/11ty/_includes/web-components/lightbox/index.js
@@ -8,7 +8,8 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
  * It provides a default slot for passing markup to render:
  *
  * To display an element as a slide, provide it with a
- * `data-lightbox-slide` attribute set to a unique id string
+ * `data-lightbox-slide` attribute set to any value
+ * `data-lightbox-slide-id` attribute set to a unique id string
  *
  * This lightbox provides access to controls with the following data attributes:
  * - `data-lightbox-fullscreen` triggers fullscreen on click and indicates status
@@ -58,7 +59,7 @@ class Lightbox extends LitElement {
   get slideIds() {
     return Array
       .from(this.slides)
-      .map((slide) => slide.dataset.lightboxSlide)
+      .map((slide) => slide.dataset.lightboxSlideId)
   }
 
   get currentSlide() {
@@ -154,7 +155,7 @@ class Lightbox extends LitElement {
     if (!this.currentSlide) return;
 
     this.slides.forEach((slide) => {
-      if (slide.dataset.lightboxSlide !== this.currentId)
+      if (slide.dataset.lightboxSlideId !== this.currentId)
         delete slide.dataset.lightboxCurrent;
     })
     this.currentSlide.dataset.lightboxCurrent = true


### PR DESCRIPTION
- Ensure lightbox slides shortcode does not render anything when mediaType is unsupported
- Provide a default value for video poster param in print output
- Ensure lightbox slides provide a unique figure id value for `data-lightbox-slide` to manage slide navigation
