### PR TITLE
Change development asset output directory to `_site`

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -3,7 +3,6 @@ require('module-alias/register')
 const fs = require('fs-extra')
 const path = require('path')
 const scss = require('rollup-plugin-scss')
-const copy = require('rollup-plugin-copy')
 
 /**
  * Quire features are implemented as Eleventy plugins
@@ -140,7 +139,7 @@ module.exports = function(eleventyConfig) {
     tempFolderName: '.11ty-vite',
     viteOptions: {
       publicDir: process.env.ELEVENTY_ENV === 'production'
-        ? 'public'
+        ? publicDir
         : false,
       /**
        * @see https://vitejs.dev/config/#build-options
@@ -167,15 +166,7 @@ module.exports = function(eleventyConfig) {
               })
               return `${filePath}[name][extname]`
             }
-          },
-          plugins: [
-            copy({
-              targets: [
-                { src: 'public/pdf.html', dest: '_site' },
-                { src: 'public/pdf.css', dest: '_site' },
-              ]
-            })
-          ]
+          }
 
         },
         sourcemap: true
@@ -215,7 +206,6 @@ module.exports = function(eleventyConfig) {
    * @see https://www.11ty.dev/docs/copy/
    */
   eleventyConfig.addPassthroughCopy(`${inputDir}/_assets`)
-  eleventyConfig.addPassthroughCopy(`${publicDir}`)
   eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript' })
 
   /**

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -183,7 +183,7 @@ module.exports = function(eleventyConfig) {
         hmr: {
           overlay: false
         },
-        middlewareMode: 'ssr',
+        middlewareMode: true,
         mode: 'development'
       }
     }

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -205,6 +205,7 @@ module.exports = function(eleventyConfig) {
    * Copy static assets to the output directory
    * @see https://www.11ty.dev/docs/copy/
    */
