### PR TITLE
Feature: Link to annotation states

### DIFF
--- a/packages/11ty/_plugins/filters/getAnnotation.js
+++ b/packages/11ty/_plugins/filters/getAnnotation.js
@@ -1,0 +1,15 @@
+/**
+ * Looks up an annotation object in figures.yaml by id
+ * @param  {Object} eleventyConfig
+ * @param  {String} id             annotation id
+ * @return {Object}                annotation
+ */
+module.exports = function(eleventyConfig, fig, annotationId) {
+  const getFigure = eleventyConfig.getFilter('getFigure')
+  const { figure_list: figureList } = eleventyConfig.globalData.figures
+  const figure = getFigure(fig)
+  if (!figure || !Array.isArray(figure.annotations)) return
+  return figure.annotations
+    .flatMap(({ items }) => items)
+    .find(({ id }) =>  id === annotationId)
+}

--- a/packages/11ty/_plugins/filters/index.js
+++ b/packages/11ty/_plugins/filters/index.js
@@ -1,5 +1,6 @@
 // Quire data filters
 const fullname = require('./fullname')
+const getAnnotation = require('./getAnnotation')
 const getContributor = require('./getContributor')
 const getFigure = require('./getFigure')
 const getObject = require('./getObject')
@@ -22,6 +23,7 @@ module.exports = function(eleventyConfig, options) {
    * Quire data filters
    */
   eleventyConfig.addFilter('fullname', (person, options) => fullname(person, options))
+  eleventyConfig.addFilter('getAnnotation', (...args) => getAnnotation(eleventyConfig, ...args))
   eleventyConfig.addFilter('getContributor', (id) => getContributor(eleventyConfig, id))
   eleventyConfig.addFilter('getFigure', (id) => getFigure(eleventyConfig, id))
   eleventyConfig.addFilter('getObject', (id) => getObject(eleventyConfig, id))

--- a/packages/11ty/_plugins/shortcodes/annoref.js
+++ b/packages/11ty/_plugins/shortcodes/annoref.js
@@ -1,0 +1,28 @@
+const chalkFactory = require('~lib/chalk')
+const { oneLine } = require('~lib/common-tags')
+const logger = chalkFactory(`Shortcodes:Annoref`)
+/**
+ * Style wrapped `content` as "backmatter"
+ *
+ * @param      {String}  content  content between shortcode tags
+ *
+ * @return     {boolean}  A styled HTML <div> element with the content
+ */
+module.exports = function (eleventyConfig) {
+  const getAnnotation = eleventyConfig.getFilter('getAnnotation')
+  return ({ anno='', fig, region='', text='' }) => {
+    const annoIds = anno.split(',').map((id) => id.trim())
+    const annotationUrls = annoIds.flatMap((id) => {
+      const annotation = getAnnotation(fig, id)
+      return annotation ? annotation.url : []
+    })
+    return oneLine`
+      <a 
+        class="annoref"
+        data-annotation-ids="${annotationUrls.join(',')}"
+        data-figure-id="${fig}"
+        data-region="${region}"
+      >${text}</a>
+    `
+  }
+}

--- a/packages/11ty/_plugins/shortcodes/annoref.js
+++ b/packages/11ty/_plugins/shortcodes/annoref.js
@@ -10,6 +10,7 @@ const logger = chalkFactory(`Shortcodes:Annoref`)
  */
 module.exports = function (eleventyConfig) {
   const getAnnotation = eleventyConfig.getFilter('getAnnotation')
+  const markdownify = eleventyConfig.getFilter('markdownify')
   return ({ anno='', fig, region='', text='' }) => {
     const annoIds = anno.split(',').map((id) => id.trim())
     const annotationUrls = annoIds.flatMap((id) => {
@@ -22,7 +23,7 @@ module.exports = function (eleventyConfig) {
         data-annotation-ids="${annotationUrls.join(',')}"
         data-figure-id="${fig}"
         data-region="${region}"
-      >${text}</a>
+      >${markdownify(text)}</a>
     `
   }
 }

--- a/packages/11ty/_plugins/shortcodes/index.js
+++ b/packages/11ty/_plugins/shortcodes/index.js
@@ -1,18 +1,20 @@
 const addComponentTag = require('../../_plugins/components/addComponentTag')
-const backmatter = require('./backmatter.js')
-const bibliography = require('./bibliography.js')
-const cite = require('./cite.js')
+const annoref = require('./annoref')
+const backmatter = require('./backmatter')
+const bibliography = require('./bibliography')
+const cite = require('./cite')
 const contributors = require('./contributors')
-const figure = require('./figure.js')
-const figureGroup = require('./figureGroup.js')
-const ref = require('./figureRef.js')
+const figure = require('./figure')
+const figureGroup = require('./figureGroup')
+const ref = require('./figureRef')
 const shortcodeFactory = require('../../_plugins/components/addShortcode')
-const title = require('./title.js')
-const tombstone = require('./tombstone.js')
+const title = require('./title')
+const tombstone = require('./tombstone')
 
 module.exports = function(eleventyConfig, collections, options) {
   const addShortcode = shortcodeFactory(eleventyConfig, collections)
 
+  addComponentTag(eleventyConfig, 'annoref', annoref)
   eleventyConfig.addPairedShortcode('backmatter', function(content, ...args) {
     return backmatter(eleventyConfig)(content, ...args)
   })

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -57,7 +57,14 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   const figure = document.querySelector(`#${figureId}`)
   if (!figure) return
   const canvasPanel = figure.querySelector('canvas-panel')
-
+  /**
+   * Reset inputs
+   */
+  const inputs = document.querySelectorAll('.annotations-ui__input')
+  for (const input of inputs) {
+    input.checked = false
+    handleSelect(input)
+  }
   /**
    * Update Canvas state
    */
@@ -89,9 +96,19 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
 }
 
 /**
- * Add event handlers to Annotations UI inputs
+ * Add event handlers to Annotations UI links and inputs
  */
 const setUpUIEventHandlers = function() {
+  const annoRefAnchorTags = document.querySelectorAll('.annoref')
+  for (const anchorTag of annoRefAnchorTags) {
+    let annotationIds = anchorTag.getAttribute('data-annotation-ids')
+    annotationIds = annotationIds.split(',')
+    const figureId = anchorTag.getAttribute('data-figure-id')
+    const region = anchorTag.getAttribute('data-region')
+    anchorTag.addEventListener('click', ({ target }) =>
+      goToCanvasState({ annotationIds, figureId, region }),
+    )
+  }
   const inputs = document.querySelectorAll('.annotations-ui__input')
   for (const input of inputs) {
     handleSelect(input)

--- a/packages/11ty/content/_assets/javascript/application/scroll-to-hash.js
+++ b/packages/11ty/content/_assets/javascript/application/scroll-to-hash.js
@@ -17,12 +17,13 @@ function scrollWindow(verticalOffset, animationDuration = null, animationStyle =
     ? verticalOffset - navBar.clientHeight - extraSpace
     : verticalOffset - extraSpace
   // redundancy here to ensure all possible document properties with `scrollTop` are being set for cross-browser compatibility
-  [
+  const documentProperties = [
     document.documentElement,
     document.body.parentNode,
     document.body
-  ].forEach((documentPropertyWithScrollTop) => {
-    documentPropertyWithScrollTop.scrollTop = scrollDistance
+  ]
+  documentProperties.forEach((element) => {
+    element.scrollTop = scrollDistance
   })
 }
 
@@ -38,8 +39,6 @@ export default (hash) => {
     const verticalOffset = target.getBoundingClientRect().top + window.scrollY
     scrollWindow(verticalOffset)
     // handle focus after scrolling
-    setTimeout(() => {
-      target.focus()
-    })
+    setTimeout(() => target.focus())
   }
 }

--- a/packages/11ty/content/iiif-demo.md
+++ b/packages/11ty/content/iiif-demo.md
@@ -4,9 +4,15 @@ order: 510
 layout: essay
 ---
 
+## Linking to Annotation States
+
+Use the `annoref` shortcode to create a link to a specific annotation state. For example, select an annotation such as {% annoref fig="fig-032" anno="wax-joints" text="Wax-to-wax Joints in Fig 32" %} or multiple annotations such as {% annoref fig="fig-032" anno="wax-joints,armature" text="Armature and Wax-to-wax Joints in Fig 32" %}. Annotations should be referenced by a comma-separated list of ids or filepaths.
+
+## IIIF Web Components
+
 The following examples demonstrate basic usage of when the `figure` shortcode renders `<canvas-panel>` and `<image-service>` web components.
 
-## Image Service
+### Image Service
 Images in `figures.yaml` with `media_type="iiif"` will be tiled and rendered using the `<image-service />` web component.
 
 The tiler output can be found in `public/iiif/<image-name>/`
@@ -36,10 +42,10 @@ _figures.yaml_
 
 {% figure "example-external-manifest" %}
 
-## Figure with Annotations
+### Figure with Annotations
 Specifying `annotations` on a figure will prompt the IIIF processing to create a manifest. The manifest can be found in `public/iiif/<figure-id>/manifest.json`.
 
-### "Choice"-type Annotations
+#### "Choice"-type Annotations
 Choices are alternate views of the same image.
 
 _figures.yaml_
@@ -58,7 +64,7 @@ _figures.yaml_
 
 {% figure "example-with-choices" %}
 
-### Image annotations
+#### Image annotations
 Image annotations can also be added on top of a "base" image specified in the `figure.src`.
 
 _figures.yaml_
@@ -77,7 +83,7 @@ _figures.yaml_
 {% figure "fig-032" %}
 
 
-## Other properties
+### Other properties
 The canvas panel and image service tags also support the `height`, `preset`, `width`, and `region` properties. See [Canvas Panel Documentation](https://iiif-canvas-panel.netlify.app/docs/examples/responsive-image) for additional details.
 
 _figures.yaml_


### PR DESCRIPTION
Changes:
- Adds `annoref` shortcode that provides a shorthand for creating links to canvas panel annotation states.
- Adds example to `iiif-demo`
- Includes handling for `region` though it doesn't work as expected, which will require some digging, _and_ since there is no UI for resetting the viewport after setting a region programmatically I'm not sure it needs to be supported yet.