### PR TITLE
Feature/DEV-12836: Print entry figures

### DIFF
--- a/packages/11ty/_includes/components/figure/label.js
+++ b/packages/11ty/_includes/components/figure/label.js
@@ -10,29 +10,24 @@ module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const modalLink = eleventyConfig.getFilter('figureModalLink')
 
-  const { epub } = eleventyConfig.globalData.config
   const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return function({ caption, id, label }) {
-    let labelElement
+    if (!label) return ''
 
-    if (epub) {
-      labelElement = `<span class="q-figure__label">${markdownify(label)}</span>`
-    } else {
-      const modifier = figureLabelLocation || ''
+    const modifier = figureLabelLocation || ''
 
-      let content = `<span class="q-figure__label-icon">${icon({ type: 'fullscreen', description: 'Expand' })}</span>`
-      content += `<span class="q-figure__label-text">${markdownify(label || '')}</span>`
+    let content = `<span class="q-figure__label-icon">${icon({ type: 'fullscreen', description: 'Expand' })}</span>`
+    content += `<span class="q-figure__label-text">${markdownify(label || '')}</span>`
 
-      content =
-        (modifier === 'below')
-          ? modalLink({ caption, content, id })
-          : content
+    content =
+      (modifier === 'below')
+        ? modalLink({ caption, content, id })
+        : content
 
-      labelElement = `<span class="q-figure__label q-figure__label--${modifier}">
-        ${content}
-      </span>`
-    }
+    const labelElement = `<span class="q-figure__label q-figure__label--${modifier}">
+      ${content}
+    </span>`
 
     return oneLine`${labelElement}`
   }

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -32,7 +32,7 @@ Entry content, including entry image and tombstone data
   <div class="quire-entry__image-wrap" data-outputs-include="epub,pdf">
     {% if image %}
       {% comment %} 
-        To do: add support for images without ids defined in front matter
+        @TODO: add support for images without ids defined in front matter
         {% figure image %}
       {% endcomment %}
     {% elsif pageObjects %}

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -5,33 +5,22 @@ description: Entry layout. This template is intended for use in catalogue-style 
 ---
 
 {% assign entryPageSideBySideLayout = config.params.entryPageSideBySideLayout %}
-{% assign epub = config.params.epub %}
-{% assign imageDir = config.params.imageDir %}
-{% assign pdf = config.params.pdf %}
-{% assign zoom = config.params.figureZoom %}
 
 {% comment %}
 Entry content, including entry image and tombstone data
 {% endcomment %}
 
-<div {% if entryPageSideBySideLayout == true or presentation == 'side-by-side' and pdf != true and epub != true %} class="side-by-side" {% endif %} data="{{ zoom }}">
-
-  {% if epub == true %}
-  <header class="quire-entry__header">
-    <div class="container">
-        {% comment %} Title {% endcomment %}
-        <h1 class="quire-page__header__title" id="{{ title | slugify }}">
-          {% pageTitle label=label, title=title, subtitle=subtitle %}
-        </h1>
-    </div>
-  </header>
-  {% endif %}
+<div {% if entryPageSideBySideLayout == true or presentation == 'side-by-side' %} class="side-by-side" {% endif %}>
 
   {% comment %} Full-width entry image header {% endcomment %}
-  <div class="quire-entry__image-wrap">
+  <div class="quire-entry__image-wrap" data-outputs-include="html">
     <div class="quire-entry__lightbox">
       {% if image %}
-        {% comment %} TODO add `lightbox` when a single `image` is included in front matter {% endcomment %}
+      {% comment %} 
+        To do: add support for images without ids defined in front matter
+        {% assign figures = image | split: ',' %}
+        {% lightbox figures %}
+      {% endcomment %}
       {% elsif pageObjects %}
         {% for object in pageObjects %}
           {% lightbox object.figures %}
@@ -40,19 +29,32 @@ Entry content, including entry image and tombstone data
     </div>
   </div>
 
-  <div class="quire-entry__content">
-    {% if epub != true %}
-      <header class="quire-entry__header">
-        <div class="container">
-          <h1 class="quire-page__header__title" id="{{ title | url }}">
-            {% pageTitle label=label, title=title, subtitle=subtitle %}
-          </h1>
-          <div class="quire-page__header__contributor">
-            {% contributors context=pageContributors, format=contributor_byline %}
-          </div>
-        </div>
-      </header>
+  <div class="quire-entry__image-wrap" data-outputs-include="epub,pdf">
+    {% if image %}
+      {% comment %} 
+        To do: add support for images without ids defined in front matter
+        {% figure image %}
+      {% endcomment %}
+    {% elsif pageObjects %}
+      {% for object in pageObjects %}
+        {% for figure in object.figures %}
+          {% figure figure.id %}
+        {% endfor %}
+      {% endfor %}
     {% endif %}
+  </div>
+
+  <div class="quire-entry__content">
+    <header class="quire-entry__header">
+      <div class="container">
+        <h1 class="quire-page__header__title" id="{{ title | url }}">
+          {% pageTitle label=label, title=title, subtitle=subtitle %}
+        </h1>
+        <div class="quire-page__header__contributor">
+          {% contributors context=pageContributors, format=contributor_byline %}
+        </div>
+      </div>
+    </header>
 
     {% tombstone pageObjects %}
 

--- a/packages/11ty/_plugins/transforms/outputs/render.js
+++ b/packages/11ty/_plugins/transforms/outputs/render.js
@@ -9,7 +9,7 @@ const path = require('path')
  * initialize with `eleventyConfig` and render each with the `data-outputs-include`
  * attribute
  */
-module.exports = function (eleventyConfig, dir, params) {
+module.exports = function (eleventyConfig, dir, params, page) {
   const fileNames = ['epub', 'html', 'pdf', 'print']
 
   const filePaths = fileNames.flatMap((output) => {
@@ -21,7 +21,7 @@ module.exports = function (eleventyConfig, dir, params) {
 
   const content = filePaths.flatMap((filePath, index) => {
     const init = require(filePath)
-    const renderFn = init(eleventyConfig)
+    const renderFn = init(eleventyConfig, { page })
     const component = renderFn(params)
     const fragment = JSDOM.fragment(component)
     return [...fragment.children].map((child) => {

--- a/packages/11ty/content/_assets/styles/print.scss
+++ b/packages/11ty/content/_assets/styles/print.scss
@@ -422,7 +422,7 @@ $print-trim: $print-bleed * 2;
 
   // @todo determine why below with `&` was failing in webpack
   // .quire-entry__image & figure {
-  .quire-entry__image figure {
+  .quire-entry__image-wrap figure {
     display: flex;
     flex-direction: column;
     height: $print-entry-image-height;


### PR DESCRIPTION
Changes:
- Adds page object to `renderOutputs` function (not used in this PR, but might need in the future)
- Removes oldie print handling from `label` shortcode and returns empty string if label is undefined
- Renders print output for entry figures using `data-outputs-include` 

Noticed there are extra blank pages between entry figures in print now, and I'm not sure why.