### PR TITLE
Use contributor_as_it_appears override in cover and menu templates

### DIFF
--- a/packages/11ty/_includes/components/menu/header.js
+++ b/packages/11ty/_includes/components/menu/header.js
@@ -12,7 +12,7 @@ module.exports = function(eleventyConfig) {
   const contributors = eleventyConfig.getFilter('contributors')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const siteTitle = eleventyConfig.getFilter('siteTitle')
-  const { publication } = eleventyConfig.globalData
+  const { contributor: publicationContributors, contributor_as_it_appears } = eleventyConfig.globalData.publication
 
   return function(params) {
     const { currentURL } = params
@@ -21,11 +21,10 @@ module.exports = function(eleventyConfig) {
     const homePageLinkOpenTag = isHomePage ? '' : `<a class="quire-menu__header__title-link" href="/">`
     const homePageLinkCloseTag = isHomePage ? '' : `</a>`
 
-    const contributorElement = publication.contributor 
-      ? `
-        <span class="visually-hidden">Contributors: </span>
-        ${contributors({ context: publication.contributor, format: 'string', type: 'primary' })}
-      `
+    const contributorContent = contributor_as_it_appears || contributors({ context: publicationContributors, format: 'string', type: 'primary' })
+
+    const contributorElement = contributorContent
+      ? `<span class="visually-hidden">Contributors: </span>${contributorContent}`
       : ''
 
     return html`

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -25,7 +25,7 @@ layout: base.11ty.js
       <div class="contributor">
         <span class="visually-hidden">Contributors:&nbsp;</span>
         {% if publication.contributor_as_it_appears %}
-          <em>{% publication.contributor_as_it_appears %}</em>
+          <em>{{ publication.contributor_as_it_appears }}</em>
         {% else %}
           <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
         {% endif %}

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -24,7 +24,11 @@ layout: base.11ty.js
       <p class="reading-line">{{ publication.reading_line | markdownify }}</p>
       <div class="contributor">
         <span class="visually-hidden">Contributors:&nbsp;</span>
-        <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
+        {% if publication.contributor_as_it_appears %}
+          <em>{% publication.contributor_as_it_appears %}</em>
+        {% else %}
+          <em>{% contributors context=publicationContributors, format='string', type='primary' %}</em>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -138,9 +138,8 @@ module.exports = {
    * Contributors with a `pages` property containing data about the pages they contributed to
    */
   publicationContributors: ({ collections, config, publication }) => {
-    const { contributor, contributor_as_it_appears } = publication
+    const { contributor } = publication
     if (!collections.all) return
-    if (contributor_as_it_appears) return contributor_as_it_appears
     return contributor
       .map((item) => {
         const { pic } = item


### PR DESCRIPTION
Changes:
- Remove `contributor_as_it_appears` from computed `publicationContributors` property and only use it in the cover and menu so that publication contributors can be rendered in other formats in other contexts like the contributors page.