### PR TITLE
Fix `isEmpty` helper

### DIFF
--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -40,7 +40,7 @@ export default class CreateCommand extends Command {
     fs.ensureDirSync(projectRoot)
 
     // if the target directory exists it must be empty
-    if (isEmpty(path)) {
+    if (!isEmpty(path)) {
       console.error(`[CLI] ${path} is not empty`)
       return
     }

--- a/packages/cli/src/helpers/is-empty.js
+++ b/packages/cli/src/helpers/is-empty.js
@@ -8,12 +8,10 @@ import fs from 'node:fs'
  * @param  {String}  dirpath
  * @return  {Boolean}
  */
-export async function isEmpty (dirpath) {
+export function isEmpty (dirpath) {
   try {
-    const directory = await fs.opendir(dirpath)
-    const entry = directory.read()
-    await directory.close()
-    return entry === null
+    const files = fs.readdirSync(dirpath);
+    return !files.length
   } catch (error) {
     console.debug(error)
     return false

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -1,4 +1,4 @@
-import { execaCommand } from 'execa'
+import execa from 'execa'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import paths from './paths.js'
@@ -31,6 +31,6 @@ export default {
 
     const command = `npx @11ty/eleventy ${eleventyOptions.join(' ')}`
 
-    execaCommand(command).stdout.pipe(process.stdout)
+    execa(command).stdout.pipe(process.stdout)
   }
 }


### PR DESCRIPTION
- Fix usage of `execa` module
- Refactor `isEmpty` helper to use `fs.readdirSync`
- Check if target directory is NOT empty

This `isEmpty` helper did not seem to be working at all, `fs.opendir` does not return anything, neither does `fs.readdir` as those async commands expect you to do things with a callback argument.

Also the usage of `isEmpty()` in the draft `create` command seemed to be doing the opposite of what the comment intended (throwing an error when the project root dir was empty rather than NOT empty)

I am pretty sure the [Execa](https://github.com/sindresorhus/execa) usage documentation is slightly wrong (importing it as `execa` rather than destructuring `{ execa }` was the only thing that works). Not sure if `execaCommand` was in an earlier version of this module? But that is definitely not part of `execa`'s default export. It's supposed to be used it like this:

``` js
const { stdout } = await execa('echo', ['BLARG']);
console.log(stdout); // $ BLARG
```

Maybe it's different because our CLI module is `type: 'module'` in `package.json`? IDK
