### PR TITLE
Image Caching

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -1,8 +1,6 @@
 require('dotenv').config()
 require('module-alias/register')
 
-const fs = require('fs-extra')
-const path = require('path')
 const scss = require('rollup-plugin-scss')
 const copy = require('rollup-plugin-copy')
 
@@ -13,6 +11,7 @@ const {
   EleventyHtmlBasePlugin,
   EleventyRenderPlugin
 } = require('@11ty/eleventy')
+const cacheAssets = require('~plugins/cacheAssets')
 const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
 const directoryOutputPlugin = require('@11ty/eleventy-plugin-directory-output')
 const citationsPlugin = require('~plugins/citations')
@@ -85,6 +84,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(globalDataPlugin)
   eleventyConfig.addPlugin(i18nPlugin)
   eleventyConfig.addPlugin(figuresPlugin)
+  eleventyConfig.addPlugin(cacheAssets)
 
   /**
    * Load plugin for custom configuration of the markdown library
@@ -189,7 +189,7 @@ module.exports = function(eleventyConfig) {
         hmr: {
           overlay: false
         },
-        middlewareMode: 'ssr',
+        middlewareMode: true,
         mode: 'development'
       }
     }
@@ -204,7 +204,7 @@ module.exports = function(eleventyConfig) {
    * @see https://www.11ty.dev/docs/copy/
    */
   eleventyConfig.addPassthroughCopy(`${inputDir}/_assets`)
-  eleventyConfig.addPassthroughCopy(`${publicDir}`)
+  eleventyConfig.addPassthroughCopy(publicDir)
   eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript' })
 
   /**

--- a/packages/11ty/.gitignore
+++ b/packages/11ty/.gitignore
@@ -1,4 +1,5 @@
 # Eleventy build artifacts
+_assets/
 _site/
 _temp/
 

--- a/packages/11ty/_plugins/cacheAssets/index.js
+++ b/packages/11ty/_plugins/cacheAssets/index.js
@@ -1,0 +1,63 @@
+const EleventyFetch = require("@11ty/eleventy-fetch");
+const chalkFactory = require('~lib/chalk')
+const fs = require('fs-extra')
+const path = require('path')
+const sharp = require('sharp')
+const logger = chalkFactory(`Cache Assets Plugin`)
+
+module.exports = function (eleventyConfig, options = {}) {
+  const { outputDir, outputRoot } = eleventyConfig.globalData.iiifConfig
+  const assetDir = path.join(outputRoot, outputDir)
+
+  if (!process.env.CACHE_ASSETS) {
+    logger.info('Using passthrough copy for IIIF assets')
+    eleventyConfig.addPassthroughCopy({ [assetDir]: outputDir })
+    return
+  }
+
+  const imageHost = process.env.IMAGE_HOST
+  const exts = ['.png', '.jpg', '.json']
+
+  const filesToCache = (assetDir) => {
+    let filePaths = []
+    const getFilesRecursive = (dir) => {
+      fs.readdirSync(dir).forEach(child => {
+        const filePath = path.join(dir, child)
+        const pathStat = fs.lstatSync(filePath)
+        if (pathStat.isDirectory()) {
+          getFilesRecursive(filePath)
+        } else if (exts.includes(path.parse(filePath).ext)) {
+          filePaths.push(filePath)
+        }
+      })
+    }
+    getFilesRecursive(assetDir)
+    return filePaths
+  }
+
+  const cache = async (filePath) => {
+    const { ext } = path.parse(filePath)
+    const [root, relativePath] = filePath.split(outputRoot)
+    const url = new URL(relativePath, imageHost).href
+    const type = ext === '.json' ? 'json' : 'buffer'
+    try {
+      const response = await EleventyFetch(url, {
+        duration: '*', // set cache to never expire
+        type
+      })
+      if (type === 'json') {
+        return response
+      }
+      const { data, info } = await sharp(response).toBuffer({ resolveWithObject: true })
+      return data
+    } catch (err) {
+      logger.error(err)
+    }
+  }
+
+  eleventyConfig.on('eleventy.after', function() {
+    logger.info('Caching IIIF images')
+    const filePaths = filesToCache(assetDir)
+    filePaths.forEach((filePath) => cache(filePath))
+  })
+}

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -1,9 +1,8 @@
 const path = require('path')
 
 module.exports = (eleventyConfig) => {
-  const { config, env } = eleventyConfig.globalData
   const iiifConfig = {
-    baseURL: config.baseURL || env.URL,
+    baseURL: process.env.CACHE_ASSETS ? process.env.IMAGE_HOST : process.env.URL,
     /**
      * Input and output of processable image formats
      * @type {Array<Object>}
@@ -46,7 +45,7 @@ module.exports = (eleventyConfig) => {
      * @type {String}
      */
     outputDir: 'iiif',
