### PR TITLE
Ensure audio, table, and video figures render centered in lightboxes

### DIFF
--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -35,6 +35,7 @@ module.exports = function(eleventyConfig) {
         src
       } = figure
 
+      const isAudio = mediaType === 'soundcloud'
       const isVideo = mediaType === 'video' || mediaType === 'vimeo' || mediaType === 'youtube'
 
       const figureElement = async (figure) => {
@@ -66,13 +67,21 @@ module.exports = function(eleventyConfig) {
         `
         : ''
 
+      const elementBaseClass = 'q-lightbox-slides__element'
+      const elementClasses = [
+        elementBaseClass,
+        mediaType ? `${elementBaseClass}--${mediaType}` : '',
+        isAudio ? `${elementBaseClass}--audio` : '',
+        isVideo ? `${elementBaseClass}--video ${elementBaseClass}--${aspectRatio}` : ''
+      ].join(' ')
+
       return html`
         <div
           class="q-lightbox-slides__slide"
           data-lightbox-slide
           data-lightbox-slide-id="${id}"
         >
-          <div class="q-lightbox-slides__element ${mediaType && 'q-lightbox-slides__element--' + mediaType} ${isVideo && 'q-lightbox-slides__element--video q-lightbox-slides__element--' + aspectRatio  }">
+          <div class="${elementClasses}">
             ${await figureElement(figure)}
           </div>
           <div class="q-figure-slides__slide-ui">

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
@@ -28,7 +28,7 @@
 
   .q-lightbox-slides__element {
     &--iiif,
-    &--video {
+    &--table {
       position: absolute;
       width: 100%;
       height: 100%;
@@ -37,17 +37,30 @@
     }
 
     &--soundcloud,
+    &--table,
+    &--video {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &--soundcloud,
     &--video {
       position: relative;
       width: 100%;
       max-width: 80vw;
       height: auto;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     &--video {
       iframe,
       video {
         position: absolute;
+        top: 0;
+        left: 0;
         width: 100%;
         height: 100%;
       }

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
@@ -36,7 +36,7 @@
       left: 0;
     }
 
-    &--soundcloud,
+    &--audio,
     &--table,
     &--video {
       display: flex;
@@ -44,7 +44,7 @@
       justify-content: center;
     }
 
-    &--soundcloud,
+    &--audio,
     &--video {
       position: relative;
       width: 100%;


### PR DESCRIPTION
- Ensure table, video, and audio figures are centered in lightboxes
- Refactor slide element classname construction to be more readable, add more general `--audio` modifier to follow video naming
