### PR TITLE
Use unique names for inputs inline vs lightbox

### DIFF
--- a/packages/11ty/_includes/components/figure/annotations-ui/index.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/index.js
@@ -14,15 +14,17 @@ module.exports = function(eleventyConfig) {
   /**
    * @param  {Object} figure
    */
-  return function(figure, context='inline') {
+  return function({ figure, lightbox=false }) {
     const { annotations } = figure
     if (!annotations || !annotations.length) return ''
     const fieldsets = annotations.map(({ input, items, title='', type }, index) => {
-      const name = `${figure.id}-${index}-${context}`
+      const nameParts = [figure.id, index]
+      if (lightbox) nameParts.push('lightbox')
+      const name = nameParts.join('-')
       const options = 
         items.map((annotation, index) => figureOption({ annotation, index, input, name }))
       return html`
-        <fieldset class="annotations-ui annotations-ui--${context}">
+        <fieldset class="annotations-ui">
           <legend>${title}</legend>
           ${options}
         </fieldset>

--- a/packages/11ty/_includes/components/figure/annotations-ui/index.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/index.js
@@ -14,15 +14,15 @@ module.exports = function(eleventyConfig) {
   /**
    * @param  {Object} figure
    */
-  return function(figure) {
+  return function(figure, context='inline') {
     const { annotations } = figure
     if (!annotations || !annotations.length) return ''
     const fieldsets = annotations.map(({ input, items, title='', type }, index) => {
-      const name = `${figure.id}-${index}`
+      const name = `${figure.id}-${index}-${context}`
       const options = 
         items.map((annotation, index) => figureOption({ annotation, index, input, name }))
       return html`
-        <fieldset class="annotations-ui">
+        <fieldset class="annotations-ui annotations-ui--${context}">
           <legend>${title}</legend>
           ${options}
         </fieldset>

--- a/packages/11ty/_includes/components/figure/annotations-ui/option.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/option.js
@@ -27,13 +27,14 @@ module.exports = function (eleventyConfig) {
     }
 
     const checked = selected || (input === "radio" && index === 0)
-    const elementId = `${name}--${slugify(label)}`
+    const elementId = `${name}--${id}`
+    const inputId = `input-${elementId}`
 
     return html`
       <div class="annotations-ui__input-wrapper" id="${elementId}">
         <input
           class="annotations-ui__input"
-          id="${url}"
+          id="${inputId}"
           name="${name}"
           type="${input}"
           value="${url}"
@@ -42,7 +43,7 @@ module.exports = function (eleventyConfig) {
         />
         <label
           class="annotations-ui__label"
-          for="${url}"
+          for="${inputId}"
         >
           ${label}
         </label>

--- a/packages/11ty/_includes/components/figure/image/html.js
+++ b/packages/11ty/_includes/components/figure/image/html.js
@@ -28,7 +28,7 @@ module.exports = function(eleventyConfig) {
       label
     } = figure
 
-    const annotationsElement = annotationsUI(figure)
+    const annotationsElement = annotationsUI({ figure })
     const labelElement = figureLabel({ caption, id, label })
 
     /**

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -86,7 +86,7 @@ module.exports = function(eleventyConfig) {
           </div>
           <div class="q-figure-slides__slide-ui">
             ${captionElement}
-            ${annotationsUI(figure, 'lightbox')}
+            ${annotationsUI({ figure, lightbox: true })}
           </div>
         </div>
       `

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -86,7 +86,7 @@ module.exports = function(eleventyConfig) {
           </div>
           <div class="q-figure-slides__slide-ui">
             ${captionElement}
-            ${annotationsUI(figure)}
+            ${annotationsUI(figure, 'lightbox')}
           </div>
         </div>
       `

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -6,11 +6,11 @@ import scrollToHash from './scroll-to-hash'
  * @param {HTMLElement} element
  */
 const handleSelect = (element) => {
-  const figure = element.closest('.q-figure')
+  const figure = element.closest('.q-figure') || element.closest('.q-lightbox-slides__slide')
   if (!figure) return
   const canvasPanel = figure.querySelector('canvas-panel')
   const annotationType = element.getAttribute('data-annotation-type')
-  const id = element.getAttribute('id')
+  const id = element.getAttribute('value')
   const inputType = element.getAttribute('type')
 
   const toggleChoice = ({ checked }) => {


### PR DESCRIPTION
Ensure inline and lightbox form elements are unique (fixes lightbox checkbox select bug)
Use `annotation.id` for `input.id` instead of `url`