### PR TITLE
Refactor method to clean build outputs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
   },
   "imports": {
     "#src/*.js": "./src/*.js",
+    "#helpers/*.js": "./src/helpers/*.js",
     "#lib/*.js": "./src/lib/*.js"
   },
   "dependencies": {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,6 +1,8 @@
 import Command from '#src/Command.js'
+import { clean } from '#helpers/clean.js'
 import cli from '#lib/11ty/cli.js'
 import eleventy from '#lib/11ty/eleventy.js'
+import paths, { eleventyRoot as projectRoot } from '#lib/11ty/paths.js'
 
 /**
  * Quire CLI `build` Command
@@ -53,5 +55,13 @@ export default class BuildCommand extends Command {
       console.debug('[CLI] running eleventy using lib/11ty api')
       eleventy.build(options)
     }
+  }
+
+  preAction(command) {
+    const options = command.opts()
+    if (options.debug) {
+      console.debug('[CLI] Calling \'build\' command preAction with options', options)
+    }
+    clean(projectRoot, paths, options)
   }
 }

--- a/packages/cli/src/commands/clean.js
+++ b/packages/cli/src/commands/clean.js
@@ -1,7 +1,6 @@
 import Command from '#src/Command.js'
-import { deleteAsync } from 'del'
-import path from 'node:path'
-import paths from '#lib/11ty/paths.js'
+import { clean } from '#helpers/clean.js'
+import paths, { eleventyRoot as projectRoot } from '#lib/11ty/paths.js'
 
 /**
  * Quire CLI `clean` Command
@@ -43,34 +42,10 @@ export default class CleanCommand extends Command {
 
   async action(options, command) {
     if (options.debug) {
-      console.debug('[CLI] Command \'%s\' called with options %o', this.name, options)
+      console.debug('[CLI] Command \'%s\' called with options %o', this.name(), options)
     }
 
-    const projectRoot = path.resolve(paths.config, '../')
-
-    const pathsToClean = [
-      path.join(projectRoot, paths.output),
-      path.join(projectRoot, 'public'),
-    ]
-
-    /**
-     * Log progess of deleted paths
-     * @see https://github.com/sindresorhus/del#onprogress
-     *
-     * @param  {ProgessData}  progress
-     * @see https://github.com/sindresorhus/del#progressdata
-     */
-    const progressLogger = (progress) => {
-      console.info('progress', progress)
-    }
-
-    process.cwd(projectRoot)
-
-    const deletedPaths = await deleteAsync(pathsToClean, {
-      dryRun: options.dryRun,
-      force: true,
-      onProgress: (options.progress || options.verbose) && progressLogger,
-    })
+    const deletedPaths = clean(projectRoot, paths, options)
 
     const message = deletedPaths && deletedPaths.length
       ? `the following files ${options.dryRun ? 'will be' : 'have been'} deleted:`

--- a/packages/cli/src/helpers/clean.js
+++ b/packages/cli/src/helpers/clean.js
@@ -1,0 +1,34 @@
+import { deleteAsync } from 'del'
+import path from 'node:path'
+
+/**
+ * Clean project paths
+ *
+ * @param  {String}  projectRoot
+ * @param  {Array<String>}  paths to
+ */
+export async function clean (projectRoot, paths, options = {}) {
+  const pathsToClean = [
+    path.join(projectRoot, paths.output),
+    path.join(projectRoot, paths.public),
+  ]
+
+  /**
+   * Log progess of deleted paths
+   * @see https://github.com/sindresorhus/del#onprogress
+   *
+   * @param  {ProgessData}  progress
+   * @see https://github.com/sindresorhus/del#progressdata
+   */
+  const progressLogger = (progress) => {
+    console.info('progress', progress)
+  }
+
+  process.cwd(projectRoot)
+
+  const deletedPaths = await deleteAsync(pathsToClean, {
+    dryRun: options.dryRun,
+    force: true,
+    onProgress: (options.progress || options.verbose) && progressLogger,
+  })
+}

--- a/packages/cli/src/lib/11ty/paths.js
+++ b/packages/cli/src/lib/11ty/paths.js
@@ -16,10 +16,11 @@ const __dirname = path.dirname(__filename)
  * to the correct version of the quire/11ty package, for example:
  *   eleventyRoot = `#lib/quire/versions/${config.version}/11ty`
  */
-const eleventyRoot = '../../packages/11ty'
+export const eleventyRoot = '../../packages/11ty'
 
 export default {
   config: path.resolve(eleventyRoot, '.eleventy.js'),
   input: './content',
-  output: './_site'
+  output: './_site',
+  public: './public',
 }

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -55,7 +55,7 @@ commands.forEach((command) => {
         if (option[0].startsWith('-') && !option[1].startsWith('--')) {
           option.splice(1, 0, '')
         }
-        // assign an attribute name to the array of option attributes
+        // assign attribute names to the array of option attributes
         const [ short, long, description, defaultValue ] = option
         // join short and long flags as the option name attribute
         const name = /^-\w/.test(short) && /^--\w/.test(long)
@@ -72,6 +72,24 @@ commands.forEach((command) => {
         // subCommand.addOption(option)
         console.error('@TODO please use an array to define option attributes')
       }
+    })
+  }
+
+  if (command.postAction) {
+    subCommand.hook('postAction', (thisCommand, actionCommand) => {
+      command.postAction.call(command, thisCommand, actionCommand)
+    })
+  }
+
+  if (command.preAction) {
+    subCommand.hook('preAction', (thisCommand, actionCommand) => {
+      command.preAction.call(command, thisCommand, actionCommand)
+    })
+  }
+
+  if (command.preSubcommand) {
+    subCommand.hook('preSubcommand', (thisCommand, theSubcommand) => {
+      command.preSubcommand.call(command, thisCommand, theSubcommand)
     })
   }
 


### PR DESCRIPTION
Implements a helper module to clean build outputs, which can be called
by the build command lifecycle hooks and a separate cli clean command.

Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [ ] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [ ] I have made my changes in a new branch and not directly in the main branch

- [ ] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?



### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.


### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

