### PR TITLE
Include semantic markup for annotations UI

### DIFF
--- a/packages/11ty/_includes/components/figure/annotations-ui/index.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/index.js
@@ -17,14 +17,16 @@ module.exports = function(eleventyConfig) {
   return function(figure) {
     const { annotations } = figure
     if (!annotations || !annotations.length) return ''
-    return annotations.map(({ input, items, type }) => {
+    const fieldsets = annotations.map(({ input, items, title='', type }) => {
       const options = 
         items.map((annotation, index) => figureOption({ annotation, figure, index, input }))
       return html`
-        <div class="annotations-ui">
+        <fieldset class="annotations-ui">
+          <legend>${title}</legend>
           ${options}
-        </div>
+        </fieldset>
       `
     })
+    return html`<form>${fieldsets}</form>`
   }
 }

--- a/packages/11ty/_includes/components/figure/annotations-ui/index.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/index.js
@@ -17,9 +17,10 @@ module.exports = function(eleventyConfig) {
   return function(figure) {
     const { annotations } = figure
     if (!annotations || !annotations.length) return ''
-    const fieldsets = annotations.map(({ input, items, title='', type }) => {
+    const fieldsets = annotations.map(({ input, items, title='', type }, index) => {
+      const name = `${figure.id}-${index}`
       const options = 
-        items.map((annotation, index) => figureOption({ annotation, figure, index, input }))
+        items.map((annotation, index) => figureOption({ annotation, index, input, name }))
       return html`
         <fieldset class="annotations-ui">
           <legend>${title}</legend>

--- a/packages/11ty/_includes/components/figure/annotations-ui/option.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/option.js
@@ -32,12 +32,13 @@ module.exports = function (eleventyConfig) {
     return html`
       <div class="annotations-ui__input-wrapper" id="${elementId}">
         <input
-          ${checked ? 'checked' : ''}
           class="annotations-ui__input"
-          data-annotation-type="${type}"
           id="${url}"
           name="${figure.id}"
           type="${input}"
+          value="${url}"
+          data-annotation-type="${type}"
+          ${checked ? 'checked' : ''}
         />
         <label
           class="annotations-ui__label"

--- a/packages/11ty/_includes/components/figure/annotations-ui/option.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/option.js
@@ -1,6 +1,6 @@
 const { html } = require('common-tags')
 const chalkFactory = require('~lib/chalk')
-const { error } = chalkFactory('Figure Annotations UI')
+const logger = chalkFactory('Figure Annotations UI')
 
 module.exports = function (eleventyConfig) {
   const slugify = eleventyConfig.getFilter('slugify')
@@ -13,28 +13,28 @@ module.exports = function (eleventyConfig) {
    * @param  {Object} figure
    * @param  {Object} annotation
    */
-  return function ({ annotation, figure, index, input }) {
+  return function ({ annotation, index, input, name }) {
     const { id, label, selected, type, url } = annotation
 
     if (!label) {
-      error(`Annotation label is required. Figure id: ${figure.id}`)
+      logger.error(`Annotation label is required. Annotation id: ${id}`)
+      return ''
     }
 
     if (!supportedInputTypes.includes(input)) {
-      error(`The provided input "${input}" for figure "${figure.id}" is not supported. Input must be ${supportedInputTypes.join(' or ')}.`)
+      logger.error(`The provided input "${input}" for annotation "${id}" is not supported. Input must be ${supportedInputTypes.join(' or ')}.`)
+      return ''
     }
 
-    const checked = selected ||
-      (input === "radio" && index === 0) ||
-      (input === "checkbox" && type === "choice" && index === 0)
-    const elementId = `${slugify(figure.id)}--${slugify(label)}`
+    const checked = selected || (input === "radio" && index === 0)
+    const elementId = `${name}--${slugify(label)}`
 
     return html`
       <div class="annotations-ui__input-wrapper" id="${elementId}">
         <input
           class="annotations-ui__input"
           id="${url}"
-          name="${figure.id}"
+          name="${name}"
           type="${input}"
           value="${url}"
           data-annotation-type="${type}"


### PR DESCRIPTION
Fixes radio select bug by including `<form>` and `<fieldset>` elements
Adds optional `title` attribute to annotation sets to be used in the `<legend>`
Add index to input name and wrapper id to ensure uniqueness when a figure has multiple sets of annotations