### PR TITLE
DEV-13012: Remove `figureLabelLocation` config option; always render labels in figure captions; clean up markup and unused styles

### DIFF
--- a/packages/11ty/_includes/components/figure/image/html.js
+++ b/packages/11ty/_includes/components/figure/image/html.js
@@ -16,7 +16,7 @@ module.exports = function(eleventyConfig) {
   const figureModalLink = eleventyConfig.getFilter('figureModalLink')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  const { imageDir, figureLabelLocation } = eleventyConfig.globalData.config.params
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function(figure) {
     const { 
@@ -33,15 +33,9 @@ module.exports = function(eleventyConfig) {
     /**
      * Wrap image in modal link
      */
-    const imageElement =
-      (figureLabelLocation === 'below')
-        ? figureModalLink({ content: figureImageElement(figure), id })
-        : figureModalLink({ caption, content: figureImageElement(figure) + labelElement, id })
+    const imageElement = figureModalLink({ content: figureImageElement(figure), id })
 
-    const captionElement =
-      (figureLabelLocation === 'below')
-        ? figureCaption({ caption, content: labelElement, credit })
-        : figureCaption({ caption, credit })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
 
     return html`
       ${imageElement}

--- a/packages/11ty/_includes/components/figure/label.js
+++ b/packages/11ty/_includes/components/figure/label.js
@@ -11,7 +11,6 @@ module.exports = function(eleventyConfig) {
   const modalLink = eleventyConfig.getFilter('figureModalLink')
 
   const { epub } = eleventyConfig.globalData.config
-  const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
   return function({ caption, id, label }) {
     let labelElement
@@ -19,17 +18,12 @@ module.exports = function(eleventyConfig) {
     if (epub) {
       labelElement = `<span class="q-figure__label">${markdownify(label)}</span>`
     } else {
-      const modifier = figureLabelLocation || ''
-
       let content = `<span class="q-figure__label-icon">${icon({ type: 'fullscreen', description: 'Expand' })}</span>`
       content += `<span class="q-figure__label-text">${markdownify(label || '')}</span>`
 
-      content =
-        (modifier === 'below')
-          ? modalLink({ caption, content, id })
-          : content
+      content = modalLink({ caption, content, id })
 
-      labelElement = `<span class="q-figure__label q-figure__label--${modifier}">
+      labelElement = `<span class="q-figure__label q-figure__label--below">
         ${content}
       </span>`
     }

--- a/packages/11ty/_includes/components/figure/modal-link.js
+++ b/packages/11ty/_includes/components/figure/modal-link.js
@@ -6,8 +6,8 @@ module.exports = function (eleventyConfig) {
   return function({ content, id }) {
     return figureModal
       ? html`<a
-          href="#${id}"
           class="q-figure__modal-link"
+          href="#${id}"
         >
           ${content}
         </a>`

--- a/packages/11ty/_includes/components/figure/placeholder.js
+++ b/packages/11ty/_includes/components/figure/placeholder.js
@@ -4,7 +4,7 @@ const { html } = require('~lib/common-tags')
 module.exports = function(eleventyConfig) {
   const figureLabel = eleventyConfig.getFilter('figureLabel')
 
-  const { figureLabelLocation, imageDir } = eleventyConfig.globalData.config.params
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function({ alt, caption, id, label, media_type: mediaType, src }) {
     let imageElement
@@ -26,9 +26,7 @@ module.exports = function(eleventyConfig) {
       `
     }
 
-    const labelElement = label && figureLabelLocation === 'on-top'
-      ? figureLabel({ caption, id, label })
-      : ''
+    const labelElement = figureLabel({ caption, id, label })
 
     const captionElement = `
       <figcaption class="quire-figure__caption">

--- a/packages/11ty/_includes/components/figure/soundcloud.js
+++ b/packages/11ty/_includes/components/figure/soundcloud.js
@@ -14,8 +14,6 @@ module.exports = function(eleventyConfig) {
   const figureLabel = eleventyConfig.getFilter('figureLabel')
   const figurePlaceholder = eleventyConfig.getFilter('figurePlaceholder')
 
-  const { figureLabelLocation } = eleventyConfig.globalData.config.params
-
   return function({ caption, credit, id, label, media_id }) {
     const src = `https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/${media_id}`
 
@@ -23,6 +21,9 @@ module.exports = function(eleventyConfig) {
       console.warn(`Error: Cannot render SoundCloud component without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
       return ''
     }
+
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
 
     return html`
       <div class="q-figure__media-wrapper">
@@ -34,9 +35,8 @@ module.exports = function(eleventyConfig) {
           src="${src}&auto_play=false&color=%23ff5500&hide_related=true&show_comments=false&show_reposts=false&show_teaser=false&show_user=false"
           width="100%"
         ></iframe>
-        ${label && figureLabelLocation === 'on-top' ? figureLabel({ caption, id, label }) : '' }
       </div>
-      ${figureCaption({ caption, credit })}
+      ${captionElement}
     `
   }
 }

--- a/packages/11ty/_includes/components/figure/table.js
+++ b/packages/11ty/_includes/components/figure/table.js
@@ -19,6 +19,7 @@ module.exports = function(eleventyConfig) {
     const title = markdownify(caption)
 
     const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
 
     return html`
       <a
@@ -28,7 +29,7 @@ module.exports = function(eleventyConfig) {
       >
         ${table}
       </a>
-      ${figureCaption({ caption, content: labelElement, credit })}
+      ${captionElement}
     `
   }
 }

--- a/packages/11ty/_includes/components/figure/table.js
+++ b/packages/11ty/_includes/components/figure/table.js
@@ -8,26 +8,27 @@ const path = require('path')
  */
 module.exports = function(eleventyConfig) {
   const figureCaption = eleventyConfig.getFilter('figureCaption')
+  const figureLabel = eleventyConfig.getFilter('figureLabel')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const renderFile = eleventyConfig.getFilter('renderFile')
 
   const assetsDir = path.join(eleventyConfig.dir.input, '_assets/images')
-  const { figureLabelLocation } = eleventyConfig.globalData.config.params
 
-  return async function({ caption, credit, id, src }) {
+  return async function({ caption, credit, id, label, src }) {
     const table = await renderFile(path.join(assetsDir, src))
     const title = markdownify(caption)
 
+    const labelElement = figureLabel({ caption, id, label })
+
     return html`
       <a
-        class="inline popup"
-        data-type="inline"
+        class="q-figure__modal-link"
         href="#${id}"
         title="${title}"
       >
         ${table}
       </a>
-      ${figureCaption({ caption, credit })}
+      ${figureCaption({ caption, content: labelElement, credit })}
     `
   }
 }

--- a/packages/11ty/_includes/components/figure/video/html.js
+++ b/packages/11ty/_includes/components/figure/video/html.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const { warn, error } = chalkFactory('Figure Video')
 
-const videoElement = {
+const videoElements = {
   video({ id, poster='', src }) {
     if (!src) {
       error(`Cannot render Video without 'src'. Check that figures data for id: ${id} has a valid 'src'`)
@@ -68,7 +68,7 @@ module.exports = function(eleventyConfig) {
   const figureCaption = eleventyConfig.getFilter('figureCaption')
   const figureLabel = eleventyConfig.getFilter('figureLabel')
 
-  const { figureLabelLocation, imageDir } = eleventyConfig.globalData.config.params
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function({ aspect_ratio: aspectRatio, caption, credit, id, label, media_id: mediaId, media_type: mediaType, src }) {
     if (src) {
@@ -76,13 +76,15 @@ module.exports = function(eleventyConfig) {
     }
 
     const isEmbed = mediaType === 'vimeo' || mediaType === 'youtube'
+    const videoElement = videoElements[mediaType]({ id, mediaId, src })
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
 
     return html`
       <div class="q-figure__media-wrapper ${isEmbed && 'q-figure__media-wrapper--' + (aspectRatio || 'widescreen')}">
-        ${videoElement[mediaType]({ id, mediaId, src })}
-        ${label && figureLabelLocation === 'on-top' ? figureLabel({ caption, id, label }) : ''}
+        ${videoElement}
       </div>
-      ${figureCaption({ caption, credit })}
+      ${captionElement}
     `
   }
 }

--- a/packages/11ty/_includes/components/figure/video/print.js
+++ b/packages/11ty/_includes/components/figure/video/print.js
@@ -15,7 +15,7 @@ module.exports = function(eleventyConfig) {
   const figureCaption = eleventyConfig.getFilter('figureCaption')
   const figureLabel = eleventyConfig.getFilter('figureLabel')
 
-  const { figureLabelLocation, imageDir } = eleventyConfig.globalData.config.params
+  const { imageDir } = eleventyConfig.globalData.config.params
 
   return function({ aspect_ratio: aspectRatio, caption, credit, id, label, mediaType, poster=''}) {
     if (!poster) {
@@ -25,13 +25,14 @@ module.exports = function(eleventyConfig) {
     const posterSrc = poster.startsWith('http')
       ? poster
       : path.join(imageDir, poster)
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement,  credit })
 
     return html`
       <div class="q-figure__media-wrapper--${ aspectRatio || 'widescreen' }">
         <img src="${posterSrc}" />
       </div>
-      ${label && figureLabelLocation === 'on-top' ? figureLabel({ caption, id, label }) : ''}
-      ${figureCaption({ caption, credit })}
+      ${captionElement}
     `
   }
 }

--- a/packages/11ty/content/_assets/styles/components/q-figure.scss
+++ b/packages/11ty/content/_assets/styles/components/q-figure.scss
@@ -47,8 +47,7 @@
       transition: box-shadow 0.35s;
     }
 
-    .q-figure__label--below,
-    .q-figure__label--on-top {
+    .q-figure__label--below {
       transition: background-color 0.35s;
     }
 
@@ -65,10 +64,6 @@
         svg {
           fill: link-hover-color($content-background-color);
         }
-      }
-
-      .q-figure__label--on-top {
-        background-color: $accent-color;
       }
     }
   }
@@ -207,26 +202,6 @@
         }
         width: 1.5rem;
         height: 1.5rem;
-      }
-    }
-    // The figure label with figureLabelLocation: on-top (default)
-    &--on-top {
-      display: flex;
-      align-items: center;
-      color: $white;
-      position: absolute;
-      font-size: 0.75em;
-      top: 0;
-      left: 0;
-      height: 2.6em;
-      padding: 0 .6em;
-      margin: 0;
-      background: $black-semi-transparent;
-      .q-figure__label-icon {
-        margin-top: .3em;
-        svg {
-          fill: $white;
-        }
       }
     }
   }

--- a/packages/11ty/content/_data/config.yaml
+++ b/packages/11ty/content/_data/config.yaml
@@ -23,7 +23,6 @@ params:
   displayBiblioShort: true
   entryPageObjectLinkText: View in Collection
   entryPageSideBySideLayout: false
-  figureLabelLocation: on-top # below | on-top
   figureModal: true
   figureModalIcons: true
   figureZoom: true


### PR DESCRIPTION
- Remove all uses of `figureLabelLocation`
- Remove `--on-top` modifier styles
- Remove `figureLabelLocation` option from `config.yaml`
- Clean up table figure markup
- Remove use of `figureLabelLocation` from placeholder figure
