### PR TITLE
Feature/DEV-13184: Select figure annotations using query paramters

### DIFF
--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -59,7 +59,7 @@ const goToCanvasState = function (figureId, annotationIds=[], region) {
   /**
    * Update Canvas state
    */
-  if (region) canvasPanel.setAttribute('region', region)x
+  if (region) canvasPanel.setAttribute('region', region)
   annotationIds.forEach((id) => {
     const input = document.getElementById(id)
     if (!input) {

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -1,4 +1,4 @@
-import scrollToHash from "./scroll-to-hash"
+import scrollToHash from './scroll-to-hash'
 
 /**
  * Handle annotation/choice selection with canvasPanel API

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -52,8 +52,9 @@ const handleSelect = (element) => {
  * @param  {Array} annotationIds  The IIIF ids of the annotations to select
  * @param  {String} region      The canvas region
  */
-const goToCanvasState = function (figureId, annotationIds=[], region) {
+const goToCanvasState = function ({ figureId, annotationIds=[], region }) {
   const figure = document.querySelector(`#${figureId}`)
+  if (!figure) return
   const canvasPanel = figure.querySelector('canvas-panel')
 
   /**
@@ -86,23 +87,15 @@ const goToCanvasState = function (figureId, annotationIds=[], region) {
   window.history.pushState({}, '', `${urlParts.join('?')}${url.hash}`)
 }
 
-const goToCanvasStateOnLoad = function(params) {
-  /**
-   * Set initial canvas state and attach click handlers to Annotations UI inputs
-   */
+/**
+ * Add event handlers to Annotations UI inputs
+ */
+const setUpUIEventHandlers = function() {
   const inputs = document.querySelectorAll('.annotations-ui__input')
   for (const input of inputs) {
     handleSelect(input)
     input.addEventListener('click', ({ target }) => handleSelect(target))
   }
-
-  /**
-   * Set canvas state from query parameters
-   */
-  const annotationIds = params['annotation-id']
-  const figureId = window.location.hash.replace(/^#/, '')
-  const region = params['region']
-  goToCanvasState(figureId, annotationIds, region)
 }
 
-export { goToCanvasStateOnLoad }
+export { goToCanvasState, setUpUIEventHandlers }

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -1,51 +1,95 @@
 import scrollToHash from "./scroll-to-hash"
 
-window.onload = function () {
-  /**
-   * Handle annotation/choice selection with canvasPanel API
-   * {@link https://iiif-canvas-panel.netlify.app/docs/examples/handling-choice}
-   */
-  const handleSelect = (element) => {
-    const figure = element.closest('.q-figure')
-    if (!figure) return
-    const canvasPanel = figure.querySelector('canvas-panel')
-    const annotationType = element.getAttribute('data-annotation-type')
-    const id = element.getAttribute('id')
-    const inputType = element.getAttribute('type')
+/**
+ * Handle annotation/choice selection with canvasPanel API
+ * {@link https://iiif-canvas-panel.netlify.app/docs/examples/handling-choice}
+ */
+const handleSelect = (element) => {
+  const figure = element.closest('.q-figure')
+  if (!figure) return
+  const canvasPanel = figure.querySelector('canvas-panel')
+  const annotationType = element.getAttribute('data-annotation-type')
+  const id = element.getAttribute('id')
+  const inputType = element.getAttribute('type')
 
-    const toggleChoice = ({ checked }) => {
-      canvasPanel.makeChoice(id, {
-        deselect: !checked,
-        deselectOthers: inputType === 'radio'
-      })
-      if (inputType !== 'checkbox') return
-      const checkedInputs = figure.querySelectorAll('.annotations-ui__input[checked]')
-      if (!checked && checkedInputs.length === 1) {
-        checkedInputs[0].setAttribute('disabled', true)
-      }
-      if (checked) {
-        const disabledInput = figure.querySelector('[disabled]')
-        disabledInput ? disabledInput.removeAttribute('disabled') : null
-      }
+  const toggleChoice = ({ checked }) => {
+    canvasPanel.makeChoice(id, {
+      deselect: !checked,
+      deselectOthers: inputType === 'radio'
+    })
+    if (inputType !== 'checkbox') return
+    const checkedInputs = figure.querySelectorAll('.annotations-ui__input[checked]')
+    if (!checked && checkedInputs.length === 1) {
+      checkedInputs[0].setAttribute('disabled', true)
     }
-
-    const toggleAnnotation = ({ checked }) => {
-      canvasPanel.applyStyles(id, { opacity: Number(!!checked) })
-    }
-
-    switch (annotationType) {
-      case 'choice':
-        toggleChoice(element)
-        break
-      case 'annotation':
-        toggleAnnotation(element)
-        break
-      default:
-        console.warn(`Invalid annotation type ${annotationType}`)
-        break
+    if (checked) {
+      const disabledInput = figure.querySelector('[disabled]')
+      disabledInput ? disabledInput.removeAttribute('disabled') : null
     }
   }
 
+  const toggleAnnotation = ({ checked }) => {
+    canvasPanel.applyStyles(id, { opacity: Number(!!checked) })
+  }
+
+  switch (annotationType) {
+    case 'choice':
+      toggleChoice(element)
+      break
+    case 'annotation':
+      toggleAnnotation(element)
+      break
+    default:
+      console.warn(`Invalid annotation type ${annotationType}`)
+      break
+  }
+}
+
+/**
+ * Scroll to a figure, select annotations and/or region, and update the URL
+ * @param  {String} figureId    The id of the figure in figures.yaml
+ * @param  {Array} annotationIds  The IIIF ids of the annotations to select
+ * @param  {String} region      The canvas region
+ */
+const setCanvasState = function (figureId, annotationIds=[], region) {
+  const figure = document.querySelector(`#${figureId}`)
+  const canvasPanel = figure.querySelector('canvas-panel')
+
+  /**
+   * Update Canvas state
+   */
+  if (region) canvasPanel.setAttribute('region', region)
+  annotationIds.forEach((id) => {
+    const input = document.getElementById(id)
+    if (!input) {
+      console.warn(`Invalid annotation id: ${id}`)
+      return
+    }
+    input.checked = true
+    console.log('setCanvasState', id)
+    handleSelect(input)
+  })
+
+  /**
+   * Build URL
+   */
+  const url = new URL(window.location.pathname, window.location.origin)
+  url.hash = figureId
+  scrollToHash(url.hash)
+  const params = new URLSearchParams(
+    annotationIds.map((id) => ['annotation-id', encodeURIComponent(id)]),
+  )
+  region ? params.set('region', encodeURIComponent(region)) : null
+  const paramsString = params.toString()
+  const urlParts = [url.pathname]
+  if (paramsString) urlParts.push(paramsString)
+  window.history.pushState({}, '', `${urlParts.join('?')}${url.hash}`)
+}
+
+const setCanvasStateOnLoad = function(params) {
+  /**
+   * Set initial canvas state and attach click handlers to Annotations UI inputs
+   */
   const inputs = document.querySelectorAll('.annotations-ui__input')
   for (const input of inputs) {
     handleSelect(input)
@@ -53,29 +97,12 @@ window.onload = function () {
   }
 
   /**
-   * Global method that scrolls to a figure, selects annotations and/or region, and updates the URL
-   * @param  {String} figureId    The id of the figure in figures.yaml
-   * @param  {Array} annotationIds  The IIIF ids of the annotations to select
-   * @param  {String} region      The canvas region
+   * Set canvas state from query parameters
    */
-  const goToAnnotation = function (figureId, annotationIds=[], region) {
-    const url = new URL(window.location.pathname, window.location.origin)
-    url.hash = figureId
-    scrollToHash(url.hash)
-    const params = new URLSearchParams(
-      annotationIds.map((id) => ['annotation-id', encodeURIComponent(id)]),
-    )
-    region ? params.set('region', encodeURIComponent(region)) : null
-    annotationIds.forEach((id) => {
-      const input = document.getElementById(id)
-      input.checked = true
-      handleSelect(input)
-    })
-    const paramsString = params.toString()
-    const urlParts = [url.pathname]
-    if (paramsString) urlParts.push(paramsString)
-    window.history.pushState({}, '', `${urlParts.join('?')}${url.hash}`)
-  }
-
-  window.goToAnnotation = goToAnnotation
+  const annotationIds = params['annotation-id']
+  const figureId = window.location.hash.replace(/^#/, '')
+  const region = params['region']
+  setCanvasState(figureId, annotationIds, region)
 }
+
+export { setCanvasStateOnLoad }

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -3,6 +3,7 @@ import scrollToHash from "./scroll-to-hash"
 /**
  * Handle annotation/choice selection with canvasPanel API
  * {@link https://iiif-canvas-panel.netlify.app/docs/examples/handling-choice}
+ * @param {HTMLElement} element
  */
 const handleSelect = (element) => {
   const figure = element.closest('.q-figure')

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -66,7 +66,6 @@ const goToCanvasState = function (figureId, annotationIds=[], region) {
       return
     }
     input.checked = true
-    console.log('goToCanvasState', id)
     handleSelect(input)
   })
 

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -51,14 +51,14 @@ const handleSelect = (element) => {
  * @param  {Array} annotationIds  The IIIF ids of the annotations to select
  * @param  {String} region      The canvas region
  */
-const setCanvasState = function (figureId, annotationIds=[], region) {
+const goToCanvasState = function (figureId, annotationIds=[], region) {
   const figure = document.querySelector(`#${figureId}`)
   const canvasPanel = figure.querySelector('canvas-panel')
 
   /**
    * Update Canvas state
    */
-  if (region) canvasPanel.setAttribute('region', region)
+  if (region) canvasPanel.setAttribute('region', region)x
   annotationIds.forEach((id) => {
     const input = document.getElementById(id)
     if (!input) {
@@ -66,7 +66,7 @@ const setCanvasState = function (figureId, annotationIds=[], region) {
       return
     }
     input.checked = true
-    console.log('setCanvasState', id)
+    console.log('goToCanvasState', id)
     handleSelect(input)
   })
 
@@ -86,7 +86,7 @@ const setCanvasState = function (figureId, annotationIds=[], region) {
   window.history.pushState({}, '', `${urlParts.join('?')}${url.hash}`)
 }
 
-const setCanvasStateOnLoad = function(params) {
+const goToCanvasStateOnLoad = function(params) {
   /**
    * Set initial canvas state and attach click handlers to Annotations UI inputs
    */
@@ -102,7 +102,7 @@ const setCanvasStateOnLoad = function(params) {
   const annotationIds = params['annotation-id']
   const figureId = window.location.hash.replace(/^#/, '')
   const region = params['region']
-  setCanvasState(figureId, annotationIds, region)
+  goToCanvasState(figureId, annotationIds, region)
 }
 
-export { setCanvasStateOnLoad }
+export { goToCanvasStateOnLoad }

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -1,51 +1,81 @@
-window.onload = function () {
-  const canvasPanels = document.getElementsByTagName('canvas-panel')
+import scrollToHash from "./scroll-to-hash"
 
+window.onload = function () {
   /**
    * Handle annotation/choice selection with canvasPanel API
    * {@link https://iiif-canvas-panel.netlify.app/docs/examples/handling-choice}
    */
-  for (const canvasPanel of canvasPanels) {
-    const figure = canvasPanel.closest('.q-figure, q-lightbox')
+  const handleSelect = (element) => {
+    const figure = element.closest('.q-figure')
     if (!figure) return
-    const inputs = figure.querySelectorAll('.annotations-ui .annotations-ui__input')
-    for (const input of inputs) {
-      const annotationType = input.getAttribute('data-annotation-type')
-      const id = input.getAttribute('id')
-      const inputType = input.getAttribute('type')
-      switch (annotationType) {
-        case 'choice':
-          const toggleChoice = ({ checked }) => {
-            canvasPanel.makeChoice(id, {
-              deselect: !checked,
-              deselectOthers: inputType === 'radio'
-            })
-            if (inputType !== 'checkbox') return
-            const checkedInputs = figure.querySelectorAll('.annotations-ui__input[checked]')
-            if (!checked && checkedInputs.length === 1) {
-              checkedInputs[0].setAttribute('disabled', true)
-            }
-            if (checked) {
-              const disabledInput = figure.querySelector('[disabled]')
-              disabledInput ? disabledInput.removeAttribute('disabled') : null
-            }
-          }
-          toggleChoice(input)
-          input.addEventListener('click', ({ target }) => {
-            toggleChoice(target)
-          })
-          break
-        case 'annotation':
-          const toggleAnnotation = ({ checked }) => {
-            canvasPanel.applyStyles(id, { opacity: Number(!!checked) })
-          }
-          toggleAnnotation(input)
-          input.addEventListener('click', ({ target }) => toggleAnnotation(target));
-          break
-        default:
-          console.warn(`Invalid annotation type ${annotationType}`)
-          break
+    const canvasPanel = figure.querySelector('canvas-panel')
+    const annotationType = element.getAttribute('data-annotation-type')
+    const id = element.getAttribute('id')
+    const inputType = element.getAttribute('type')
+
+    const toggleChoice = ({ checked }) => {
+      canvasPanel.makeChoice(id, {
+        deselect: !checked,
+        deselectOthers: inputType === 'radio'
+      })
+      if (inputType !== 'checkbox') return
+      const checkedInputs = figure.querySelectorAll('.annotations-ui__input[checked]')
+      if (!checked && checkedInputs.length === 1) {
+        checkedInputs[0].setAttribute('disabled', true)
+      }
+      if (checked) {
+        const disabledInput = figure.querySelector('[disabled]')
+        disabledInput ? disabledInput.removeAttribute('disabled') : null
       }
     }
+
+    const toggleAnnotation = ({ checked }) => {
+      canvasPanel.applyStyles(id, { opacity: Number(!!checked) })
+    }
+
+    switch (annotationType) {
+      case 'choice':
+        toggleChoice(element)
+        break
+      case 'annotation':
+        toggleAnnotation(element)
+        break
+      default:
+        console.warn(`Invalid annotation type ${annotationType}`)
+        break
+    }
   }
+
+  const inputs = document.querySelectorAll('.annotations-ui__input')
+  for (const input of inputs) {
+    handleSelect(input)
+    input.addEventListener('click', ({ target }) => handleSelect(target))
+  }
+
+  /**
+   * Global method that scrolls to a figure, selects annotations and/or region, and updates the URL
+   * @param  {String} figureId    The id of the figure in figures.yaml
+   * @param  {Array} annotationIds  The IIIF ids of the annotations to select
+   * @param  {String} region      The canvas region
+   */
+  const goToAnnotation = function (figureId, annotationIds=[], region) {
+    const url = new URL(window.location.pathname, window.location.origin)
+    url.hash = figureId
+    scrollToHash(url.hash)
+    const params = new URLSearchParams(
+      annotationIds.map((id) => ['annotation-id', encodeURIComponent(id)]),
+    )
+    region ? params.set('region', encodeURIComponent(region)) : null
+    annotationIds.forEach((id) => {
+      const input = document.getElementById(id)
+      input.checked = true
+      handleSelect(input)
+    })
+    const paramsString = params.toString()
+    const urlParts = [url.pathname]
+    if (paramsString) urlParts.push(paramsString)
+    window.history.pushState({}, '', `${urlParts.join('?')}${url.hash}`)
+  }
+
+  window.goToAnnotation = goToAnnotation
 }

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -373,6 +373,6 @@ window.addEventListener('DOMContentLoaded', () => {
   goToCanvasState({
     figureId: window.location.hash.replace(/^#/, ''),
     annotationIds: params['annotation-id'],
-    region: params['region']
+    region: params['region'][0]
   })
 })

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -15,6 +15,7 @@ import "../../styles/custom.css";
 import scrollToHash from "./scroll-to-hash"
 import Search from "../../../../_plugins/search/search.js";
 import "./canvas-panel";
+import { setCanvasStateOnLoad } from "./canvas-panel";
 import "./soundcloud-api";
 
 // array of leaflet instances
@@ -352,6 +353,17 @@ function pageSetup() {
   toggleCite();
 }
 
+function parseQueryParams() {
+  const url = new URL(window.location)
+  const uniqueKeys = [...new Set(url.searchParams.keys())]
+  return Object.fromEntries(
+    uniqueKeys.map((key) => [
+      key,
+      url.searchParams.getAll(key).map(decodeURIComponent)
+    ])
+  )
+}
+
 // Start
 // -----------------------------------------------------------------------------
 //
@@ -360,6 +372,8 @@ globalSetup();
 
 // Run when DOM content has loaded
 window.addEventListener('DOMContentLoaded', () => {
-  pageSetup();
-  scrollToHashOnLoad();
+  pageSetup()
+  const params = parseQueryParams()
+  setCanvasStateOnLoad(params)
+  scrollToHashOnLoad()
 })

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -15,7 +15,7 @@ import "../../styles/custom.css";
 import scrollToHash from "./scroll-to-hash"
 import Search from "../../../../_plugins/search/search.js";
 import "./canvas-panel";
-import { setCanvasStateOnLoad } from "./canvas-panel";
+import { goToCanvasStateOnLoad } from "./canvas-panel";
 import "./soundcloud-api";
 
 // array of leaflet instances
@@ -374,6 +374,6 @@ globalSetup();
 window.addEventListener('DOMContentLoaded', () => {
   pageSetup()
   const params = parseQueryParams()
-  setCanvasStateOnLoad(params)
+  goToCanvasStateOnLoad(params)
   scrollToHashOnLoad()
 })

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -15,7 +15,7 @@ import "../../styles/custom.css";
 import scrollToHash from "./scroll-to-hash"
 import Search from "../../../../_plugins/search/search.js";
 import "./canvas-panel";
-import { goToCanvasStateOnLoad } from "./canvas-panel";
+import { goToCanvasState, setUpUIEventHandlers } from "./canvas-panel";
 import "./soundcloud-api";
 
 // array of leaflet instances
@@ -364,7 +364,15 @@ globalSetup();
 // Run when DOM content has loaded
 window.addEventListener('DOMContentLoaded', () => {
   pageSetup()
+  scrollToHash(window.location.hash, 75, 'swing')
   const params = parseQueryParams()
-  goToCanvasStateOnLoad(params)
-  scrollToHash(window.location.hash, 75, 'swing');
+  /**
+   * Canvas Panel Setup
+   */
+  setUpUIEventHandlers()
+  goToCanvasState({
+    figureId: window.location.hash.replace(/^#/, ''),
+    annotationIds: params['annotation-id'],
+    region: params['region']
+  })
 })

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -12,6 +12,7 @@ import "../../styles/application.scss";
 import "../../styles/custom.css";
 
 // Modules (feel free to define your own and import here)
+import scrollToHash from "./scroll-to-hash"
 import Search from "../../../../_plugins/search/search.js";
 import "./canvas-panel";
 import "./soundcloud-api";
@@ -134,51 +135,6 @@ window["search"] = () => {
     });
   }
 };
-
-/**
- * scrollWindow
- * @description scroll viewport to a certain vertical offset, minus the height of the quire navbar
- * TODO add animation duration and style of easing function previously provided by jQuery `.animate()`
- */
-function scrollWindow(verticalOffset, animationDuration = null, animationStyle = null) {
-  const navBar = document.querySelector(".quire-navbar");
-  const extraSpace = 7
-  const scrollDistance = navBar
-    ? verticalOffset - navBar.clientHeight - extraSpace
-    : verticalOffset - extraSpace
-  // redundancy here to ensure all possible document properties with `scrollTop` are being set for cross-browser compatibility
-  [
-    document.documentElement,
-    document.body.parentNode,
-    document.body
-  ].forEach((documentPropertyWithScrollTop) => {
-    documentPropertyWithScrollTop.scrollTop = scrollDistance;
-  });
-}
-
-/**
- * scrollToHash
- * @description Scroll the #main area after each smoothState reload.
- * If a hash id is present, scroll to the location of that element,
- * taking into account the height of the navbar.
- */
-function scrollToHash(hash) {
-  // prefix all ':' and '.' in hash with '\\' to make them query-selectable
-  hash = hash.replace(":", "\\:");
-  hash = hash.replace(".", "\\.");
-  // Figure out element to scroll to
-  let target = document.querySelector(hash);
-  target = target ? target : document.querySelector(`[name="${link.hash.slice(1)}"]`);
-  // Does a scroll target exist?
-  if (target) {
-    const verticalOffset = target.getBoundingClientRect().top + window.scrollY;
-    scrollWindow(verticalOffset);
-    // handle focus after scrolling
-    setTimeout(() => {
-      target.focus();
-    });
-  }
-}
 
 function onHashLinkClick(event) {
   // only override default link behavior if it points to the same page

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -168,15 +168,6 @@ function setupCustomScrollToHash() {
   });
 }
 
-function scrollToHashOnLoad() {
-  if (window.location.hash) {
-    setTimeout(() => {
-      // TODO see scrollToHash definition. Add animation duration and easing function style previously provided as args to jQuery `.animate()`
-      scrollToHash(window.location.hash, 75, 'swing');
-    });
-  }
-}
-
 /**
  * globalSetup
  * @description Initial setup on first page load.
@@ -375,5 +366,5 @@ window.addEventListener('DOMContentLoaded', () => {
   pageSetup()
   const params = parseQueryParams()
   goToCanvasStateOnLoad(params)
-  scrollToHashOnLoad()
+  scrollToHash(window.location.hash, 75, 'swing');
 })

--- a/packages/11ty/content/_assets/javascript/application/scroll-to-hash.js
+++ b/packages/11ty/content/_assets/javascript/application/scroll-to-hash.js
@@ -1,0 +1,44 @@
+/**
+ * scrollToHash
+ * @description Scroll the #main area after each smoothState reload.
+ * If a hash id is present, scroll to the location of that element,
+ * taking into account the height of the navbar.
+ */
+
+/**
+ * scrollWindow
+ * @description scroll viewport to a certain vertical offset, minus the height of the quire navbar
+ * TODO add animation duration and style of easing function previously provided by jQuery `.animate()`
+ */
+function scrollWindow(verticalOffset, animationDuration = null, animationStyle = null) {
+  const navBar = document.querySelector('.quire-navbar')
+  const extraSpace = 7
+  const scrollDistance = navBar
+    ? verticalOffset - navBar.clientHeight - extraSpace
+    : verticalOffset - extraSpace
+  // redundancy here to ensure all possible document properties with `scrollTop` are being set for cross-browser compatibility
+  [
+    document.documentElement,
+    document.body.parentNode,
+    document.body
+  ].forEach((documentPropertyWithScrollTop) => {
+    documentPropertyWithScrollTop.scrollTop = scrollDistance
+  })
+}
+
+export default (hash) => {
+  // prefix all ':' and '.' in hash with '\\' to make them query-selectable
+  hash = hash.replace(':', '\\:')
+  hash = hash.replace('.', '\\.')
+  // Figure out element to scroll to
+  const target = document.querySelector(hash)
+  // Does a scroll target exist?
+  if (target) {
+    const verticalOffset = target.getBoundingClientRect().top + window.scrollY
+    scrollWindow(verticalOffset)
+    // handle focus after scrolling
+    setTimeout(() => {
+      target.focus()
+    })
+  }
+}

--- a/packages/11ty/content/_assets/javascript/application/scroll-to-hash.js
+++ b/packages/11ty/content/_assets/javascript/application/scroll-to-hash.js
@@ -27,6 +27,7 @@ function scrollWindow(verticalOffset, animationDuration = null, animationStyle =
 }
 
 export default (hash) => {
+  if (!hash) return
   // prefix all ':' and '.' in hash with '\\' to make them query-selectable
   hash = hash.replace(':', '\\:')
   hash = hash.replace('.', '\\.')


### PR DESCRIPTION
Changes:
- Adds `goToCanvasState` method to `javascript/application/canvas-panel.js` which scrolls to a figure, and can select annotations and/or a region
- Calls `goToCanvasState` on page load with data from query parameters