### PR TITLE
Fix build cli command

### DIFF
--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -211,18 +211,11 @@ module.exports = class Figure {
   /**
    * Create the IIIF `manifest.json` for <canvas-panel> components,
    * collect errors from calling toJSON and the file system writer.
-   *
-   * @todo the `figure` should not need to know to call `toJSON`,
-   * building the JSON is a concern of either the `manifest` or perhaps;
-   * refactor `createManifest` to only create the manifest instance
-   * and call its `write` method.
    */
   async createManifest() {
     if (!this.isCanvas) return
     const manifest = new Manifest(this)
-    await manifest.toJSON()
-      .then(({ errors }) => this.errors = this.errors.concat(errors))
-    await manifest.write()
-      .then(({ errors }) => this.errors = this.errors.concat(errors))
+    const { errors } = await manifest.write()
+    if (errors) this.errors = this.errors.concat(errors)
   }
 }

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -121,17 +121,17 @@ module.exports = class Manifest {
       })
     })
     try {
-      this.json = builder.toPresentation3(manifest)
-      logger.info(`Generated manifest for figure "${this.figure.id}"`)
-      return { success: true }
+      return builder.toPresentation3(manifest)
     } catch(error) {
-      return { errors: [`Failed to generate manifest: ${error}`]}
+      throw new Error(`Failed to generate manifest: ${error}`)
     }
   }
 
   async write() {
     try {
-      return await this.writer.write(this.json)
+      const json = await this.toJSON()
+      logger.info(`Generated manifest for figure "${this.figure.id}"`)
+      return await this.writer.write(json)
     } catch(error) {
       return { errors: [error] }
     }

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -80,12 +80,12 @@ module.exports = class Manifest {
    * @todo handle text annotations
    * @todo handle annotations with target region
    */
-  createAnnotationBody({ format, info, label, src, url }) {
+  createAnnotationBody({ format, info, label, src, uri }) {
     const { ext } = path.parse(src)
     return {
       format,
       height: this.figure.canvasHeight,
-      id: url,
+      id: uri,
       label: { en: [label] },
       type: 'Image',
       service: info && [

--- a/packages/11ty/_plugins/figures/iiif/manifest/writer.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/writer.js
@@ -15,7 +15,7 @@ module.exports = class ManifestWriter {
   write(manifest) {
     if (!manifest) return { errors: ['Error writing manifest. Manifest is undefined.'] }
     const uri = new URL(manifest.id)
-    const outputPath = path.join(this.outputRoot, uri.pathName())
+    const outputPath = path.join(this.outputRoot, uri.pathname)
     try {
       fs.ensureDirSync(path.parse(outputPath).dir)
       fs.writeJsonSync(outputPath, manifest)

--- a/packages/11ty/_plugins/figures/image/processor.js
+++ b/packages/11ty/_plugins/figures/image/processor.js
@@ -22,7 +22,7 @@ module.exports = class ImageProcessor {
 
     this.inputRoot = path.join(inputRoot, imagesDir)
     this.outputRoot = outputRoot
-    this.tiler = tiler.tile
+    this.tiler = tiler.tile.bind(tiler)
     this.transform = transformer.transform.bind(transformer)
 
     logger.debug(`


### PR DESCRIPTION
Fixes some minor naming/syntaxy things to get `build` command working, and refactors the `manifest.write` method to handle json-ifying the manifest per to-do in comment above `figure.createManifest`.