### PR TITLE
Refactor bibliography config to use data cascade

### DIFF
--- a/packages/11ty/_layouts/bibliography.liquid
+++ b/packages/11ty/_layouts/bibliography.liquid
@@ -7,7 +7,7 @@ layout: page
 {{ content }}
 
 <div class="quire-page__content__references">
-  {% if config.params.displayBiblioShort == true %}
+  {% if config.bibliography.displayShort == true %}
     {% for entry in entries %}
       <dl>
         <dt><span id="{{ forloop.index }}">{{ entry.id | markdownify }}</span></dt>

--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -12,10 +12,9 @@ module.exports = function (eleventyConfig, { page }) {
   const slugify = eleventyConfig.getFilter('slugify')
   const sortReferences = eleventyConfig.getFilter('sortReferences')
 
-  const { biblioHeading, displayBiblioShort, pageBibliography } = eleventyConfig.globalData.config.params
   const { entries } = eleventyConfig.globalData.references
-  const { page_bibliography } = page.data
 
+  const { displayOnPage, displayShort, heading } = page.data.config.bibliography
   /**
    * bibliography shortcode
    * @example {% bibliography pageReferences %}
@@ -29,13 +28,9 @@ module.exports = function (eleventyConfig, { page }) {
   return function (referenceIds = []) {
     if (!page.citations && !referenceIds) return
 
-    const biblio = page_bibliography == null
-      ? pageBibliography
-      : page_bibliography
-
-    if (biblio == false) {
+    if (!displayOnPage) {
       page.citations
-        ? info(`A bibiliography of citations on ${page.inputPath} is not being displayed there, because 'page_bibliography' on that page or 'pageBibliography' in config.yaml, is set to false.`)
+        ? info(`A bibiliography of citations on ${page.inputPath} is not being displayed there, because 'config.bibliography.displayOnPage' on that page or in config.yaml, is set to false.`)
         : ''
       return ''
     }
@@ -59,8 +54,8 @@ module.exports = function (eleventyConfig, { page }) {
 
     const bibliographyItems = sortReferences(Object.values(page.citations))
 
-    const heading = () => biblioHeading
-      ? `<h2 id="${slugify(biblioHeading)}">${biblioHeading}</h2>`
+    const bibliographyHeading = () => heading
+      ? `<h2 id="${slugify(heading)}">${heading}</h2>`
       : ''
 
     const definitionList = () => html`
@@ -86,8 +81,8 @@ module.exports = function (eleventyConfig, { page }) {
     return bibliographyItems.length
       ? html`
           <div class="quire-page__content__references backmatter">
-            ${heading()}
-            ${displayBiblioShort ? definitionList() : unorderedList()}
+            ${bibliographyHeading()}
+            ${displayShort ? definitionList() : unorderedList()}
           </div>
         `
       : ''

--- a/packages/11ty/content/_data/config.yaml
+++ b/packages/11ty/content/_data/config.yaml
@@ -16,11 +16,9 @@ disableKinds:
   - term
 
 params:
-  biblioHeading: Bibliography
   citationPageLocationDivider: ', '
   citationPopupStyle: text # text | icon
   contributorByline: name-title # name | name-title | false
-  displayBiblioShort: true
   entryPageObjectLinkText: View in Collection
   entryPageSideBySideLayout: false
   figureModal: true
@@ -30,9 +28,13 @@ params:
   licenseIcons: true
   menuType: full
   nextPageButtonText: Next
-  pageBibliography: true
   pageContributorDivider: ' — '
   pageLabelDivider: '. '
   prevPageButtonText: Back
   searchEnabled: true
   tocType: full
+
+bibliography:
+  displayOnPage: true
+  displayShort: true
+  heading: Bibliography


### PR DESCRIPTION
Putting this out there as an alternate solution - I was finding the bibliography logic hard to follow, and the ideal solution here is to leverage the data cascade, which we hadn't approached yet since it required refactoring the `config.yaml`. This refactors just the bibliography configuration, but shows that you can override any `config` property from a page by using the `config` key. For example in `essay.md` to override `displayOnPage` you would write:
```yaml
layout: essay
title: My Essay
config:
  bibliography:
    displayOnPage: true
```
Maybe more verbose, but I think it's simpler because you only have to remember the structure of one config instead of remembering when/where to use `page_bibliography` or `pageBibliography`, and this pattern could definitely be applied elsewhere.