### PR TITLE
Refactor menu item active class

### DIFF
--- a/packages/11ty/_includes/components/menu/index.js
+++ b/packages/11ty/_includes/components/menu/index.js
@@ -37,7 +37,7 @@ module.exports = function(eleventyConfig) {
         ${menuHeader({ currentURL: pageData.url })}
         <nav id="nav" class="quire-menu__list menu-list" role="navigation" aria-label="full">
           <h3 class="visually-hidden">Table of Contents</h3>
-          ${menuList({ navigation: eleventyNavigation(collections.menu) })}
+          ${menuList({ currentURL: pageData.url, navigation: eleventyNavigation(collections.menu) })}
         </nav>
 
         ${menuResources()}

--- a/packages/11ty/_includes/components/menu/item.js
+++ b/packages/11ty/_includes/components/menu/item.js
@@ -11,14 +11,18 @@ module.exports = function(eleventyConfig) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
 
   return function(params) {
-    const { data, url } = params
+    const { currentURL, page } = params
+    const { data, url } = page
     const { label, layout, title } = data
-    const item = pageTitle({ label, title })
+
+    const titleText = pageTitle({ label, title })
     /**
      * Check if item is a reference to a built page or just a heading
      * @type {Boolean}
      */
     const isPage = !!layout
-    return isPage ? `<a href="${url}">${item}</a>` : item
+    return isPage
+      ? `<a href="${url}" class="${currentURL === url ? 'active' : ''}">${titleText}</a>`
+      : titleText
   }
 }

--- a/packages/11ty/_includes/components/menu/list.js
+++ b/packages/11ty/_includes/components/menu/list.js
@@ -11,19 +11,19 @@ module.exports = function(eleventyConfig) {
   const { config } = eleventyConfig.globalData
 
   return function(params) {
-    const { navigation } = params
+    const { currentURL, navigation } = params
 
     const renderList = (items) => {
       return html`
         <ol>
-          ${items.map((item) => {
+          ${items.map((page) => {
             let listItem = ''
-            if (!item.children || item.children.length === 0) {
-              return `<li class="page-item">${menuItem(item)}</li>`
+            if (!page.children || page.children.length === 0) {
+              return `<li class="page-item">${menuItem({ currentURL, page })}</li>`
             } else {
-              listItem += `<li class="section-item">${menuItem(item)}`
+              listItem += `<li class="section-item">${menuItem({ currentURL, page })}`
               if (config.params.menuType !== 'brief') {
-                listItem += renderList(item.children)
+                listItem += renderList(page.children)
               }
               listItem += '</li>'
               return listItem

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -44,28 +44,6 @@ window["toggleMenu"] = () => {
 };
 
 /**
- * activeMenuPage
- * @description This function is called on pageSetup to go through the navigation
- * (#nav in partials/menu.html) and find all the anchor tags.  Then find the user's
- * current URL directory. Then it goes through the array of anchor tags and if the
- * current URL directory matches the nav anchor, it's the active link.
- */
-function activeMenuPage() {
-  let nav = document.getElementById("nav");
-  let anchor = nav.getElementsByTagName("a");
-  let current =
-    window.location.protocol +
-    "//" +
-    window.location.host +
-    window.location.pathname;
-  for (var i = 0; i < anchor.length; i++) {
-    if (anchor[i].href == current) {
-      anchor[i].className = "active";
-    }
-  }
-}
-
-/**
  * toggleSearch
  * @description Show/hide the search UI by changing CSS classes and Aria status.
  * This function is bound to the global window object so it can be called from
@@ -341,7 +319,6 @@ function toggleCite() {
  */
 function pageSetup() {
   setDate();
-  activeMenuPage();
   toggleCite();
 }
 


### PR DESCRIPTION
Was just going through application.js and figured setting the active class should probably be moved into the menu shortcode, I think this was just ported over from old Quire.