### PR TITLE
Refactor annoref annotation ID parameter

### DIFF
--- a/packages/11ty/_includes/components/figure/annotations-ui/option.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/option.js
@@ -39,6 +39,7 @@ module.exports = function (eleventyConfig) {
           name="${name}"
           type="${input}"
           value="${url}"
+          data-annotation-id="${id}"
           data-annotation-type="${type}"
           ${checked ? 'checked' : ''}
         />

--- a/packages/11ty/_plugins/shortcodes/annoref.js
+++ b/packages/11ty/_plugins/shortcodes/annoref.js
@@ -20,7 +20,8 @@ module.exports = function (eleventyConfig) {
     return oneLine`
       <a 
         class="annoref"
-        data-annotation-ids="${annotationUrls.join(',')}"
+        data-annotation-ids="${annoIds.join(',')}"
+        data-annotation-urls="${annotationUrls.join(',')}"
         data-figure-id="${fig}"
         data-region="${region}"
       >${markdownify(text)}</a>

--- a/packages/11ty/_plugins/shortcodes/annoref.js
+++ b/packages/11ty/_plugins/shortcodes/annoref.js
@@ -2,26 +2,25 @@ const chalkFactory = require('~lib/chalk')
 const { oneLine } = require('~lib/common-tags')
 const logger = chalkFactory(`Shortcodes:Annoref`)
 /**
- * Style wrapped `content` as "backmatter"
+ * Annoref Shortcode
+ * Link to the annotation or region state of a canvas
  *
- * @param      {String}  content  content between shortcode tags
- *
- * @return     {boolean}  A styled HTML <div> element with the content
+ * @param      {Object} params
+ * @property   {String} anno Comma-separated list of annotation ids
+ * @property   {String} fig Figure ID
+ * @property   {String} region Comma-separated, with format "x,y,width,height"
+ * @property   {String} text Link text
+ * 
+ * @return     {String}  Anchor tag with link text annotation and region data attributes
  */
 module.exports = function (eleventyConfig) {
-  const getAnnotation = eleventyConfig.getFilter('getAnnotation')
   const markdownify = eleventyConfig.getFilter('markdownify')
   return ({ anno='', fig, region='', text='' }) => {
     const annoIds = anno.split(',').map((id) => id.trim())
-    const annotationUrls = annoIds.flatMap((id) => {
-      const annotation = getAnnotation(fig, id)
-      return annotation ? annotation.url : []
-    })
     return oneLine`
       <a 
         class="annoref"
         data-annotation-ids="${annoIds.join(',')}"
-        data-annotation-urls="${annotationUrls.join(',')}"
         data-figure-id="${fig}"
         data-region="${region}"
       >${markdownify(text)}</a>

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -33,7 +33,7 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region='' }) {
   const lightbox = figure.closest('q-lightbox')
   const inputs = document.querySelectorAll(`${figureSelectors} .annotations-ui__input`)
   const annotations = [...inputs].map((input) => {
-    const id = input.getAttribute('value')
+    const id = input.getAttribute('data-annotation-id')
     input.checked = annotationIds.includes(id)
     return annotationData(input)
   })

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -23,14 +23,15 @@ const annotationData = (input) => {
  */
 const goToCanvasState = function ({ annotationIds=[], figureId, region='' }) {
   if (!figureId) return
-  const figure = document.querySelector(`#${figureId}, [data-lightbox-slide-id="${figureId}"]`)
+  const figureSelectors = `#${figureId}, [data-lightbox-slide-id="${figureId}"]`
+  const figure = document.querySelector(figureSelectors)
   if (!figure) return
   const canvasPanel = figure.querySelector('canvas-panel')
   if (region && canvasPanel.getAttribute('preset') !== 'zoom') {
     console.warn(`Using the "annoref" shortcode to link to a region on a figure without zoom enabled is not supported. Please set the "preset" property to "zoom" on figure id "${figureId}"`)
   }
   const lightbox = figure.closest('q-lightbox')
-  const inputs = figure.querySelectorAll('.annotations-ui__input')
+  const inputs = document.querySelectorAll(`${figureSelectors} .annotations-ui__input`)
   const annotations = [...inputs].map((input) => {
     const id = input.getAttribute('value')
     input.checked = annotationIds.includes(id)

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -15,6 +15,16 @@ const annotationData = (input) => {
 }
 
 /**
+ * Get canvas id from child canvas-panel element
+ * @param  {HTML Element} element
+ * @return {String} canvasId
+ */
+const getCanvasId = (element) => {
+  const canvasPanel = element.querySelector('canvas-panel')
+  return canvasPanel && canvasPanel.getAttribute('canvas-id');
+}
+
+/**
  * Scroll to a figure, or go to figure slide in lightbox
  * Select annotations and/or region, and update the URL
  * @param  {String} figureId    The id of the figure in figures.yaml
@@ -50,10 +60,7 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   /**
    * Update Canvas state
    */
-  const canvasId = document
-    .querySelector(`${figureSelector}, ${slideSelector}`)
-    .querySelector('canvas-panel')
-    .getAttribute('canvas-id');
+  const canvasId = getCanvasId(figure || figureSlide)
   update(canvasId, { annotations, region: region || 'reset' })
 
   /**
@@ -77,7 +84,7 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
  */
 const handleSelect = (element) => {
   const elementId = element.getAttribute('id')
-  const canvasId = element.closest('.q-figure, .q-lightbox-slides__slide').querySelector('canvas-panel').getAttribute('canvas-id')
+  const canvasId = getCanvasId(element.closest('.q-figure, .q-lightbox-slides__slide'))
   const inLightbox = document.querySelector('q-lightbox').contains(element)
   const annotation = annotationData(element)
   const { checked, input } = annotation

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -187,13 +187,12 @@ const update = (canvasId, data) => {
   }
   const { annotations, region } = data
   canvasPanels.forEach((canvasPanel) => {
-    canvasPanel.setAttribute('region', region || canvasPanel.getAttribute('region'))
     if (region === 'reset') {
       canvasPanel.clearTarget()
     } else if (region) {
       const [x, y, width, height] = region.split(',').map((i) => parseInt(i.trim()))
       const options = { immediate: false }
-      canvasPanel.goToTarget(region, options)
+      canvasPanel.goToTarget({ x, y, width, height }, options)
     }
     annotations.forEach((annotation) => selectAnnotation(canvasPanel, annotation))
   })

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -175,6 +175,7 @@ const update = (canvasPanel, data) => {
   const canvasPanels = document.querySelectorAll(`[canvas-id="${canvasId}"]`)
   const { annotations, region } = data
   canvasPanels.forEach((canvasPanel) => {
+    canvasPanel.setAttribute('region', region || canvasPanel.getAttribute('region'))
     if (region === 'reset') {
       canvasPanel.clearTarget()
     } else if (region) {

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -21,7 +21,7 @@ const annotationData = (input) => {
  * @param  {Array} annotationIds  The IIIF ids of the annotations to select
  * @param  {String} region      The canvas region
  */
-const goToCanvasState = function ({ annotationIds=[], figureId, region='' }) {
+const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   if (!figureId) return
   const figureSelector = `#${figureId}`
   const slideSelector = `[data-lightbox-slide-id="${figureId}"]`
@@ -54,7 +54,7 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region='' }) {
     .querySelector(`${figureSelector}, ${slideSelector}`)
     .querySelector('canvas-panel')
     .getAttribute('canvas-id');
-  update(canvasId, { annotations, region })
+  update(canvasId, { annotations, region: region || 'reset' })
 
   /**
    * Build URL
@@ -156,9 +156,9 @@ const setUpUIEventHandlers = () => {
     /**
      * Annoref shortcode resets the region if none is provided
      */
-    const region = annoRef.getAttribute('data-region') || 'reset'
+    const region = annoRef.getAttribute('data-region')
     annoRef.addEventListener('click', ({ target }) =>
-      goToCanvasState({ annotationIds, figureId, region }),
+      goToCanvasState({ annotationIds, figureId, region })
     )
   }
 

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -27,7 +27,7 @@ const goToCanvasState = function ({ annotationIds=[], figureId, region }) {
   const slideSelector = `[data-lightbox-slide-id="${figureId}"]`
   const figure = document.querySelector(figureSelector)
   const figureSlide = document.querySelector(slideSelector)
-  if (!figure || !figureSlide) return
+  if (!figure && !figureSlide) return
   [figure, figureSlide].forEach((element) => {
     if (!element) return
     const canvasPanel = element.querySelector('canvas-panel')


### PR DESCRIPTION
Update the annoref query params to using the Quire annotation id (a string) instead of the IIIF id (a url) as an identifier, and a few additional QA tasks and improvements:
- Add jsdoc to annoref shortcode
- Fix target parameter
- Refactor canvas-panel `update` method to accept an id instead of an element