### PR TITLE
Refactor: publication contributors

### DIFF
--- a/packages/11ty/_includes/components/contributor/bio.js
+++ b/packages/11ty/_includes/components/contributor/bio.js
@@ -19,9 +19,18 @@ module.exports = function (eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const slugify = eleventyConfig.getFilter('slugify')
+  const { config } = eleventyConfig.globalData
 
+  /**
+   * @param  {Object} params
+   * @property {String} bio Contributor bio
+   * @property {String} id Contributor Id
+   * @property {String} image Path to contributor image (relative to images directory)
+   * @property {Array<Object>} pages Array of page objects with `title`, `subtitle`, `label` and `url` properties
+   * @property {String} URL Contributor URL
+   */
   return function (params) {
-    const { bio, id, imagePath, pages=[], url } = params
+    const { bio, id, image, pages=[], url } = params
 
     const name = fullname(params)
 
@@ -29,10 +38,10 @@ module.exports = function (eleventyConfig) {
       ? link({ classes: ["quire-contributor__url"], name: icon({ type: 'link', description:'' }), url })
       : ''
 
-    const contributorImage = imagePath
+    const contributorImage = image
       ? html`
           <div class="media-left">
-            <img class="image quire-contributor__pic" src="${imagePath}" alt="Picture of ${name}">
+            <img class="image quire-contributor__pic" src="${path.join(config.params.imageDir, image)}" alt="Picture of ${name}">
           </div>
       `
       : ''
@@ -46,8 +55,7 @@ module.exports = function (eleventyConfig) {
       : ''
 
     const contributorPagesList = () => {
-      const items = pages.map(({ data, url }) => {
-        const { label, subtitle, title } = data
+      const items = pages.map(({ label, subtitle, title, url }) => {
         const classes = ['quire-contributor__page-link']
         const name = pageTitle({ label, subtitle, title })
         return `<li>${link({ classes, name, url })}</li>`


### PR DESCRIPTION
Changes:
- Renames `contributor.pic` to `contributor.image`
- Refactors `eleventyComputed.publicationContributors` to include contributors defined on pages
- Simplifies `contributor.pages[]` to only include the page data necessary to render the `contributor` shortcode