### PR TITLE
Set annotation targets on manifest json directly

### DIFF
--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -145,6 +145,15 @@ module.exports = class Manifest {
     })
     try {
       this.json = builder.toPresentation3(manifest)
+      /**
+       * Note: Builder can't currently create annotations with target regions,
+       * so set the target on each annotation directly
+       */
+      const manifestAnnotations = this.json.items[0]?.items[0]?.items || []
+      manifestAnnotations.forEach((item) => {
+        const annotation = this.annotations.find((a) => a.id === item.id)
+        if (annotation) item.target = annotation.target
+      })
       info(`Generated manifest for figure "${this.figure.id}"`)
       return { success: true }
     } catch(errorMessage) {

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -148,7 +148,7 @@ module.exports = class Manifest {
       /**
        * Note: Builder can't currently create annotations with target regions,
        * so set the target on each annotation directly
-       * @see {@link https://github.com/stephenwf/iiif-builder}
+       * @see {@link https://github.com/stephenwf/iiif-builder/issues/6}
        */
       const manifestAnnotations = this.json.items[0]?.items[0]?.items || []
       manifestAnnotations.forEach((item) => {

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -148,6 +148,7 @@ module.exports = class Manifest {
       /**
        * Note: Builder can't currently create annotations with target regions,
        * so set the target on each annotation directly
+       * @see {@link https://github.com/stephenwf/iiif-builder}
        */
       const manifestAnnotations = this.json.items[0]?.items[0]?.items || []
       manifestAnnotations.forEach((item) => {


### PR DESCRIPTION
Builder only uses the default annotation target (the canvas id) and doesn't allow you to pass a target value. This change updates the target on the manifest, allowing us to create annotations that target a region of the canvas. 