### PR TITLE
Remove environment variables and use config.yaml for production baseURL

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 require('module-alias/register')
 
 const fs = require('fs-extra')
@@ -193,6 +192,14 @@ module.exports = function(eleventyConfig) {
         mode: 'development'
       }
     }
+  })
+
+  /**
+   * Set eleventy dev server options
+   * @see https://www.11ty.dev/docs/dev-server/
+   */
+  eleventyConfig.setServerOptions({
+    port: 8080
   })
 
   // @see https://www.11ty.dev/docs/copy/#passthrough-during-serve

--- a/packages/11ty/.env.example
+++ b/packages/11ty/.env.example
@@ -1,3 +1,0 @@
-ELEVENTY_ENV=development
-ELEVENTY_OUTPUT_DIR=_site
-URL=http://localhost:8080

--- a/packages/11ty/.gitignore
+++ b/packages/11ty/.gitignore
@@ -5,11 +5,6 @@ _temp/
 # EleventFetch cache directory
 .cache
 
-# environment variables file
-.env
-.env.*
-!.env.example
-
 # ESLint cache directory
 .eslintcache
 

--- a/packages/11ty/_plugins/figures/annotation-factory.js
+++ b/packages/11ty/_plugins/figures/annotation-factory.js
@@ -28,7 +28,7 @@ module.exports = class AnnotationFactory {
    * @return {Annotation}
    */
   create(figure, data) {
-    const { baseURL, imageServiceDirectory, inputDir, outputDir } = this.iiifConfig
+    const { baseURL, dirs } = this.iiifConfig
     /**
      * If an id is not provided, compute id from the `label` or `src` properties
      * @return {String}
@@ -57,11 +57,11 @@ module.exports = class AnnotationFactory {
     const filepath = () => {
       return figure.preset === "zoom"
         ? [
-            outputDir,
+            dirs.output,
             data.id,
-            imageServiceDirectory,
+            dirs.imageService,
           ].join('/')
-        : [inputDir, data.src].join('/');
+        : [dirs.input, data.src].join('/');
     }
 
     /**

--- a/packages/11ty/_plugins/figures/annotation-factory.js
+++ b/packages/11ty/_plugins/figures/annotation-factory.js
@@ -28,6 +28,7 @@ module.exports = class AnnotationFactory {
    * @return {Annotation}
    */
   create(figure, data) {
+    const { baseURL, imageServiceDirectory, inputDir, outputDir } = this.iiifConfig
     /**
      * If an id is not provided, compute id from the `label` or `src` properties
      * @return {String}
@@ -56,11 +57,11 @@ module.exports = class AnnotationFactory {
     const filepath = () => {
       return figure.preset === "zoom"
         ? [
-            this.iiifConfig.outputDir,
+            outputDir,
             data.id,
-            this.iiifConfig.imageServiceDirectory,
+            imageServiceDirectory,
           ].join('/')
-        : [this.iiifConfig.inputDir, data.src].join('/');
+        : [inputDir, data.src].join('/');
     }
 
     /**
@@ -76,7 +77,7 @@ module.exports = class AnnotationFactory {
      * @return {String}
      */
     const url = () => {
-      return new URL(filepath(), process.env.URL).href
+      return new URL(filepath(), baseURL).href
     }
 
     return {

--- a/packages/11ty/_plugins/figures/figure-factory.js
+++ b/packages/11ty/_plugins/figures/figure-factory.js
@@ -73,7 +73,7 @@ module.exports = class FigureFactory {
       isImageService: isImageService(data),
       manifestId: data.manifestId,
       printImage: getPrintImage(this.iiifConfig, data),
-      outputDir: path.join(this.iiifConfig.outputDir, data.id),
+      outputDir: path.join(this.iiifConfig.dirs.output, data.id),
       ...data
     }
   }

--- a/packages/11ty/_plugins/figures/figure-factory.js
+++ b/packages/11ty/_plugins/figures/figure-factory.js
@@ -104,7 +104,7 @@ module.exports = class FigureFactory {
    * Sets canvasId and manifestId properties on the figure instance
    */
   async generateManifest(figure) {
-    const manifest = new Manifest({ figure, writer: this.writer })
+    const manifest = new Manifest({ figure, iiifConfig: this.iiifConfig, writer: this.writer })
     const manifestJSON = await manifest.write()
     return { 
       canvasId: manifestJSON.items[0].id,

--- a/packages/11ty/_plugins/figures/helpers/get-print-image.js
+++ b/packages/11ty/_plugins/figures/helpers/get-print-image.js
@@ -7,7 +7,7 @@ const path = require('path')
  * @return {String}            Path to figure's print image
  */
 module.exports = (iiifConfig, figure) => {
-  const { outputDir } = iiifConfig
+  const { dirs } = iiifConfig
   const { printImage, src } = figure
 
   let defaultImage
@@ -18,7 +18,7 @@ module.exports = (iiifConfig, figure) => {
    */
   if (figure.src) {
     const { ext, name } = path.parse(src)
-    defaultImage = path.join(outputDir, name, `print-image${ext}`)
+    defaultImage = path.join(dirs.output, name, `print-image${ext}`)
   }
 
   return printImage || defaultImage

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -4,7 +4,7 @@ module.exports = (eleventyConfig) => {
   const { baseURL } = eleventyConfig.globalData.config
   const { port } = eleventyConfig.serverOptions
   const iiifConfig = {
-    baseURL: process.env.ELEVENTY_ENV === 'development' ? `http://localhost:${port}`: baseURL,
+    baseURL: process.env.ELEVENTY_ENV === 'production' ? baseURL : `http://localhost:${port}`,
     /**
      * Input and output of processable image formats
      * @type {Array<Object>}

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -5,6 +5,27 @@ module.exports = (eleventyConfig) => {
   const { port } = eleventyConfig.serverOptions
   const iiifConfig = {
     baseURL: process.env.ELEVENTY_ENV === 'production' ? baseURL : `http://localhost:${port}`,
+    dirs: {
+      /**
+       * The name of the directory for image tiles and info.json
+       * @type {String}
+       */
+      imageService: 'tiles',
+      /**
+       * Image file directory relative to `inputRoot`
+       */
+      input: path.join('_assets', 'images'),
+      /**
+       * Image file root directory
+       */
+      inputRoot: eleventyConfig.dir.input,
+      /**
+       * Output directory
+       * @type {String}
+       */
+      output: 'iiif',
+      outputRoot: 'public'
+    },
     /**
      * Input and output of processable image formats
      * @type {Array<Object>}
@@ -20,19 +41,6 @@ module.exports = (eleventyConfig) => {
      }
     ],
     /**
-     * The name of the directory for image tiles and info.json
-     * @type {String}
-     */
-    imageServiceDirectory: 'tiles',
-    /**
-     * Image file directory relative to `inputRoot`
-     */
-    inputDir: path.join('_assets', 'images'),
-    /**
-     * Image file root directory
-     */
-    inputRoot: eleventyConfig.dir.input,
-    /**
      * Generated manifest locale
      * @type {String}
      */ 
@@ -42,12 +50,6 @@ module.exports = (eleventyConfig) => {
      * @type {String}
      */
     manifestFilename: 'manifest.json',
-    /**
-     * Output directory
-     * @type {String}
-     */
-    outputDir: 'iiif',
-    outputRoot: 'public',
     tileSize: 256,
     /**
      * Transformations to apply to each image

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -1,9 +1,10 @@
 const path = require('path')
 
 module.exports = (eleventyConfig) => {
-  const { config, env } = eleventyConfig.globalData
+  const { baseURL } = eleventyConfig.globalData.config
+  const { port } = eleventyConfig.serverOptions
   const iiifConfig = {
-    baseURL: config.baseURL || env.URL,
+    baseURL: process.env.ELEVENTY_ENV === 'development' ? `http://localhost:${port}`: baseURL,
     /**
      * Input and output of processable image formats
      * @type {Array<Object>}

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -11,15 +11,15 @@ const vault = globalVault()
 const builder = new IIIFBuilder(vault)
 
 module.exports = class Manifest {
-  constructor({ figure, writer }) {
-    const { manifestFilename } = writer.iiifConfig
-    const baseId = [process.env.URL, figure.outputDir].join('/')
+  constructor({ figure, iiifConfig, writer }) {
+    const { baseURL, manifestFilename } = iiifConfig
+    const baseId = [baseURL, figure.outputDir].join('/')
 
     this.canvas = {
       id: [baseId, 'canvas'].join('/')
     }
     this.figure = figure
-    this.iiifConfig = writer.iiifConfig
+    this.iiifConfig = iiifConfig
     this.manifestId = [baseId, manifestFilename].join('/')
     this.writer = writer
   }

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -95,8 +95,8 @@ module.exports = class Manifest {
   }
 
   async calcCanvasDimensions() {
-    const { inputDir, inputRoot } = this.iiifConfig
-    const fullImagePath = path.join(inputRoot, inputDir, this.canvasImagePath)
+    const { dirs } = this.iiifConfig
+    const fullImagePath = path.join(dirs.inputRoot, dirs.input, this.canvasImagePath)
     const { height, width } = await sharp(fullImagePath).metadata()
     this.canvas.height = height
     this.canvas.width = width

--- a/packages/11ty/_plugins/figures/iiif/manifest/writer.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/writer.js
@@ -14,7 +14,7 @@ module.exports = class ManifestWriter {
    * @param  {Object} manifest JSON manifest
    */
   write({ figure, manifest }) {
-    const { outputRoot } = this.iiifConfig
+    const { outputRoot } = this.iiifConfig.dirs
     const { pathname } = new URL(manifest.id)
     const outputPath = path.join(outputRoot, pathname)
     fs.ensureDirSync(path.parse(outputPath).dir)

--- a/packages/11ty/_plugins/figures/iiif/tiler.js
+++ b/packages/11ty/_plugins/figures/iiif/tiler.js
@@ -31,20 +31,17 @@ module.exports = class Tiler {
 
     const {
       baseURL,
+      dirs,
       formats,
-      imageServiceDirectory,
-      inputDir,
-      inputRoot,
-      outputRoot,
       tileSize
     } = this.iiifConfig
 
     const format = formats.find(({ input }) => input.includes(ext))
-    const inputPath = path.join(inputRoot, inputDir, figure.src)
-    const tileDirectory = path.join(figure.outputDir, name, imageServiceDirectory)
+    const inputPath = path.join(dirs.inputRoot, dirs.input, figure.src)
+    const tileDirectory = path.join(figure.outputDir, name, dirs.imageService)
     const url = new URL(path.join(tileDirectory, 'info.json'), baseURL).href
 
-    if (fs.existsSync(path.join(outputRoot, tileDirectory, 'info.json'))) {
+    if (fs.existsSync(path.join(dirs.outputRoot, tileDirectory, 'info.json'))) {
       info(`Skipping previously tiled image "${inputPath}"`)
       return { info: url }
     }
@@ -59,7 +56,7 @@ module.exports = class Tiler {
           layout: 'iiif',
           size: tileSize
         })
-        .toFile(path.join(outputRoot, tileDirectory))
+        .toFile(path.join(dirs.outputRoot, tileDirectory))
       info(`Done tiling image "${inputPath}"`)
       return { info: url }
     } catch(error) {

--- a/packages/11ty/_plugins/figures/transform.js
+++ b/packages/11ty/_plugins/figures/transform.js
@@ -11,10 +11,8 @@ const { info, error } = chalkFactory('plugins:iiif:createImage')
  */
 module.exports = (iiifConfig, figure, options={}) => {
   const {
+    dirs,
     formats,
-    inputDir,
-    inputRoot,
-    outputRoot,
     transformations
   } = iiifConfig
 
@@ -34,8 +32,8 @@ module.exports = (iiifConfig, figure, options={}) => {
     const { ext, name } = path.parse(src)
     const { resize } = transformation
     const format = formats.find(({ input }) => input.includes(ext))
-    const inputPath = path.join(inputRoot, inputDir, src)
-    const outputPath = path.join(outputRoot, outputDir, name, `${transformation.name}${format.output}`)
+    const inputPath = path.join(dirs.inputRoot, dirs.input, src)
+    const outputPath = path.join(dirs.outputRoot, outputDir, name, `${transformation.name}${format.output}`)
 
     fs.ensureDirSync(path.parse(outputPath).dir)
 

--- a/packages/11ty/content/_data/config.yaml
+++ b/packages/11ty/content/_data/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "http://localhost:8080"
+baseURL: 'https://www.example.com/project'
 
 title: Quire Starter
 languageCode: en-us

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -30,7 +30,6 @@
         "common-tags": "^2.0.0-alpha.1",
         "cpy-cli": "^4.1.0",
         "del-cli": "^4.0.1",
-        "dotenv": "^16.0.1",
         "eslint": "^8.19.0",
         "exifr": "^7.1.3",
         "fs-extra": "^10.1.0",
@@ -2111,15 +2110,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -9248,12 +9238,6 @@
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
       }
-    },
-    "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -38,7 +38,6 @@
     "common-tags": "^2.0.0-alpha.1",
     "cpy-cli": "^4.1.0",
     "del-cli": "^4.0.1",
-    "dotenv": "^16.0.1",
     "eslint": "^8.19.0",
     "exifr": "^7.1.3",
     "fs-extra": "^10.1.0",


### PR DESCRIPTION
Changes:
- Remove references to .env
- Set IIIF baseURL from eleventy server config in development, and `config.baseURL` in production