### PR TITLE
Correctly destructure and rename `mediaType` in figure shortcode

### DIFF
--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -46,7 +46,7 @@ module.exports = function (eleventyConfig, { page }) {
     if (!page.figures) page.figures = [];
     page.figures.push(figure);
 
-    const { mediaType } =  figure
+    const { media_type: mediaType } =  figure
 
     const component = async (figure) => {
       switch (true) {


### PR DESCRIPTION
typo! sorry y'all