### PR TITLE
Add IIIF figure src copy passthrough

### DIFF
--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -141,10 +141,10 @@ module.exports = class Figure {
    * Process `figure.src`
    */
   async processFigureImage() {
-    if (this.src && this.isImageService) {
+    if (this.src && (this.isCanvas || this.isImageService)) {
       const { transformations } = this.iiifConfig
       const { errors } = await this.imageProcessor.processImage(this.src, this.outputDir, {
-        tile: true,
+        tile: this.isImageService,
         transformations
       })
       if (errors) this.errors = this.errors.concat(errors)


### PR DESCRIPTION
Ensure `processImage` is called on `figure.src` when image is part of a canvas but not an image service