### PR TITLE
Refactor linking to region

### DIFF
--- a/packages/11ty/_includes/components/figure/image/canvas-panel.js
+++ b/packages/11ty/_includes/components/figure/image/canvas-panel.js
@@ -26,7 +26,7 @@ module.exports = function(eleventyConfig) {
     iiifContent,
     interactive='false',
     manifestId,
-    preset='zoom',
+    preset='responsive',
     region='',
     virtualSizes='',
     width=''

--- a/packages/11ty/_includes/components/figure/image/canvas-panel.js
+++ b/packages/11ty/_includes/components/figure/image/canvas-panel.js
@@ -24,7 +24,6 @@ module.exports = function(eleventyConfig) {
     height='',
     id,
     iiifContent,
-    interactive='false',
     manifestId,
     preset='responsive',
     region='',
@@ -44,7 +43,6 @@ module.exports = function(eleventyConfig) {
         height="${height}"
         iiif-content="${iiifContent}"
         manifest-id="${manifestId}"
-        interactive="${interactive}"
         preset="${preset}"
         region="${region}"
         virtual-sizes="${virtualSizes}"

--- a/packages/11ty/_includes/components/figure/image/canvas-panel.js
+++ b/packages/11ty/_includes/components/figure/image/canvas-panel.js
@@ -24,8 +24,9 @@ module.exports = function(eleventyConfig) {
     height='',
     id,
     iiifContent,
+    interactive='false',
     manifestId,
-    preset='responsive',
+    preset='zoom',
     region='',
     virtualSizes='',
     width=''
@@ -43,6 +44,7 @@ module.exports = function(eleventyConfig) {
         height="${height}"
         iiif-content="${iiifContent}"
         manifest-id="${manifestId}"
+        interactive="${interactive}"
         preset="${preset}"
         region="${region}"
         virtual-sizes="${virtualSizes}"

--- a/packages/11ty/_includes/components/lightbox/index.js
+++ b/packages/11ty/_includes/components/lightbox/index.js
@@ -13,10 +13,6 @@ module.exports = function (eleventyConfig, { page }) {
 
   return async function (figures=page.figures) {
     if (!figures) return;
-    figures = figures.map((figure) => ({
-      preset: 'zoom',
-      ...figure
-    }))
 
     return html`
       <q-lightbox>

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -22,17 +22,20 @@ module.exports = function(eleventyConfig) {
   return async function(figures) {
     if (!figures) return ''
 
+    figures = figures.map((figure) => ({
+      interactive: 'true',
+      preset: 'zoom',
+      ...figure
+    }))
+
     const slideElement = async (figure) => {
       const {
         aspect_ratio: aspectRatio='widescreen',
         caption,
         credit,
         id,
-        iiif,
         label,
-        media_type: mediaType,
-        preset,
-        src
+        media_type: mediaType
       } = figure
 
       const isAudio = mediaType === 'soundcloud'

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -23,7 +23,6 @@ module.exports = function(eleventyConfig) {
     if (!figures) return ''
 
     figures = figures.map((figure) => ({
-      interactive: 'true',
       preset: 'zoom',
       ...figure
     }))

--- a/packages/11ty/_includes/components/modal/index.js
+++ b/packages/11ty/_includes/components/modal/index.js
@@ -12,10 +12,6 @@ module.exports = function (eleventyConfig, { page }) {
 
   return async function (figures=page.figures) {
     if (!figures) return;
-    figures = figures.map((figure) => ({
-      preset: 'zoom',
-      ...figure
-    }))
 
     return html`
       <q-modal>

--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -48,11 +48,14 @@ module.exports = class Annotation {
     }
 
     /**
+     * Create image service for annotation image if it is a JPG and
+     * the figure has zoom enabled
+     * 
      * Note: Currently only JPG image services are supported by 
      * canvas-panel/image-service tags
      */
-    const isImageService = !!figure.isImageService && ext === '.jpg'
-
+    const isImageService = !!figure.zoom && ext === '.jpg'
+    console.log(figure)
     const info = () => {
       if (!isImageService) return
       const tileDirectory = path.join(outputDir, name, iiifConfig.dirs.imageService)

--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -55,7 +55,6 @@ module.exports = class Annotation {
      * canvas-panel/image-service tags
      */
     const isImageService = !!figure.zoom && ext === '.jpg'
-    console.log(figure)
     const info = () => {
       if (!isImageService) return
       const tileDirectory = path.join(outputDir, name, iiifConfig.dirs.imageService)

--- a/packages/11ty/_plugins/figures/figure/README.md
+++ b/packages/11ty/_plugins/figures/figure/README.md
@@ -13,4 +13,4 @@ Files are written to `<iiifConfig.dirs.outputRoot>/<iiifConfig.dirs.output>/<fig
 Processes image files in `figure.src` and `annotation.src`. Image processing includes creating tiles if the resource is an image service and performing image transformations.
 
 #### Manifest generation
-Generates a IIIF manifest for figures with annotations.
+Generates a IIIF manifest for figures with annotations and figures with a single image and `zoom=true`.

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -47,8 +47,8 @@ module.exports = class Figure {
   }
 
   /**
-   * Represents the "base" figure image defined in `figure.src` as an annotation
-   * for use in IIIF manifests
+   * When the figure is a canvas, represent the image
+   * in `figure.src` as an annotation for use in IIIF manifests
    * @return {Annotation|null}
    */
   get baseImageAnnotation() {
@@ -59,7 +59,8 @@ module.exports = class Figure {
   }
 
   /**
-   * Use dimensions of src or first choice as canvas dimensions
+   * Path to the image file that represents the canvas
+   * Used to define canvas properties `width` and `height`
    */
   get canvasImagePath() {
     if (!this.isCanvas) return

--- a/packages/11ty/_plugins/figures/helpers/is-canvas.js
+++ b/packages/11ty/_plugins/figures/helpers/is-canvas.js
@@ -1,3 +1,24 @@
-module.exports = ({ annotations, id, canvasId, manifestId, iiifContent }) => {
-  return (!!canvasId && !!manifestId) || !!iiifContent || !!annotations
+const path = require('path')
+
+/**
+ * Figure `isCanvas` helper
+ * A figure is a canvas if it has a src and has zoom=true, has annotations,
+ * or links to an external IIIF manifest
+ * 
+ * @param  {Object} data Figure data
+ * @return {Boolean}     True if figure contains a canvas
+ */
+module.exports = (data) => {
+  const { 
+    annotations,
+    canvasId,
+    iiifContent,
+    manifestId,
+    src,
+    zoom
+  } = data
+  return (!!canvasId && !!manifestId)
+    || !!iiifContent
+    || !!annotations
+    || (!!src && !!zoom)
 }

--- a/packages/11ty/_plugins/figures/helpers/is-image-service.js
+++ b/packages/11ty/_plugins/figures/helpers/is-image-service.js
@@ -5,7 +5,6 @@ const path = require('path')
  * @return {Boolean}
  */
 module.exports = function(figure) {
-  const { src='', zoom } = figure
-  const { base } = path.parse(src)
-  return base === 'info.json' || zoom
+  const { src='' } = figure
+  return path.parse(src) === 'info.json'
 }

--- a/packages/11ty/_plugins/figures/iiif/manifest/writer.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/writer.js
@@ -12,7 +12,7 @@ module.exports = class ManifestWriter {
    * @param  {Object} manifest JSON manifest
    */
   write(manifest) {
-    if (!manifest) return
+    if (!manifest) return { errors: ['Error writing manifest. Manifest is undefined.'] }
     const { outputRoot } = this.iiifConfig.dirs
     const pathName = manifest.id.split(this.iiifConfig.baseURL)[1]
     const outputPath = path.join(outputRoot, pathName)

--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -17,7 +17,7 @@ module.exports = function (eleventyConfig, options = {}) {
     figureList = await Promise.all(figureList.map((data) => {
       return figureFactory.create(data)
     }))
-    const errors = figureList.filter(({ errors }) => !!errors.length)
+    const errors = figureList.filter(({ errors }) => errors && !!errors.length)
 
     if (errors.length) {
       error(`There were errors processing the following images:`)

--- a/packages/11ty/_plugins/shortcodes/annoref.js
+++ b/packages/11ty/_plugins/shortcodes/annoref.js
@@ -14,8 +14,13 @@ const logger = chalkFactory(`Shortcodes:Annoref`)
  * @return     {String}  Anchor tag with link text annotation and region data attributes
  */
 module.exports = function (eleventyConfig) {
+  const getFigure = eleventyConfig.getFilter('getFigure')
   const markdownify = eleventyConfig.getFilter('markdownify')
   return ({ anno='', fig, region='', text='' }) => {
+    const figure = getFigure(fig)
+    if (!figure) {
+      console.error(`[annoref shortcode] "fig" parameter doesn't correspond to a valid figure id in "figures.yaml". Fig: ${fig}`)
+    }
     const annoIds = anno.split(',').map((id) => id.trim())
     return oneLine`
       <a 

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -211,7 +211,30 @@ const update = (id, data) => {
   }
   const { annotations, region } = data
   webComponents.forEach((element) => {
-    element.setAttribute('region', region || null)
+
+    /**
+     * Create target object from region string passed to `update` method,
+     * or reset viewport using original region defined in `region` attribute
+     */
+    const getTargetFromRegion = () => {
+      const string = region || element.getAttribute('region')
+      const [ x, y, width, height ] = string.split(',').map((x) => parseInt(x.trim()))
+      return { x, y, width, height }
+    }
+    const goToRegion = () => {
+      const target = getTargetFromRegion()
+      element.transition(tm => {
+        tm.goToRegion(target, {
+          transition: {
+            easing: element.easingFunctions().easeOutExpo,
+            duration: 2000
+          }
+        })
+      })
+    }
+
+    goToRegion()
+
     if (element.tagName === 'CANVAS-PANEL') {
       annotations.forEach((annotation) => selectAnnotation(element, annotation))
     }

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -45,14 +45,9 @@ const goToFigureState = function ({ annotationIds=[], figureId, region }) {
   const slideSelector = `[data-lightbox-slide-id="${figureId}"]`
   const figure = document.querySelector(figureSelector)
   const figureSlide = document.querySelector(slideSelector)
+
   if (!figure && !figureSlide) return
-  [figure, figureSlide].forEach((element) => {
-    if (!element) return
-    const webComponent = element.querySelector('canvas-panel, image-service')
-    if (region && webComponent.getAttribute('preset') !== 'zoom') {
-      console.warn(`Using the "annoref" shortcode to link to a region on a figure without zoom enabled is not supported. Please set the "preset" property to "zoom" on figure id "${figureId}"`)
-    }
-  })
+
   const inputs = document.querySelectorAll(`#${figureId} .annotations-ui__input, [data-lightbox-slide-id="${figureId}"] .annotations-ui__input`)
   const annotations = [...inputs].map((input) => {
     const id = input.getAttribute('data-annotation-id')
@@ -69,7 +64,7 @@ const goToFigureState = function ({ annotationIds=[], figureId, region }) {
    * Update figure state
    */
   const serviceId = getServiceId(figure || figureSlide)
-  update(serviceId, { annotations, region: region || 'reset' })
+  update(serviceId, { annotations, region })
 
   /**
    * Build URL
@@ -216,13 +211,7 @@ const update = (id, data) => {
   }
   const { annotations, region } = data
   webComponents.forEach((element) => {
-    if (region === 'reset') {
-      element.clearTarget()
-    } else if (region) {
-      const [x, y, width, height] = region.split(',').map((i) => parseInt(i.trim()))
-      const options = { immediate: false }
-      element.goToTarget({ x, y, width, height }, options)
-    }
+    element.setAttribute('region', region || null)
     if (element.tagName === 'CANVAS-PANEL') {
       annotations.forEach((annotation) => selectAnnotation(element, annotation))
     }

--- a/packages/11ty/content/_data/figures.yaml
+++ b/packages/11ty/content/_data/figures.yaml
@@ -2,7 +2,6 @@ figure_list:
   - id: "fig-032"
     src: "figures/032/base.jpg"
     label: "Figure 32"
-    preset: zoom
     zoom: true
     caption: "X-radiograph showing a complex armature made of different sizes of rods and wire (11 mm, 7 mm, and 4 mm in diameter). See also the wax-to-wax joints. A 15 mm Cu filter was needed to keep the same exposure parameters for all the different areas of the sculpture, despite the significant variations in thickness (400kV, 8mA, 15 min. exposure, 3 m source-to-object distance, AA400PB film). Antoine-Louis Barye (French, 1795–1875), Theseus and the Centaur Bienor, cast by Eugène Gonon (1814–1892) in 1877, H. 1.3 m (Musée du Louvre, inv. RF 3882). For daylight photography of the statue see **fig. 395**. See {C2RMF Internal Report 2016b}."
     annotations:

--- a/packages/11ty/content/iiif-demo.md
+++ b/packages/11ty/content/iiif-demo.md
@@ -6,7 +6,7 @@ layout: essay
 
 ## Linking to Annotation States
 
-Use the `annoref` shortcode to create a link to a specific annotation state. For example, select an annotation such as {% annoref fig="fig-032" anno="wax-joints" text="Wax-to-wax Joints in Fig 32" %} or multiple annotations such as {% annoref fig="fig-032" anno="wax-joints,armature" text="Armature and Wax-to-wax Joints in Fig 32" %}. Annotations should be referenced by a comma-separated list of ids or filepaths. Linking to a region is supported on both {% annoref fig="fig-032" anno="wax-joints" region="200,200,200,200" text="canvas panels" %} and {% annoref fig="example-image-service-2" region="1000,1000,2000,2000" text="image services" %}.
+Use the `annoref` shortcode to create a link to a specific annotation state. For example, select an annotation such as {% annoref fig="fig-032" anno="wax-joints" text="Wax-to-wax Joints in Fig 32" %} or multiple annotations such as {% annoref fig="fig-032" anno="wax-joints,armature" text="Armature and Wax-to-wax Joints in Fig 32" %}. Annotations should be referenced by a comma-separated list of ids or filepaths. Linking to a region is supported on both {% annoref fig="fig-032" anno="wax-joints" region="200,200,200,200" text="canvas panels" %} and {% annoref fig="example-image-service-2" region="500,500,1000,1000" text="image services" %}.
 
 ## IIIF Web Components
 

--- a/packages/11ty/content/iiif-demo.md
+++ b/packages/11ty/content/iiif-demo.md
@@ -6,7 +6,7 @@ layout: essay
 
 ## Linking to Annotation States
 
-Use the `annoref` shortcode to create a link to a specific annotation state. For example, select an annotation such as {% annoref fig="fig-032" anno="wax-joints" text="Wax-to-wax Joints in Fig 32" %} or multiple annotations such as {% annoref fig="fig-032" anno="wax-joints,armature" text="Armature and Wax-to-wax Joints in Fig 32" %}. Annotations should be referenced by a comma-separated list of ids or filepaths. {% annoref fig="fig-032" anno="wax-joints" region="200,200,200,200" text="Linking to a region" %} is only supported on figures with `preset="zoom"`.
+Use the `annoref` shortcode to create a link to a specific annotation state. For example, select an annotation such as {% annoref fig="fig-032" anno="wax-joints" text="Wax-to-wax Joints in Fig 32" %} or multiple annotations such as {% annoref fig="fig-032" anno="wax-joints,armature" text="Armature and Wax-to-wax Joints in Fig 32" %}. Annotations should be referenced by a comma-separated list of ids or filepaths. Linking to a region is supported on both {% annoref fig="fig-032" anno="wax-joints" region="200,200,200,200" text="canvas panels" %} and {% annoref fig="example-image-service-2" region="1000,1000,2000,2000" text="image services" %}.
 
 ## IIIF Web Components
 


### PR DESCRIPTION
Linking to the region of a canvas panel or image service had a wonky user experience due to `zoom` being enabled

Changes:
- Moves `canvasHeight` and `canvasWidth` definition into `figure` model 
- Replaces `canvas.goToTarget` with `goToRegion` with a transition. Using this method allows us to use `preset=responsive` (no letterboxing, disabled user interaction with the figure) and modify the region programmatically.
- Adds a default region value of the full canvas dimensions to use to reset the viewport

Note:
- The `goToRegion` method isn't available on `image-service` components, so I refactored them as manifests with a single annotation (the image service). As a result, you can't use the annoref shortcode to link to a region of an externally hosted image service (hoping that would be an edge case).
- We also may need to add a button to reset the viewport

Still troubleshooting firefox bugs (properly scrolling to figure and region on load)