### PR TITLE
Add classes to the markup based on `tags`

### DIFF
--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -50,7 +50,11 @@ module.exports = {
    */
   pageClasses: ({ collections, class: classes, layout, page, tags }) => {
     const pageClasses = []
-    // Add classes based on tags
+    /**
+     * Add Eleventy collection tags as style classes;
+     * enables custom page styles to be defined for a collection tag.
+     * @see https://www.11ty.dev/docs/collections/
+     */
     tags ? pageClasses.push(tags) : ''
     // Add computed frontmatter and page-one classes
     const pageIndex = collections.allSorted.findIndex(({ outputPath }) => outputPath === page.outputPath)

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -48,8 +48,10 @@ module.exports = {
   /**
    * Classes applied to <main> page element
    */
-  pageClasses: ({ collections, class: classes, layout, page }) => {
+  pageClasses: ({ collections, class: classes, layout, page, tags }) => {
     const pageClasses = []
+    // Add classes based on tags
+    tags ? pageClasses.push(tags) : ''
     // Add computed frontmatter and page-one classes
     const pageIndex = collections.allSorted.findIndex(({ outputPath }) => outputPath === page.outputPath)
     const pageOneIndex = collections.allSorted.findIndex(({ data }) => data.class && data.class.includes('page-one'))
@@ -73,7 +75,7 @@ module.exports = {
     return collections.all.find(({ url }) => url === page.url)
   },
   /**
-   * Figures data for figures referenced by id in page frontmatter 
+   * Figures data for figures referenced by id in page frontmatter
    */
   pageFigures: ({ figure, figures }) => {
     if (!figure || !figure.length) return


### PR DESCRIPTION
Eleventy lets you define `tags` on Markdown pages, which can then be accessed in a group through Eleventy's `collections`. 

```liquid
{% for page in collections.vocabulary %}
  ...
{% endfor %}
```
I used this in *Bronze Guidelines* and we'll add info about it to the Quire documentation as I could see it being a useful feature for the community, and certainly us again in the future.

It was also then useful to be able to style those tagged pages in a particular way, and by adding tags in as part of our page classes, as this PR does, it eliminates the needs to add both `tags:` and a separate `class:` to every page.
