### PR TITLE
Define pageLabelDivider to config, and wrap it in spans in the markup

### DIFF
--- a/packages/11ty/_includes/components/table-of-contents/item/grid.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/grid.js
@@ -20,7 +20,7 @@ module.exports = function (eleventyConfig) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const tableOfContentsImage = eleventyConfig.getFilter('tableOfContentsImage')
   const urlFilter = eleventyConfig.getFilter('url')
-  const { imageDir } = eleventyConfig.globalData.config.params
+  const { imageDir, pageContributorDivider } = eleventyConfig.globalData.config.params
 
   return function (params) {
     const {
@@ -48,8 +48,10 @@ module.exports = function (eleventyConfig) {
      */
     const isPage = !!layout
 
+    const divider = pageContributorDivider ? pageContributorDivider : ' — '
+
     const pageContributorsElement = pageContributors
-      ? `<span class="contributor"> — ${contributors({ context: pageContributors, format: 'string' })}</span>`
+      ? `<span class="contributor-divider">${divider}</span><span class="contributor">${contributors({ context: pageContributors, format: 'string' })}</span>`
       : ''
     const pageTitleElement = oneLine`${pageTitle({ label, subtitle, title })}${pageContributorsElement}`
     const arrowIcon = `<span class="arrow" data-outputs-exclude="epub,pdf">${icon({ type: 'arrow-forward', description: '' })}</span>`

--- a/packages/11ty/_includes/components/table-of-contents/item/grid.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/grid.js
@@ -48,7 +48,7 @@ module.exports = function (eleventyConfig) {
      */
     const isPage = !!layout
 
-    const divider = pageContributorDivider ? pageContributorDivider : ' — '
+    const divider = pageContributorDivider || ' — '
 
     const pageContributorsElement = pageContributors
       ? `<span class="contributor-divider">${divider}</span><span class="contributor">${contributors({ context: pageContributors, format: 'string' })}</span>`

--- a/packages/11ty/_includes/components/table-of-contents/item/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/list.js
@@ -45,7 +45,7 @@ module.exports = function (eleventyConfig) {
      */
     const isPage = !!layout
 
-    const divider = pageContributorDivider ? pageContributorDivider : ' — '
+    const divider = pageContributorDivider || ' — '
 
     const pageContributorsElement = pageContributors
       ? `<span class="contributor-divider">${divider}</span><span class="contributor">${contributors({ context: pageContributors, format: 'string' })}</span>`

--- a/packages/11ty/_includes/components/table-of-contents/item/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/list.js
@@ -18,6 +18,7 @@ module.exports = function (eleventyConfig) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const removeHTML = eleventyConfig.getFilter('removeHTML')
   const urlFilter = eleventyConfig.getFilter('url')
+  const { pageContributorDivider } = eleventyConfig.globalData.config.params
 
   return function (params) {
     const {
@@ -44,8 +45,10 @@ module.exports = function (eleventyConfig) {
      */
     const isPage = !!layout
 
+    const divider = pageContributorDivider ? pageContributorDivider : ' — '
+
     const pageContributorsElement = pageContributors
-      ? `<span class="contributor"> — ${contributors({ context: pageContributors, format: 'string' })}</span>`
+      ? `<span class="contributor-divider">${divider}</span><span class="contributor">${contributors({ context: pageContributors, format: 'string' })}</span>`
       : ''
 
     let pageTitleElement

--- a/packages/11ty/content/_data/config.yaml
+++ b/packages/11ty/content/_data/config.yaml
@@ -30,6 +30,7 @@ params:
   licenseIcons: true
   menuType: full
   nextPageButtonText: Next
+  pageContributorDivider: ' — '
   pageLabelDivider: '. '
   prevPageButtonText: Back
   searchEnabled: true


### PR DESCRIPTION
Needed better control of the divider between the page label and the page title for _Bronze Guidelines_. And it seemed like a useful change for core Quire as well so I'm submitting it in this PR. I also took the opportunity to define the value in config.yaml rather than leave it hard coded in the templates, though I have a fallback in the templates if `pageLabelDivider` is not present.