### PR TITLE
Enable table scrolling and refine default styles

### DIFF
--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -43,7 +43,7 @@ module.exports = function(eleventyConfig) {
           case mediaType === 'soundcloud':
             return figureAudioElement(figure)
           case mediaType === 'table':
-            return `<div class="table-wrapper">${await figureTableElement(figure)}</div>`
+            return `<div class="overflow-container">${await figureTableElement(figure)}</div>`
           case isVideo:
             return figureVideoElement(figure)
           case mediaType === 'image':

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -43,7 +43,7 @@ module.exports = function(eleventyConfig) {
           case mediaType === 'soundcloud':
             return figureAudioElement(figure)
           case mediaType === 'table':
-            return await figureTableElement(figure)
+            return `<div class="table-wrapper">${await figureTableElement(figure)}</div>`
           case isVideo:
             return figureVideoElement(figure)
           case mediaType === 'image':

--- a/packages/11ty/content/_assets/images/tables/table-1.html
+++ b/packages/11ty/content/_assets/images/tables/table-1.html
@@ -1,0 +1,441 @@
+<table>
+  <caption><strong>Table 1</strong><br />
+    <strong>Duration of different steps in making a bronze sculpture</strong><br />
+    <span class="details">The time required for each step depends on many parameters, including the size of the sculpture, its desired finish quality, the casting process employed, the number of parts requiring assembly, the amount of repair and fettling necessary, the type of patina used, and more. Time also depends on the available technologies and the production environment (e.g., a specific commission in a small workshop versus industrial production of a replica in an industrial foundry). Some extreme examples are given here based on historical documents and direct knowledge of recent fabrications.</span>
+  </caption>
+<thead>
+ <tr>
+  <th>PROCESS
+  STEP</th>
+  <th>GENERAL
+  COMMENTS</th>
+  <th>SPECIFIC
+  EXAMPLES</th>
+  <th>APPROX.
+  DURATION</th>
+  <th>DETAILED
+  PROCESS</th>
+  <th>ILLUSTRATIONS</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+  <td rowspan=4 ><a target="_blank" href="/vocabulary/lost-wax-casting/">lost-wax casting</a>: making the wax <a target="_blank" href="/vocabulary/model/">model</a></td>
+  <td rowspan=4 >Given
+  the variety of methods used to prepare the wax, the varying complexity of
+  models, and the range of sizes that may be encountered in lost-wax casting of
+  bronze sculpture, time to form the wax model may vary greatly (see <a target="_blank" href="/intro/#S2.2">GI§2.2</a>, <a target="_blank" href="/intro/#S2.3">GI§2.3</a>).</td>
+  <td>Head
+  of Apollo of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>3–4
+  hours</td>
+  <td>Making
+  a plaster piece mold of the 3D resin print took 2 hours, including setting of
+  the plaster. Time to prepare the wax model depended on the process chosen: 1
+  hour was needed for slush molding; 1.5 hours for the indirect wax-slab
+  process; 2 hours for lasagna.</td>
+  <td><a target="_blank" href="/visual-atlas/#fig-015">figs.
+  15</a>, <a target="_blank" href="/visual-atlas/#fig-017">17</a>, <a target="_blank" href="/visual-atlas/#fig-024">24</a>, <a target="_blank" href="/visual-atlas/#fig-074">74</a>, <a target="_blank" href="/visual-atlas/#fig-080">80</a>, <a target="_blank" href="/visual-atlas/#fig-377">377</a></td>
+ </tr>
+ <tr>
+  <td>Horse head by Andrew Lacey (H. 45 cm)<sup>(5)</sup></td>
+  <td>1
+  day</td>
+  <td>Making
+  a a two-piece silicone rubber mold of the original clay model took 1 day;
+  making the wax inter-model (slush molding) took 1.5 hours.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-03">video 3</a></td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s experimental replica of the
+  Satyr and Satyress by Andrea Riccio (H. 18.5 cm) (after original in the
+  V&amp;A: A.8-1949, presented by the Art Fund)</td>
+  <td>3
+  days</td>
+  <td>A
+  direct process was used; the hand modeling took 3 days.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-562">fig. 562</a></td>
+ </tr>
+ <tr>
+  <td>Rodin’s <i>Gates of Hell</i> (H. ~6 m), Fonderie Couberin<sup>(2)</sup></td>
+  <td>1.3
+  years</td>
+  <td>A
+  total of almost 13,000 person-hours were recorded for molding the model,
+  pouring wax in separate sections (two main sections and 136 small ones),
+  assembly of waxes, insertion of armatures, and core. Considering 5 persons
+  working simultaneously, this meant 64 weeks of work for the foundry.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+ <tr>
+  <td rowspan=5 ><a target="_blank" href="/vocabulary/lost-wax-casting/">lost-wax casting</a>: applying <a target="_blank" href="/vocabulary/sprue/">sprues</a> and completing
+  the <a target="_blank" href="/vocabulary/refractory-mold">refractory mold</a></td>
+  <td rowspan=5 >Once
+  sprueing is carried out (see <a target="_blank" href="/intro/#S2.7">GI§2.7</a>) and the investment and core are set, the refractory mold is
+  baked to dry it fully and melt out the wax (see <a target="_blank" href="/intro/#S2.1.1">GI§2.1.1</a>).</td>
+  <td>Head
+  of Apollo of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>4 hours</td>
+  <td>Sprueing took
+  30 min.; pouring and setting of the plaster for both core and investment took
+  30 min.; 3 hours firing in a kiln were necessary to ensure that the plaster
+  core and refractory mold were free of wax and moisture.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Horse head by Andrew Lacey (H. 45 cm)</td>
+  <td>5
+  hours</td>
+  <td>Sprueing
+  took 1 hour; making the ceramic shell investment of seven layers took 2.5
+  hours spread over 3 days of drying; dewaxing 30 min.; kiln firing 1.5 hours.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-02">video 2</a></td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s experimental replica of the
+  Satyr and Satyress by Andrea Riccio (H. 18.5 cm) (after original in the
+  V&amp;A: A.8-1949, presented by the Art Fund)</td>
+  <td>4
+  hours</td>
+  <td>Sprueing
+  took 30 min.; making the investment 2 hours; dewaxing 10 min.; kiln firing
+  1.5 hours.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Rodin’s <i>Gates of Hell</i> (H. ~6 m), Fonderie Couberin<sup>(2)</sup></td>
+  <td>3
+  months</td>
+  <td>A
+  total of ~760 person-hours were recorded for making the ceramic-shell
+  investment. Considering five persons working simultaneously, this meant 4
+  weeks of work for the foundry. 2 months were then needed to dry and bake the
+  investment.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+ <tr>
+  <td>Comparison of two monumental equestrian
+  statues: François Girardon’s monumental Louis XIV (cast by Balthasar Keller
+  in 1699) and Edme Bouchardon’s Louis XV (cast by Pierre Gor in 1758)<sup>(3)</sup></td>
+  <td>1
+  month</td>
+  <td>Once the wax
+  was withdrawn, it took 23 days to bake the refractory mold and the core for
+  the Louis XIV versus more than 27 days for the Louis XV, including the
+  cooling down. Note that the building of the huge brick refractory molds
+  (whether buried [Louis XVI]; or not [Louis XV]) certainly required several
+  days, although not specified by Boffrand or Mariette.</td>
+  <td><a target="_blank" href="/visual-atlas/#fig-045">fig. 45</a></td>
+ </tr>
+ <tr>
+  <td rowspan=2><a target="_blank" href="/vocabulary/sand-casting/">sand casting</a></td>
+  <td rowspan=2>The process here
+  includes the formation of the chef-modèle, ramming the sand around the
+  chef-modèle (including the formation of piece mold sections), formation of
+  the core, and drying of the mold (see <a target="_blank" href="/intro/#S2.4.1">GI§2.4.1</a>).</td>
+  <td>Head
+  of Apollo of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>1–2
+  days</td>
+  <td>Preparing
+  the sand casting mold took &lt;0.5 days; drying the mold took approximately
+  1.5 days.</td>
+  <td><a target="_blank" href="/visual-atlas/#fig-062">fig. 62</a></td>
+ </tr>
+ <tr>
+  <td>Two sculptures of two very different sizes by
+  Santiago Calatra Valls, cast by Fonderie Coubertin: <i>Support de table homme assis</i> (H. 70 cm), and <i>Grand disque solaire fendu</i> (D. 300
+  cm)<sup>(6)</sup></td>
+  <td>Small
+  sculpture: 8 days; large one: 1.5 months</td>
+  <td>The
+  formation of the plaster chef-modèle took 5 person-hours for the small
+  sculpture, 35 person-hours for the large one (5/35). Ramming of the sand
+  required 30/210 person-hours; forming of the core 25/175 person-hours. Drying
+  of the sand was accelerated by using carbon dioxide. Considering one person
+  alone for the small piece and two people working simultaneously for the big
+  one, this meant ~8 days total work for the small sculpture and 1.5 months for
+  the larger one.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td rowspan=6 >melting the metal</td>
+  <td rowspan=6 >Time needed to melt the metal can vary greatly and depends on
+  the type of furnace and fuel used, the capacity of the crucible or furnace
+  load, the quantity of metal, and the alloy composition.</td>
+  <td>Head
+  of Apollo of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>1
+  hour</td>
+  <td>Melting
+  the batch of metal (~50 kg) in an induction furnace took 1 hour.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Horse head by Andrew Lacey (H. 45 cm)</td>
+  <td>1.5
+  hours</td>
+  <td>1.5
+  hours needed to melt 45 kg of alloy in a gas furnace and degassed by poling
+  with a hazel stick.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s experimental replica of the
+  Satyr and Satyress by Andrea Riccio (H. 18.5 cm) (after original in the
+  V&amp;A: A.8-1949, presented by the Art Fund)</td>
+  <td>30
+  minutes</td>
+  <td>30
+  min. needed to melt 3 kg of alloy in a charcoal hearth using Cu90% Sn10%,
+  degassed and cleaned by poling with a hazel stick (for a final sculpture
+  weight of 1.98 kg).</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Rodin’s <i>Gates of Hell</i> (H. ~6 m), Fonderie Couberin<sup>(2)</sup></td>
+  <td>12–20
+  hours</td>
+  <td>8.5
+  tons of metal were needed for the two main pieces.Thanks to several
+  improvements in the reverberatory furnace, the melting time dropped from 20
+  hours for the first edition in 1981, to 16 hours in 1992, to 12 hours in
+  1996. 500 kg of metal were needed for the small pieces, melted in a small gas
+  furnace.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+ <tr>
+  <td>Two sculptures of two very different sizes by
+  Santiago Calatra Valls, cast by Fonderie Coubertin: <i>Support
+  de table homme assis</i> (H. 70 cm), and <i>Grand disque solaire fendu</i> (D. 300
+  cm)(6)</td>
+  <td>Small
+  sculpture: 6 hours; large one: 40 hours</td>
+  <td>150
+  kg of metal was melted for the small piece, 1,500 kg for the large one.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Comparison of two monumental equestrian
+  statues: François Girardon’s monumental Louis XIV (cast by Balthasar Keller
+  in 1699) and Edme Bouchardon’s Louis XV (cast by Pierre Gor in 1758)</td>
+  <td>1–2
+  days</td>
+  <td>For
+  the cast of Louis XIV, the furnace was heated for 40 hours, including 24
+  hours to melt the ~41 tons of metal (84,000 French pounds), versus 28 hours
+  for the 29 tons of metal (60,000 French pounds) for the cast of Louis XV.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td rowspan=6 ><a target="_blank" href="/vocabulary/pour/">pouring</a> of the metal</td>
+  <td rowspan=6 >Pouring of the metal never exceeds several
+  minutes, even for monumental bronzes (see <a target="_blank" href="/intro/#S2.7">GI§2.7</a>).</td>
+  <td>Head
+  of Apollo of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>10
+  seconds</td>
+  <td>The
+  pour lasted less than 10 sec. Two people were needed to take the crucible out
+  of the induction furnace and to feed the mold. One more was needed to prevent
+  slags from entering the mold.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-18">video 18</a></td>
+ </tr>
+ <tr>
+  <td>Horse head by Andrew Lacey (H. 45 cm)</td>
+  <td>30
+  seconds</td>
+  <td>The
+  single-handed pour using an electric host lasted 30 sec.: ~10–12 sec. for the
+  two casts with 8–10 sec. between to steady the crucilbe. The bronze was
+  metaled in a gas furnace and degassed by poling with a hazel stick.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-11">video 11</a></td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s experimental replica of the
+  Satyr and Satyress by Andrea Riccio (H. 18.5 cm) (after original in the
+  V&amp;A: A.8-1949, presented by the Art Fund)</td>
+  <td>6
+  seconds</td>
+  <td>This
+  very small pour took no more than 6 sec. from a 3 kg crucible held in
+  blacksmith tongs. The bronze was melted on a charcoal hearth using Cu90%
+  Sn10%, degassed and cleaned by poling with a hazel stick.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-09">video 9</a></td>
+ </tr>
+ <tr>
+  <td>Rodin’s <i>Gates of Hell</i> (H. ~6 m), Fonderie Couberin<sup>(2)</sup></td>
+  <td>55
+  seconds</td>
+  <td>To
+  feed the main mold, 7 min. were required to transfer the metal from the
+  reverberatory furnace to the quenouilles (holding) basin. Subsequent feeding of the mold took 55 sec.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+ <tr>
+  <td>Two sculptures of two very different sizes by
+  Santiago Calatra Valls, cast by Fonderie Coubertin: <i>Support
+  de table homme assis</i> (H. 70 cm), and <i>Grand disque solaire fendu</i> (D. 300
+  cm)(6)</td>
+  <td>Small
+  sculpture: 90 seconds; large one: 150 seconds</td>
+  <td>-</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Comparison of two monumental equestrian
+  statues: François Girardon’s monumental Louis XIV (cast by Balthasar Keller
+  in 1699) and Edme Bouchardon’s Louis XV (cast by Pierre Gor in 1758)</td>
+  <td>a
+  few minutes</td>
+  <td>The
+  duration of the pour is described as “en très peu de temps” (very
+  little time) for the Louis XIV; the pour took 5:04 min. for the Louis XV.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td rowspan=7 ><a target="_blank" href="/vocabulary/fettling/">fettling</a>, <a target="_blank" href="/vocabulary/chasing/">chasing</a>, and repairs</td>
+  <td rowspan=7 >The amount of
+  fettling, chasing, and repairs undertaken depends on several parameters,
+  including the success of the casting, the type and degree of chasing desired,
+  as well as the number and type of repairs and assemblies undertaken (see <a target="_blank" href="/vol-1/4/">I.4</a>, <a target="_blank" href="/vol-1/5/">I.5</a>). Nevertheless, these are
+  often the most time-consuming steps in the making of a bronze (see also <a target="_blank" href="/visual-atlas/#fig-003">fig. 3</a>). For more on fettling and
+  chasing see <a target="_blank" href="/intro/#S2.9">GI§2.9</a>, <a target="_blank" href="/vol-1/6/">I.6</a>).</td>
+  <td>Head
+  of Apollo of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>6
+  hours</td>
+  <td>Fettling
+  took 2 hours, chasing 4 hours. The hole in the face was relatively quickly
+  repaired with a welding rod.</td>
+  <td><a target="_blank" href="/visual-atlas/#fig-073">figs. 73</a>, <a target="_blank" href="/visual-atlas/#fig-121">121</a></td>
+ </tr>
+ <tr>
+  <td>Horse head by Andrew Lacey (H. 45 cm)</td>
+  <td>6
+  hours</td>
+  <td>Fettling
+  took 2 hours, chasing and repairs 4 hours.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-11">video 11</a></td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s experimental replica of the
+  Satyr and Satyress by Andrea Riccio (H. 18.5 cm) (after original in the
+  V&amp;A: A.8-1949, presented by the Art Fund)</td>
+  <td>2
+  hours</td>
+  <td>Fettling
+  took 15 min., chasing and repairs 2 hours.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s reconstruction of a figure (the
+  old man) from one of a pair of sculptures formerly in the Rothschild
+  Collection<sup>(4)</sup></td>
+  <td>1–2
+  days</td>
+  <td>A
+  more careful application of the first layers of the investment considerably
+  reduced surface imperfections on the second replica, thus requiring half the
+  time for chasing: 1 day instead of 2 days on the first replica.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-13">videos 13</a>, <a target="_blank" href="/visual-atlas/#vid-15">15</a>; <a target="_blank" href="/visual-atlas/#fig-004">figs. 4</a>, <a target="_blank" href="/visual-atlas/#fig-005">5</a>, <a target="_blank" href="/visual-atlas/#fig-105">105</a></td>
+ </tr>
+ <tr>
+  <td>Rodin’s <i>Gates of Hell</i> (H. ~6 m), Fonderie Couberin<sup>(2)</sup></td>
+  <td>1.4
+  years</td>
+  <td>A
+  total of ~13,600 person-hours were recorded for fettling and chasing.
+  Considering five people working simultaneously, this required 68 weeks. Note that 2 weeks were necessary
+  for the bronze to cool down before fettling could start.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+ <tr>
+  <td>Two sculptures of two very different sizes by
+  Santiago Calatra Valls, cast by Fonderie Coubertin: <i>Support
+  de table homme assis</i> (H. 70 cm), and <i>Grand disque solaire fendu</i> (D. 300
+  cm)<sup>(6)</sup></td>
+  <td>Small
+  sculpture: 1 week; large one: 3 weeks</td>
+  <td>5 person-hours
+  were needed for the fettling of the small piece, versus 30 person-hours for
+  the large one. Chasing lasted 32 versus 225 person-hours. Considering one
+  person alone for the small piece and two working simultaneously for the big
+  one, this meant ~1 week (respectively 3 weeks) of work for the foundry.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Comparison of two monumental equestrian
+  statues: François Girardon’s monumental Louis XIV (cast by Balthasar Keller
+  in 1699) and Edme Bouchardon’s Louis XV (cast by Pierre Gor in 1758)</td>
+  <td>A few years</td>
+  <td>Due to major
+  casting flaws, chasing and repairing the monumental cast of Louis XV took 5
+  years. No indications are given by Boffrand the time needed to finish the
+  cast of Louis XIV.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td rowspan=5 ><a target="_blank" href="/vocabulary/patina/">patination</a></td>
+  <td rowspan=5 >For more on patination, see <a target="_blank" href="/vol-1/8/">I.8</a>. Other finishing processes such as metal plating and inlaying
+  might be carried out instead of or in addition to patination.</td>
+  <td>Head of Apollo
+  of Lillebonne (H. 18 cm), Fonderie Coubertin<sup>(1)</sup></td>
+  <td>1 hour</td>
+  <td>Chemical
+  patination took 1 hour.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Horse head by Andrew Lacey (H. 45 cm)</td>
+  <td>1
+  hour</td>
+  <td>Chemical
+  patination took 1 hour.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-15">video 15</a></td>
+ </tr>
+ <tr>
+  <td>Andrew Lacey’s experimental replica of the
+  Satyr and Satyress by Andrea Riccio (H. 18.5 cm) (after original in the
+  V&amp;A: A.8-1949, presented by the Art Fund)</td>
+  <td>1
+  hour</td>
+  <td>Chemical
+  patination took 1 hour.</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td>Rodin’s <i>Gates of Hell</i> (H. ~6 m), Fonderie Couberin<sup>(2)</sup></td>
+  <td>4
+  weeks</td>
+  <td>1,560
+  hours-person were recorded for the chemical patination, representing 4 weeks
+  of work.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+ <tr>
+  <td>Two sculptures of two very different sizes by Santiago Calatra
+  Valls, cast by Fonderie Coubertin: <i>Support de table homme
+  assis</i> (H. 70 cm), and <i>Grand
+  disque solaire fendu</i> (D. 300 cm)<sup>(6)</sup></td>
+  <td>Small
+  sculpture: 2 days; large one: 2 weeks</td>
+  <td>Chemical
+  patination took 2 days/2 weeks.</td>
+  <td><a target="_blank" href="/visual-atlas/#vid-17">video 17</a></td>
+ </tr>
+</tbody>
+</table>
+
+<div class="table-key">
+<dl>
+  <dt><sup>1</sup></dt><dd>Although the casting of reproductions of the Apollo heads illustrated here was carried out by inexperienced attendees of a training workshop in 2016, all of the reported durations have been adjusted for skilled craftspeople based on interviews with professional foundry workers.</dd>
+  <dt><sup>2</sup></dt><dd>Three editions of the monumental <i>Gates of Hell</i> have been cast by the Fonderie Coubertin: 1981, 1992, and 1996. Casting of the 1992 edition was recorded in a documentary for French national television FR3 in 1993 by Laurène L'allinec (<i>Du modèle au bronze</i>, 20 min.). Details of the casting processes in use at the Fonderie Coubertin can be
+  found in {Dubos 2003}; {Dubos 2014}.</dd>
+  <dt><sup>3</sup></dt><dd>More details in {Boffrand 1743}, 54, 57; {Mariette 1768},111; {Desmas 2014}.</dd>
+  <dt><sup>4</sup></dt><dd>More details in {Lacey 2018}. See also in the present publication <a target="_blank" href="/vol-2/9/#S2.2">II.9§2.2</a>.</dd>
+  <dt><sup>5</sup></dt><dd>See <a target="_blank" href="/case-studies/7/">Case Study 7</a> for a
+  detailed description of the process.</dd>
+  <dt><sup>6</sup></dt><dd>The plaster models provided by the artist were enlarged at the foundry.</dd>
+</dl>
+</div>

--- a/packages/11ty/content/_assets/images/tables/table-3.html
+++ b/packages/11ty/content/_assets/images/tables/table-3.html
@@ -1,0 +1,393 @@
+<table>
+  <caption><strong>Table 3</strong><br />
+  <strong>Casting processes used in selected modern art foundries worldwide</strong>
+  </caption>
+<thead>
+<tr>
+  <th colspan=2 >Country</th>
+  <th colspan=2 >France</th>
+  <th colspan=3 >UK</th>
+  <th colspan=3 >Germany</th>
+  <th colspan=3 >Italy</th>
+  <th colspan=2 >USA</th>
+  <th>Cameroon</th>
+  <th>Burkina Faso</th>
+  <th>Mali</th>
+  <th>South Africa</th>
+  <th>India</th>
+  <th>Nepal</th>
+  <th colspan=5 >Thailand</th>
+  <th>Cambodia</th>
+  <th colspan=2 >China</th>
+ </tr>
+<tbody>
+ <tr>
+  <th colspan=2 >Foundry name (and/or location)</th>
+  <td>Fonderie
+  de Coubertin (St Rémy-lès-Chevreuse, Ile de France)</td>
+  <td>Fonderie
+  Susse (Arcueil, Ile de France)</td>
+  <td>Andrew
+  Lacey</td>
+  <td>Pangolin</td>
+  <td>Royal
+  College of Art (London)</td>
+  <td>Hermann
+  Noack (Berlin)</td>
+  <td>Strassacker
+  (near Stuttgart)</td>
+  <td>Lauchammer
+  (near Dresden)</td>
+  <td>Fonderia
+  Del Chiaro (Pietrasanta, Tuscany)</td>
+  <td>Fonderia
+  Mariani (Pietrasanta, Tuscany)</td>
+  <td>Fonderia
+  Battaglia (Milan)</td>
+  <td>Modern
+  Art Foundry (Astoria, NY)</td>
+  <td>Shindoni
+  (Tesuque, NM)</td>
+  <td>(Bamenda)</td>
+  <td>(Ouagadougou)</td>
+  <td>(Bamako)</td>
+  <td>Dionysus
+  Sculpture Works (Pretoria)</td>
+  <td>(Swamimilai)</td>
+  <td>&nbsp;</td>
+  <td>(Thonburi)</td>
+  <td>(Chiang Mai)</td>
+  <td>Brass worker
+  village (Ubon)</td>
+  <td>Buranathai Buddha
+  Image Factory (Pitsanulok)</td>
+  <td>Bangkok Noi
+  Foundry (Bangkok)</td>
+  <td>It
+  Sopheap foundry (Siem Reap)</td>
+  <td>Tongling
+  Xinjiuding Bronze Culture Industry Co., Ltd. (铜陵新九鼎铜文化有限公司 | Tongling City,
+  Anhui Province)</td>
+  <td>Various factories (Shanxi,
+  Shandong, Jiangxi, Sichuan, and other provinces, e.g., Yuda Group, Shanxi
+  province; Aerosun Corporation, Jiangsu province)</td>
+ </tr>
+ <tr>
+  <th colspan=2 >Source</th>
+  <td>Dubos,
+  pers. comm. 2020; {Dubos 2003}; {Dubos 2014}</td>
+  <td>{Ginisty
+  1987}</td>
+  <td>Lacey,
+  pers. comm. 2020</td>
+  <td>Lacey,
+  pers. comm. 2020</td>
+  <td>{Rome
+  and Young 2003}</td>
+  <td>Welter,
+  pers. comm. 2020; {Diehl 1927}; {Schulz and Baatz 1993}</td>
+  <td>Kreutner,
+  pers. comm. 2020</td>
+  <td>Welter,
+  pers. comm. 2020; {Schmidt 2011}</td>
+  <td>Morigi,
+  pers. comm. 2020</td>
+  <td>Morigi,
+  pers. comm. 2020</td>
+  <td>Morigi,
+  pers. comm. 2020</td>
+  <td>Bassett,
+  pers. comm. 2020 w/ Jeffrey Spring</td>
+  <td>Lacey,
+  pers. comm. 2020</td>
+  <td>{Coutant
+  2005}</td>
+  <td colspan=2 >{Armbruster 1993}</td>
+  <td>Nolene Gerber, pers. comm. w/
+  Bewer 2021</td>
+  <td>{Levy 2008}</td>
+  <td>{Craddock
+  2015}</td>
+  <td colspan=5 >{Strahan 1997}</td>
+  <td>It
+  Sopheap, pers. comm.</td>
+  <td>Strahan,
+  pers. comm. w/ Bewer 2021</td>
+  <td>Haiping Lian, pers. comm. w/ Bewer
+  2021</td>
+ </tr>
+ <tr>
+  <th rowspan=7 ><a target="_blank" href="/vocabulary/lost-wax-casting/">lost-wax processes</a></th>
+  <th>direct
+  lost wax</th>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+ <tr>
+  <th>direct wax slab</th>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+ <tr>
+  <th>slush molding</th>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+ </tr>
+ <tr>
+  <th>indirect wax slab</th>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+ <tr>
+  <th>indirect wax painting</th>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+ <tr>
+  <th>lasagna</th>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+ <tr>
+  <th>cut-back core</th>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+ <tr>
+  <th rowspan=2 >other processes</th>
+  <th><a target="_blank" href="/vocabulary/sand-casting/">sand</a></th>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+ </tr>
+ <tr>
+  <th><a target="_blank" href="/vocabulary/piece-mold/">piece-mold</a></th>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>x</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+  <td>&nbsp;</td>
+ </tr>
+</tbody>
+</table>

--- a/packages/11ty/content/_assets/styles/components/q-figure.scss
+++ b/packages/11ty/content/_assets/styles/components/q-figure.scss
@@ -18,8 +18,15 @@
 
 // .q-figure
 // -----------------------------------------------------------------------------
+// overwrite bulma
 .content .q-figure {
-  text-align: unset; // overwrite bulma
+  text-align: unset;
+  &:not(:last-child) {
+    margin-bottom: 2rem;
+  }
+  &:not(:first-child) {
+    margin-top: 2rem;
+  }
 }
 
 .q-figure {
@@ -28,7 +35,7 @@
   &:not(.q-figure--group__item) {
     border-top: 1px solid $accent-color;
     border-bottom: 1px solid $accent-color;
-    padding: 1em 0;
+    padding: 1rem 0;
     margin-top: 0.5em;
     margin-left: 0;
     margin-right: 0;
@@ -73,26 +80,14 @@
     width: 100%;
   }
 
-  &__table {
-    &-wrapper {
+  &--table {
+    a {
+      color: currentColor;
     }
-  }
-
-  &__table {
     table {
-      margin: 0 !important;
       caption {
         font-size: 1rem;
-        margin: 1rem;
-      }
-      tfoot {
-        ul {
-          li {
-            &:before {
-              content: "" !important;
-            }
-          }
-        }
+        margin: 0 1rem 1rem;
       }
     }
     th {
@@ -103,44 +98,41 @@
       border-left-width: 0px;
       border-bottom: 0;
     }
-    margin: 0 !important;
-    padding-bottom: 1em;
+  }
+  &.is-table-scale-1 {
+    font-size: 0.1rem;
+  }
+
+  &.is-table-scale-2 {
+    font-size: 0.2rem;
+  }
+
+  &.is-table-scale-3 {
+    font-size: 0.3rem;
+  }
+
+  &.is-table-scale-4 {
+    font-size: 0.4rem;
+  }
+
+  &.is-table-scale-5 {
+    font-size: 0.5rem;
+  }
+
+  &.is-table-scale-6 {
+    font-size: 0.6rem;
+  }
+
+  &.is-table-scale-7 {
+    font-size: 0.7rem;
+  }
+
+  &.is-table-scale-8 {
     font-size: 0.8rem;
-    &.q-table-scale-1 {
-      font-size: 0.1rem;
-    }
+  }
 
-    &.q-table-scale-2 {
-      font-size: 0.2rem;
-    }
-
-    &.q-table-scale-3 {
-      font-size: 0.3rem;
-    }
-
-    &.q-table-scale-4 {
-      font-size: 0.4rem;
-    }
-
-    &.q-table-scale-5 {
-      font-size: 0.5rem;
-    }
-
-    &.q-table-scale-6 {
-      font-size: 0.6rem;
-    }
-
-    &.q-table-scale-7 {
-      font-size: 0.7rem;
-    }
-
-    &.q-table-scale-8 {
-      font-size: 0.8rem;
-    }
-
-    &.q-table-scale-9 {
-      font-size: 0.9rem;
-    }
+  &.is-table-scale-9 {
+    font-size: 0.9rem;
   }
 
   .content & {

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
@@ -44,17 +44,12 @@
       justify-content: center;
     }
 
-    &--table .table-wrapper {
-      background-color: white;
-      color: black;
-      display: flex;
-      flex-direction: column;
-      max-height: 80vh;
-      max-width: 80vw;
-      overflow: scroll;
-      padding: 16px;
+    &--table {
 
-      table,
+      table {
+        background-color: white;
+        color: black;
+      }
       caption {
         margin-bottom: 1rem;
       }
@@ -122,6 +117,16 @@
 
     img {
       object-fit: contain;
+    }
+
+    .overflow-container {
+      background-color: white;
+      color: black;
+      display: flex;
+      flex-direction: column;
+      max-height: 80vh;
+      max-width: 80vw;
+      padding: 1rem;
     }
   }
 

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
@@ -46,6 +46,16 @@
 
     &--table {
 
+      .overflow-container {
+        background-color: white;
+        color: black;
+        display: flex;
+        flex-direction: column;
+        max-height: 80vh;
+        max-width: 80vw;
+        padding: 1rem;
+      }
+
       table {
         background-color: white;
         color: black;
@@ -117,16 +127,6 @@
 
     img {
       object-fit: contain;
-    }
-
-    .overflow-container {
-      background-color: white;
-      color: black;
-      display: flex;
-      flex-direction: column;
-      max-height: 80vh;
-      max-width: 80vw;
-      padding: 1rem;
     }
   }
 

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
@@ -23,20 +23,7 @@
       transform: translateY(0);
       opacity: 1;
       transition: transform 0s, opacity 0.4s linear;
-      z-index: 1;
-
-      .table-wrapper {
-        z-index: 4;
-      }
     }
-  }
-
-  .q-lightbox-ui * {
-    z-index: 2;
-  }
-
-  .q-modal__close-button {
-    z-index: 3;
   }
 
   .q-lightbox-slides__element {

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-slides.scss
@@ -23,7 +23,20 @@
       transform: translateY(0);
       opacity: 1;
       transition: transform 0s, opacity 0.4s linear;
+      z-index: 1;
+
+      .table-wrapper {
+        z-index: 4;
+      }
     }
+  }
+
+  .q-lightbox-ui * {
+    z-index: 2;
+  }
+
+  .q-modal__close-button {
+    z-index: 3;
   }
 
   .q-lightbox-slides__element {
@@ -42,6 +55,41 @@
       display: flex;
       align-items: center;
       justify-content: center;
+    }
+
+    &--table .table-wrapper {
+      background-color: white;
+      color: black;
+      display: flex;
+      flex-direction: column;
+      max-height: 80vh;
+      max-width: 80vw;
+      overflow: scroll;
+      padding: 16px;
+
+      table,
+      caption {
+        margin-bottom: 1rem;
+      }
+      table,
+      th,
+      td {
+        border: 1px solid black;
+        border-collapse: collapse;
+        width: fit-content;
+      }
+      th,
+      td {
+        padding: 4px;
+      }
+      a {
+        border-bottom: 1px dotted currentColor;
+        color: currentColor;
+
+        &:hover {
+          border-bottom-style: solid;
+        }
+      }
     }
 
     &--audio,

--- a/packages/11ty/content/_assets/styles/components/q-lightbox-ui.scss
+++ b/packages/11ty/content/_assets/styles/components/q-lightbox-ui.scss
@@ -5,6 +5,12 @@
 // Styles for `lightboxUi` shortcode used in `lightbox` shortcode
 
 @media screen {
+  .q-lightbox-ui > *,
+  .q-modal__close-button,
+  .q-lightbox-slides__caption {
+    z-index: 1;
+  }
+  
   .q-lightbox-ui__fullscreen-button {
     position: absolute;
     top: 0;

--- a/packages/11ty/content/_assets/styles/utilities.scss
+++ b/packages/11ty/content/_assets/styles/utilities.scss
@@ -151,6 +151,11 @@ sub {
   }
 }
 
+.overflow-container {
+  overflow: scroll;
+  box-sizing: border-box;
+}
+
 .quire-error {
   text-align: left;
   p {

--- a/packages/11ty/content/_data/figures.yaml
+++ b/packages/11ty/content/_data/figures.yaml
@@ -125,6 +125,12 @@ figure_list:
     label: "Table 1"
     caption: "Area of the characteristic absorption band."
     credit: "Ivana Bačić, Jasna Jablan"
+  - id: "table-1"
+    src: "tables/table-1.html"
+    media_type: table
+  - id: "table-3"
+    src: "tables/table-3.html"
+    media_type: table
   - id: "photo-podcast"
     media_id: 336879231
     media_type: soundcloud

--- a/packages/11ty/content/figures-demo.md
+++ b/packages/11ty/content/figures-demo.md
@@ -16,9 +16,13 @@ order: 505
 
 {% figure "example-with-choices" %}
 
-## Table
+## Tables
 
 {% figure "table-21-1" %}
+
+{% figure "table-1" "is-table-scale-7" %}
+
+{% figure "table-3" "is-table-scale-2" %}
 
 ## YouTube
 


### PR DESCRIPTION
Some table-related fixes that I made first in _Bronze Guidelines_:

- Add a a div wrapper and the necessary css to enable scrolling on large tables in the lightbox
- Clean up default table styles in the lightbox and for tables on the page
- Fix a series of classes that users can add in the figure shortcode to make table font size smaller (ie., `is-table-scale-7`)
- Adjusted the z-index of several UI elements so that they weren't hidden behind the table. (Note, I put them all in `q-lightbox-ui.scss` for clarity, though technically one is part of the modal, and one is part of the lightbox slides.)
- Add a couple large tables to the starter material for testing