+  if (process.env.ELEVENTY_ENV === 'production') eleventyConfig.addPassthroughCopy(publicDir)
   eleventyConfig.addPassthroughCopy(`${inputDir}/_assets`)
   eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript' })
 

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -139,12 +139,16 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(EleventyVitePlugin, {
     tempFolderName: '.11ty-vite',
     viteOptions: {
+      publicDir: process.env.ELEVENTY_ENV === 'production'
+        ? 'public'
+        : false,
       /**
        * @see https://vitejs.dev/config/#build-options
        */
       root: '_site',
       build: {
         assetsDir: '_assets',
+        emptyOutDir: process.env.ELEVENTY_ENV !== 'production',
         manifest: true,
         mode: 'production',
         outDir: '_site',

--- a/packages/11ty/README.md
+++ b/packages/11ty/README.md
@@ -47,3 +47,7 @@ For a discussion of this approach see ilearnio/module-alias#113, several caveats
 ``` javascript
 const { renderOneLine, stripIndent } = require('#lib/common-tags/index.js')
 ```
+
+## IIIF Assets
+
+Quire's IIIF processing generates additional files such as image tiles and JSON manifests before building the project. During development, these files are written directly to the eleventy `output` directory (default `_site`) and are only re-written if they are removed. During production, these files will be re-generated and written to the `public` directory, which is copied by 11ty through to the final build in `_site`. As a result, running sequential production _or_ development builds is optimized, though if you are switching _between_ development and production builds you will notice a slower build time as the IIIF processing is re-running.

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -3,6 +3,9 @@ const path = require('path')
 module.exports = (eleventyConfig) => {
   const { baseURL } = eleventyConfig.globalData.config
   const { port } = eleventyConfig.serverOptions
+  const { viteOptions } = eleventyConfig.plugins.find(
+    ({ options }) => !!options && !!options.viteOptions
+  ).options
   const iiifConfig = {
     baseURL: process.env.ELEVENTY_ENV === 'production' ? baseURL : `http://localhost:${port}`,
     dirs: {
@@ -24,7 +27,7 @@ module.exports = (eleventyConfig) => {
        * @type {String}
        */
       output: 'iiif',
-      outputRoot: 'public'
+      outputRoot: viteOptions.publicDir || eleventyConfig.dir.output
     },
     /**
      * Input and output of processable image formats

--- a/packages/11ty/_plugins/figures/iiif/manifest/README.md
+++ b/packages/11ty/_plugins/figures/iiif/manifest/README.md
@@ -3,7 +3,7 @@
 The Quire figure model is a simple interface for creating IIIF manifests that are rendered by Quire's `figure` shortcode using the [`<canvas-panel>`](https://iiif-canvas-panel.netlify.app/docs/intro/) web component.
 
 ## Process
-Quire's IIIF processing parses the `figures.yaml` data and for each figure writes a manifest file to the directory `/public/iiif/<figure.id>.json`. A list of manifests is also added to the eleventy global data object `eleventyConfig.globalData.iiifManifests[figure.id]`.
+Quire's IIIF processing parses the `figures.yaml` data and for each figure writes a manifest file to the directory `/<iiifConfig.dirs.outputRoot>/iiif/<figure.id>.json`. A list of manifests is also added to the eleventy global data object `eleventyConfig.globalData.iiifManifests[figure.id]`.
 
 ## Annotations Model
 | Property    | Description                  |

--- a/packages/11ty/_plugins/figures/iiif/manifest/writer.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/writer.js
@@ -15,8 +15,8 @@ module.exports = class ManifestWriter {
    */
   write({ figure, manifest }) {
     const { outputRoot } = this.iiifConfig.dirs
-    const { pathname } = new URL(manifest.id)
-    const outputPath = path.join(outputRoot, pathname)
+    const pathName = manifest.id.split(this.iiifConfig.baseURL)[1]
+    const outputPath = path.join(outputRoot, pathName)
     fs.ensureDirSync(path.parse(outputPath).dir)
     fs.writeJsonSync(outputPath, manifest)
   }

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -17,7 +17,8 @@ module.exports = async function(collection) {
    * Output must be written to a directory using Passthrough File Copy
    * @see https://www.11ty.dev/docs/copy/#passthrough-file-copy
    */
-  const outputPath = path.join('public', 'pdf.html')
+  const outputDir = process.env.ELEVENTY_ENV === 'production' ? 'public' : '_site'
+  const outputPath = path.join(outputDir, 'pdf.html')
 
   const { JSDOM } = jsdom
   const dom = await JSDOM.fromFile(layoutPath)
@@ -56,7 +57,7 @@ module.exports = async function(collection) {
     const print = sass.compile(path.resolve('content', '_assets', 'styles', 'print.scss'), sassOptions)
     const custom = sass.compile(path.resolve('content', '_assets', 'styles', 'custom.css'), sassOptions)
     fs.ensureDirSync(path.parse(outputPath).dir)
-    fs.writeFileSync(path.join('public', 'pdf.css'), application.css + print.css + custom.css)
+    fs.writeFileSync(path.join(outputDir, 'pdf.css'), application.css + print.css + custom.css)
   } catch (error) {
     error('Eleventy transform for PDF error compiling SASS. Error message: ', error)
   }

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -52,7 +52,6 @@
         "path": "^0.12.7",
         "prettier": "^3.0.0-alpha.0",
         "remove-markdown": "^0.5.0",
-        "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-scss": "^3.0.0",
         "sass": "^1.54.5",
         "sharp": "^0.30.7",
@@ -675,30 +674,11 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
-      "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/geojson": {
       "version": "7946.0.10",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
       "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
       "dev": true
-    },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/linkify-it": {
       "version": "3.0.2",
@@ -741,7 +721,8 @@
       "version": "18.6.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
       "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1463,12 +1444,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4001,15 +3976,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -6438,73 +6404,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-copy": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
-      "integrity": "sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/fs-extra": "^8.0.1",
-        "colorette": "^1.1.0",
-        "fs-extra": "^8.1.0",
-        "globby": "10.0.1",
-        "is-plain-object": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.3"
-      }
-    },
-    "node_modules/rollup-plugin-copy/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/rollup-plugin-copy/node_modules/globby": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-copy/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/rollup-plugin-copy/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/rollup-plugin-scss": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
@@ -8163,30 +8062,11 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
-    "@types/fs-extra": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
-      "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/geojson": {
       "version": "7946.0.10",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
       "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
       "dev": true
-    },
-    "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
     },
     "@types/linkify-it": {
       "version": "3.0.2",
@@ -8229,7 +8109,8 @@
       "version": "18.6.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
       "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8766,12 +8647,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -10575,12 +10450,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true
-    },
-    "is-plain-object": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
       "dev": true
     },
     "is-potential-custom-element-name": {
@@ -12405,63 +12274,6 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "rollup-plugin-copy": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
-      "integrity": "sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==",
-      "dev": true,
-      "requires": {
-        "@types/fs-extra": "^8.0.1",
-        "colorette": "^1.1.0",
-        "fs-extra": "^8.1.0",
-        "globby": "10.0.1",
-        "is-plain-object": "^3.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "globby": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-          "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
-          "dev": true,
-          "requires": {
-            "@types/glob": "^7.1.1",
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.0.3",
-            "glob": "^7.1.3",
-            "ignore": "^5.1.1",
-            "merge2": "^1.2.3",
-            "slash": "^3.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
       }
     },
     "rollup-plugin-scss": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -9,11 +9,11 @@
     "build": "ELEVENTY_ENV=production eleventy",
     "build:pdf": "pagedjs-cli public/pdf.html --outline-tags 'h1' -o paged.pdf",
     "build:prince": "prince public/pdf.html --output prince.pdf",
-    "clean": "del-cli _site public/pdf.css public/pdf.html",
+    "clean": "del-cli _site public",
     "debug": "DEBUG=Eleventy* eleventy --dryrun",
     "dev": "ELEVENTY_ENV=development eleventy --serve",
     "prebuild": "npm run clean",
-    "predev": "npm run clean",
+    "predev": "del-cli public",
     "preserve": "npm run clean",
     "serve": "ELEVENTY_ENV=production eleventy --serve",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -60,7 +60,6 @@
     "path": "^0.12.7",
     "prettier": "^3.0.0-alpha.0",
     "remove-markdown": "^0.5.0",
-    "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-scss": "^3.0.0",
     "sass": "^1.54.5",
     "sharp": "^0.30.7",


### PR DESCRIPTION
Changes:
- When `ELEVENTY_ENV=development`, write generated static assets (for pdf and IIIF) directly to `_site/`
- Change `predev` npm script to remove `public/`
- Do *not* clean `_site` directory in development mode so that assets aren't regenerated every time the dev server is started
- Continue writing assets to `public/` for production builds