### PR TITLE
Restrict web-component head tag transform to html pages

### DIFF
--- a/packages/11ty/_plugins/transforms/index.js
+++ b/packages/11ty/_plugins/transforms/index.js
@@ -4,7 +4,6 @@ const path = require('path')
 
 const formatOutput = require('./format')
 const outputs = require('./outputs')
-const webComponents = require('./web-components')
 
 /**
  * An Eleventy plugin to configure output transforms
@@ -17,10 +16,6 @@ module.exports = function(eleventyConfig, collections) {
    * Registers a transform to format output using Prettier
    */
   eleventyConfig.addTransform('format', formatOutput)
-  /**
-   * Registers a transform to register web component modules in document `<head>`
-   */
-  eleventyConfig.addTransform('web-components', webComponents)
 
   /**
    * Register plugin to generate output for epub, html, and pdf using `transforms`

--- a/packages/11ty/_plugins/transforms/outputs/html/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/html/transform.js
@@ -2,6 +2,7 @@ const path = require('path')
 const jsdom = require('jsdom')
 const { JSDOM } = jsdom
 const filterOutputs = require('../filter.js')
+const registerWebComponents = require('./web-components')
 
 /**
  * Content transforms for html output
@@ -14,12 +15,16 @@ module.exports = function(eleventyConfig, collections, content) {
   const { ext } = path.parse(this.outputPath)
   content = pages.includes(this.outputPath) ? content : undefined
 
-  /**
-   * Remove elements excluded from this output type
-   */
   if (ext === '.html') {
     const dom = new JSDOM(content)
+    /**
+     * Remove elements excluded from this output type
+     */
     filterOutputs(dom.window.document, 'html')
+    /**
+     * Add web component script tags to <head>
+     */
+    registerWebComponents(dom)
     content = dom.serialize()
   }
 

--- a/packages/11ty/_plugins/transforms/outputs/html/web-components.js
+++ b/packages/11ty/_plugins/transforms/outputs/html/web-components.js
@@ -8,7 +8,7 @@ const path = require('path')
  * @param      {String}  content
  * @return     {String}  transformed content
  */
-module.exports = function (content) {
+module.exports = function (dom) {
   const webComponentPath = path.resolve('_includes', 'web-components')
 
   const webComponentModulePaths = fs
@@ -21,8 +21,6 @@ module.exports = function (content) {
       return modulePaths
     }, [])
 
-  const { JSDOM } = jsdom
-  const dom = new JSDOM(content)
   const { document } = dom.window
   const { head } = document
 


### PR DESCRIPTION
Fixes: Error loading `search-index.json`

Changes:
- Only add web-component script tags to html pages
- Bonus: one less JSDOM instance per-transformed page