-    outputRoot: 'public',
+    outputRoot: '_assets',
     tileSize: 256,
     /**
      * Transformations to apply to each image

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -12,8 +12,8 @@ const builder = new IIIFBuilder(vault)
 
 module.exports = class Manifest {
   constructor({ figure, writer }) {
-    const { outputDir, manifestFilename } = writer.iiifConfig
-    const baseId = [process.env.URL, outputDir, figure.id].join('/')
+    const { baseURL, outputDir, manifestFilename } = writer.iiifConfig
+    const baseId = [baseURL, outputDir, figure.id].join('/')
 
     this.canvas = {
       id: [baseId, 'canvas'].join('/')

--- a/packages/11ty/_plugins/figures/iiif/tiler.js
+++ b/packages/11ty/_plugins/figures/iiif/tiler.js
@@ -2,7 +2,7 @@ const chalkFactory = require('~lib/chalk')
 const fs = require('fs-extra')
 const path = require('path')
 const sharp = require('sharp')
-const { info } = chalkFactory('Figure Processing:IIIF:Tile Image')
+const logger = chalkFactory('Figure Processing:IIIF:Tile Image')
 
 
 module.exports = class Tiler {
@@ -44,27 +44,28 @@ module.exports = class Tiler {
     const format = formats.find(({ input }) => input.includes(ext))
     const inputPath = path.join(inputRoot, inputDir, figure.src)
     const outputPath = path.join(outputRoot, outputDir, name, imageServiceDirectory)
-    const url = new URL(path.join(outputDir, name, imageServiceDirectory, 'info.json'), baseURL).href
+    const id = new URL(path.join(outputDir, name), baseURL).href
+    const info = [id, imageServiceDirectory, 'info.json'].join('/')
 
     if (fs.existsSync(outputFile)) {
-      info(`Skipping previously tiled image "${inputPath}"`)
-      return { info: url }
+      logger.info(`Skipping previously tiled image "${inputPath}"`)
+      return { info }
     }
 
     fs.ensureDirSync(outputPath)
 
     try {
-      info(`Tiling image: "${inputPath}"`)
+      logger.info(`Tiling image: "${inputPath}"`)
       const response = await sharp(inputPath)
         .toFormat(format.output.replace('.', ''))
         .tile({
-          id: url,
+          id,
           layout: 'iiif',
           size: tileSize
         })
         .toFile(outputPath)
-      info(`Done tiling image "${inputPath}"`)
-      return { info: url }
+      logger.info(`Done tiling image "${inputPath}"`)
+      return { info }
     } catch(error) {
       return { errors: [error] }
     }

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0-canary.15",
+        "@11ty/eleventy-fetch": "^3.0.0",
         "@11ty/eleventy-img": "^2.0.1",
         "@11ty/eleventy-navigation": "^0.3.5",
         "@11ty/eleventy-plugin-directory-output": "^1.0.1",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -11,11 +11,14 @@
     "clean": "del ${ELEVENTY_OUTPUT_DIR:-_site} public/pdf.css public/pdf.html",
     "debug": "DEBUG=Eleventy* eleventy --dryrun",
     "dev": "ELEVENTY_ENV=development eleventy --serve",
+    "dev-cache-assets": "npm run serve-assets & CACHE_ASSETS=true npm run dev && npm run stop-serve-assets",
     "prebuild": "npm run clean",
     "prepare": "test -f .env || cpy .env.example . --rename=.env",
     "predev": "npm run clean",
     "preserve": "npm run clean",
     "serve": "ELEVENTY_ENV=production eleventy --serve",
+    "serve-assets": "npx http-server _assets --cors --port=9999",
+    "stop-serve-assets": "kill $(lsof -t -i:9999)",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -26,6 +29,7 @@
   "license": "J Paul Getty Trust",
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0-canary.15",
+    "@11ty/eleventy-fetch": "^3.0.0",
     "@11ty/eleventy-img": "^2.0.1",
     "@11ty/eleventy-navigation": "^0.3.5",
     "@11ty/eleventy-plugin-directory-output": "^1.0.1",


### PR DESCRIPTION
\~Exploring image caching options\~

This approach adds an npm script `npm run dev-cache-assets` which process IIIF images -> runs an image server ->  uses [`EleventyFetch`](https://www.11ty.dev/docs/plugins/fetch/) to fetch and cache IIIF images and json. `npm run dev` still use `passthroughCopy` for images.  I don't know if we want both to be an option, having both right now is just for demonstration purposes.

Todo:
- cache regular non-IIIF images

Thoughts:
- iiif processing shouldn't re-run on watch (currently rebuilds manifests and logs what it's skipping), and probably shouldn't re-run at all unless the user wants it to, and it probably should be part of the CLI
- 