### PR TITLE
Fix: selected annotations on load

### DIFF
--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -26,7 +26,7 @@ const titleCase = require('~plugins/filters/titleCase')
 module.exports = class Annotation {
   constructor(figure, data) {
     const { iiifConfig, outputDir } = figure
-    const { label, src, target, text } = data
+    const { label, selected, src, target, text } = data
     const { base, ext, name } = src ? path.parse(src) : {}
 
     /**
@@ -72,6 +72,7 @@ module.exports = class Annotation {
     this.isImageService = isImageService
     this.label = label || titleCase(path.parse(src).name)
     this.motivation = src ? 'painting' : 'text'
+    this.selected = selected
     this.src = src
     this.target = target
     this.text = text

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -87,7 +87,7 @@ const handleSelect = (element) => {
   const canvasId = getCanvasId(element.closest('.q-figure, .q-lightbox-slides__slide'))
   const inLightbox = document.querySelector('q-lightbox').contains(element)
   const annotation = annotationData(element)
-  const { checked, input } = annotation
+  const { checked, input, type } = annotation
   /**
    * Two-way data binding for annotaion UI inputs in lightbox and inline
    */
@@ -101,7 +101,7 @@ const handleSelect = (element) => {
   /**
    * Prevent deselecting all layers if choices and checkboxes are used together
    */
-  if (input === 'checkbox') {
+  if (input === 'checkbox' && type === 'choice') {
     const form = element.closest('form')
     const checkedInputs = form.querySelectorAll('.annotations-ui__input[checked]')
     if (!checked && checkedInputs.length === 1) {


### PR DESCRIPTION
Changes:
- Update annotation class to include `selected` property
- Update choice-type annotation UI with checkboxes