### PR TITLE
Fix image processor error handling

### DIFF
--- a/packages/11ty/_plugins/figures/image/processor.js
+++ b/packages/11ty/_plugins/figures/image/processor.js
@@ -53,17 +53,13 @@ module.exports = class ImageProcessor {
       /**
        * Transform Image
        */
-      const results = await Promise.all(
+      await Promise.all(
         options.transformations.map((transformation) => {
           return this.transform(inputPath, outputPath, transformation, options)
         })
-      )
-      const transformationErrors = results.flatMap(
-        ({ errors }) => errors || []
-      )
-      if (transformationErrors.length) {
-        errors.push(`Failed to transform source image ${imagePath} ${transformationErrors.join(' ')}`)
-      }
+      ).catch((error) => {
+        errors.push(`Failed to transform source image ${imagePath} ${error}`)
+      })
     }
 
     if (options.tile) {

--- a/packages/11ty/_plugins/figures/image/tiler.js
+++ b/packages/11ty/_plugins/figures/image/tiler.js
@@ -26,42 +26,36 @@ module.exports = class Tiler {
   /**
    * Tile an image for IIIF image service using sharp
    * @param  {String} inputPath   Path to the image file to tile
-   * @param  {Object}
+   * @param  {String} outputDir   Destination directory for the tiles
+   * @return {Promise}
    */
-  async tile(inputPath, outputDir) {
+  tile(inputPath, outputDir) {
     if (!inputPath) return
 
     const { ext, name } = path.parse(inputPath)
 
     if (!this.supportedExtensions.includes(ext)) {
-      return {
-        errors: [`Image file of type '${ext}' is not supported. Supported file types are: ${this.supportedExtensions.join(', ')}`]
-      }
+      throw new Error(`Image file of type '${ext}' is not supported. Supported file types are: ${this.supportedExtensions.join(', ')}`)
     }
 
     const outputPath = path.join(this.outputRoot, outputDir, name, this.tilesDir)
 
     if (fs.existsSync(path.join(outputPath, 'info.json'))) {
       logger.debug(`skipping previously tiled image '${inputPath}'`)
-      return { success: true }
+      return
     }
 
     fs.ensureDirSync(outputPath)
 
-    try {
-      logger.debug(`tiling '${inputPath}'`)
-      const format = this.formats.find(({ input }) => input.includes(ext))
-      const response = await sharp(inputPath)
-        .toFormat(format.output.replace('.', ''))
-        .tile({
-          id: new URL(path.join(outputDir, name), this.baseURI).toString(),
-          layout: 'iiif',
-          size: this.tileSize
-        })
-        .toFile(path.join(outputPath))
-      return { success: true }
-    } catch (error) {
-      return { errors: [error] }
-    }
+    logger.debug(`tiling '${inputPath}'`)
+    const format = this.formats.find(({ input }) => input.includes(ext))
+    return sharp(inputPath)
+      .toFormat(format.output.replace('.', ''))
+      .tile({
+        id: new URL(path.join(outputDir, name), this.baseURI).toString(),
+        layout: 'iiif',
+        size: this.tileSize
+      })
+      .toFile(path.join(outputPath))
   }
 }

--- a/packages/11ty/_plugins/figures/image/transformer.js
+++ b/packages/11ty/_plugins/figures/image/transformer.js
@@ -23,6 +23,7 @@ module.exports = class Transformer {
    * @property  {Object} transformation A transformation item from `iiif/config.js#transformations`
    * @param  {Object} options
    * @property  {Object} resize Resize options for `sharp`
+   * @return {Promise}
    */
   async transform(inputPath, outputDir, transformation, options = {}) {
     if (!inputPath) return {}
@@ -36,30 +37,25 @@ module.exports = class Transformer {
     fs.ensureDirSync(path.parse(outputPath).dir)
 
     if (fs.pathExistsSync(outputPath)) {
-      return {
-        messages: ['Image has already been transformed. Skipping.']
-      }
+      logger.debug(`skipping previously transformed image '${inputPath}'`)
+      return
     }
 
-    try {
-      /**
-       * Declare a `sharp` service with a `crop` method that is callable
-       * without a `region`, which the sharp API `extract` method does not allow
-       */
-      const service = sharp(inputPath)
-      service.crop = function (region) {
-        if (!region) return this
-        const [ top, left, width, height ] = region.split(',').map((item) => parseFloat(item.trim()))
-        service.extract({ top, left, width, height })
-        return this
-      }
-      return await service
-        .crop(region)
-        .resize(resize)
-        .withMetadata()
-        .toFile(outputPath)
-    } catch (error) {
-      return { errors: [error] }
+    /**
+     * Declare a `sharp` service with a `crop` method that is callable
+     * without a `region`, which the sharp API `extract` method does not allow
+     */
+    const service = sharp(inputPath)
+    service.crop = function (region) {
+      if (!region) return this
+      const [ top, left, width, height ] = region.split(',').map((item) => parseFloat(item.trim()))
+      service.extract({ top, left, width, height })
+      return this
     }
+    return service
+      .crop(region)
+      .resize(resize)
+      .withMetadata()
+      .toFile(outputPath)
   }
 }


### PR DESCRIPTION
Think I finally got a handle on how to handle processing errors. 

Refactors image processes (tile, transform) to return promises. Catch, collect, and return errors from image processor.