### PR TITLE
Add oxford comma to contributors list

### DIFF
--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -6,7 +6,7 @@ const { error } = chalkFactory('shortcodes:contributors')
 /**
  * Contributor shortcode
  * Renders a list of contributors
- * 
+ *
  * @param  {Array|String} context Array of contributor objects OR string override
  * @param  {String} align How to align the text (name-title-block and bio only) Values: 'left' (default), 'center', 'right'
  * @param  {String} type The contributor type to render. Values: 'all' (default), 'primary', 'secondary'
@@ -75,7 +75,7 @@ module.exports = function (eleventyConfig) {
         const last = contributorInitials.pop()
         const nameString =
           contributorInitials.length >= 1
-            ? contributorInitials.join(', ') + ' and ' + last
+            ? contributorInitials.join(', ') + ', and ' + last
             : last
           contributorsElement = `<span class="quire-contributor">${nameString}</span>`
         break
@@ -112,7 +112,7 @@ module.exports = function (eleventyConfig) {
         const last = contributorNames.pop()
         const namesString =
           contributorNames.length >= 1
-            ? contributorNames.join(', ') + ' and ' + last
+            ? contributorNames.join(', ') + ', and ' + last
             : last
         contributorsElement = `<span class='quire-contributor'>${namesString}</span>`
         break


### PR DESCRIPTION
Getty Pubs' standard is to use the Oxford comma ("one, two, and three" rather than "one, two and three") and so that should be Quire's standard too. I've done it here for the contributors list, which I needed for my current book projects.

Though I wondered if at some point you'd want to refactor this using [common-tags with oneLineCommaListsAnd](https://www.npmjs.com/package/common-tags#onelinecommalistsand) which is used on the `ref` shortcode. And looks like there are some options that could be called and so maybe made into config values for Quire users who hate the Oxford comma, or for i18n (changing "and" to "et" or "y").

```js
opts = {
  separator: ',', // what to separate each item with (always followed by a space)
  conjunction: 'and', // replace the last separator with this value
  serial: true // should the separator be included before the conjunction? As in the case of serial/oxford commas
}
```
Not a task that needs doing now, but I can put it in Jira if you'd like.