### PR TITLE
Fix image on page headers

### DIFF
--- a/packages/11ty/_includes/components/page-header.js
+++ b/packages/11ty/_includes/components/page-header.js
@@ -12,7 +12,7 @@ module.exports = function(eleventyConfig) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const slugify = eleventyConfig.getFilter('slugify')
 
-  const { imgDir, pageLabelDivider } = eleventyConfig.globalData.config.params
+  const { imageDir, pageLabelDivider } = eleventyConfig.globalData.config.params
 
   return function (params) {
     const {
@@ -38,7 +38,7 @@ module.exports = function(eleventyConfig) {
       ? html`
           <section
             class="${classes} hero__image"
-           style="background-image: url('${path.join(imgDir, image)}');"
+           style="background-image: url('${path.join(imageDir, image)}');"
           >
           </section>
         `
@@ -62,7 +62,7 @@ module.exports = function(eleventyConfig) {
           ${contributorsElement}
         </div>
       </section>
-      ${image}
+      ${imageElement}
     `
   }
 }


### PR DESCRIPTION
Just a small fix that must have slipped by in some earlier refactoring. I caught it while working on _Bronze Guidelines_.

Changes `imgDir` to `imageDir`, and returns `imageElement` instead of the plain `image`.