### PR TITLE
Feature/DEV-12650: Refactor section navigation data

### DIFF
--- a/packages/11ty/_includes/components/table-of-contents/epub.js
+++ b/packages/11ty/_includes/components/table-of-contents/epub.js
@@ -4,10 +4,11 @@
 module.exports = function(eleventyConfig) {
   const tableOfContentsList = eleventyConfig.getFilter('tableOfContentsList')
   return function(params) {
-    const { collections, currentPageUrl, presentation } = params
+    const { collections, currentPageUrl, key, presentation } = params
     return tableOfContentsList({ 
       collection: collections.tableOfContentsEpub,
       currentPageUrl,
+      key,
       presentation
     })
   }

--- a/packages/11ty/_includes/components/table-of-contents/html.js
+++ b/packages/11ty/_includes/components/table-of-contents/html.js
@@ -4,10 +4,11 @@
 module.exports = function(eleventyConfig) {
   const tableOfContentsList = eleventyConfig.getFilter('tableOfContentsList')
   return function(params) {
-    const { collections, currentPageUrl, presentation } = params
+    const { collections, currentPageUrl, key, presentation } = params
     return tableOfContentsList({ 
       collection: collections.tableOfContentsHtml,
       currentPageUrl,
+      key,
       presentation
     })
   }

--- a/packages/11ty/_includes/components/table-of-contents/list/index.js
+++ b/packages/11ty/_includes/components/table-of-contents/list/index.js
@@ -16,26 +16,11 @@ module.exports = function(eleventyConfig) {
   const tableOfContentsItem = eleventyConfig.getFilter('tableOfContentsItem')
 
   return function(params) {
-    const { collection, currentPageUrl, presentation } = params
+    const { collection, currentPageUrl, key, presentation } = params
 
-    /**
-     * Determine if we are rendering a section or publication Table of Contents
-     */
-    const findNavigationItem = (url, items) => {
-      if (!items || !items.length) return
-      let item = items.find((page) => url === page.url)
-      if (!item) {
-        items = items.flatMap((item) => item.children)
-        return findNavigationItem(url, items)
-      }
-      return item
-    }
-    const currentNavigationItem = findNavigationItem(currentPageUrl, eleventyNavigation(collection))
-
-    if (!currentNavigationItem) return
-
-    const navigation = currentNavigationItem.children && currentNavigationItem.children.length
-      ? currentNavigationItem.children
+    const sectionNavigation = eleventyNavigation(collection, key)
+    const navigation = sectionNavigation.length
+      ? sectionNavigation
       : eleventyNavigation(collection)
 
     const filterCurrentPage = (pages) => {

--- a/packages/11ty/_includes/components/table-of-contents/pdf.js
+++ b/packages/11ty/_includes/components/table-of-contents/pdf.js
@@ -4,10 +4,11 @@
 module.exports = function(eleventyConfig) {
   const tableOfContentsList = eleventyConfig.getFilter('tableOfContentsList')
   return function(params) {
-    const { collections, currentPageUrl, presentation } = params
+    const { collections, currentPageUrl, key, presentation } = params
     return tableOfContentsList({ 
       collection: collections.tableOfContentsPdf,
       currentPageUrl,
+      key,
       presentation
     })
   }

--- a/packages/11ty/_layouts/table-of-contents.11ty.js
+++ b/packages/11ty/_layouts/table-of-contents.11ty.js
@@ -18,11 +18,11 @@ module.exports = class TableOfContents {
     const {
       collections,
       content,
+      key,
       page,
       pages,
       pagination,
-      presentation='list',
-      section
+      presentation='list'
     } = data
 
     const contentElement = content
@@ -49,7 +49,7 @@ module.exports = class TableOfContents {
         ${contentElement}
         <div class="container ${containerClass}">
           <div class="quire-contents-list ${presentation}">
-            ${this.tableOfContents({ collections, currentPageUrl: page.url, presentation })}
+            ${this.tableOfContents({ collections, currentPageUrl: page.url, key, presentation })}
             <div class="content">
               {% bibliography pageReferences %}
             </div>

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -29,12 +29,7 @@ module.exports = {
         title: data.title
       }
     },
-    key: (data) => {
-      if (!data.page.url) return
-      const segments = data.page.url.split('/')
-      const key = segments.slice(1, segments.length - 1).join('/')
-      return data.key || key
-    },
+    key: (data) => data.key,
     order: (data) => data.order,
     parent: (data) => {
       if (!data.page.url) return
@@ -44,6 +39,12 @@ module.exports = {
     },
     url: (data) => data.page.url,
     title: (data) => data.title
+  },
+  key: (data) => {
+    if (!data.page.url) return
+    const segments = data.page.url.split('/')
+    const key = segments.slice(1, segments.length - 1).join('/')
+    return data.key || key
   },
   /**
    * Classes applied to <main> page element


### PR DESCRIPTION
Replaces many lines of code with the `eleventyNavigation` method filtered by `key`. See: https://www.11ty.dev/docs/plugins/navigation/#example-get-just-one-branch