### PR TITLE
Fix: npm clean script to use a cross platform command name

### DIFF
--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -13,7 +13,6 @@
     "debug": "DEBUG=Eleventy* eleventy --dryrun",
     "dev": "ELEVENTY_ENV=development eleventy --serve",
     "prebuild": "npm run clean",
-    "prepare": "test -f .env || cpy .env.example . --rename=.env",
     "predev": "npm run clean",
     "preserve": "npm run clean",
     "serve": "ELEVENTY_ENV=production eleventy --serve",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -5,10 +5,11 @@
   "description": "",
   "main": ".eleventy.js",
   "scripts": {
+    "benchmark": "DEBUG=Eleventy:Benchmark* eleventy",
     "build": "ELEVENTY_ENV=production eleventy",
     "build:pdf": "pagedjs-cli public/pdf.html --outline-tags 'h1' -o paged.pdf",
     "build:prince": "prince public/pdf.html --output prince.pdf",
-    "clean": "del ${ELEVENTY_OUTPUT_DIR:-_site} public/pdf.css public/pdf.html",
+    "clean": "del-cli _site public/pdf.css public/pdf.html",
     "debug": "DEBUG=Eleventy* eleventy --dryrun",
     "dev": "ELEVENTY_ENV=development eleventy --serve",
     "prebuild": "npm run clean",


### PR DESCRIPTION
## Added

- Npm `benchmark` script to run Eleventy debug with output of benchmarks.

## Fixed

- Updates the npm `clean` script to use the cross platform `del-cli` command name

## Changed

- Remove environment variable for output directory from npm `clean` script

## Removed

- Npm `prepare` script as it is not cross platform
  