### PR TITLE
Fix/DEV-13262: Annoref should open lightbox slide 

### DIFF
--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -65,7 +65,8 @@ const handleSelect = (element) => {
 }
 
 /**
- * Scroll to a figure, select annotations and/or region, and update the URL
+ * Scroll to a figure, or go to figure slide in lightbox
+ * Select annotations and/or region, and update the URL
  * @param  {String} figureId    The id of the figure in figures.yaml
  * @param  {Array} annotationIds  The IIIF ids of the annotations to select
  * @param  {String} region      The canvas region
@@ -75,6 +76,11 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   const figure = document.querySelector(`#${figureId}, [data-lightbox-slide-id="${figureId}"]`)
   if (!figure) return
   const canvasPanel = figure.querySelector('canvas-panel')
+  const lightbox = figure.closest('q-lightbox')
+
+  if (lightbox) {
+    lightbox.currentId = figureId
+  }
 
   /**
    * Reset checkboxes

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -72,16 +72,19 @@ const handleSelect = (element) => {
  */
 const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   if (!figureId) return
-  const figure = document.querySelector(`#${figureId}`)
+  const figure = document.querySelector(`#${figureId}, [data-lightbox-slide-id="${figureId}"]`)
   if (!figure) return
   const canvasPanel = figure.querySelector('canvas-panel')
+
   /**
-   * Reset inputs
+   * Reset checkboxes
    */
   const inputs = document.querySelectorAll('.annotations-ui__input')
   for (const input of inputs) {
-    input.checked = false
-    handleSelect(input)
+    if (input.getAttribute('type') === 'checkbox') {
+      input.checked = false
+      handleSelect(input)
+    }
   }
   /**
    * Update Canvas state

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -85,7 +85,7 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   /**
    * Reset checkboxes
    */
-  const inputs = document.querySelectorAll('.annotations-ui__input')
+  const inputs = figure.querySelectorAll('.annotations-ui__input')
   for (const input of inputs) {
     if (input.getAttribute('type') === 'checkbox') {
       input.checked = false


### PR DESCRIPTION
Changes:
- Update `goToCanvasState` method to select figures inside the lightbox and update the slide id
- Fix input reset to only apply to the selected figure