### PR TITLE
Replace config.baseURL with publication.url

### DIFF
--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -42,7 +42,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: pageTitle(page.data),
       type: 'chapter',
-      url: new URL(page.url, url)
+      URL: new URL(page.url, url)
     }
   }
 }

--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -42,7 +42,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: pageTitle(page.data),
       type: 'chapter',
-      URL: new URL(page.url, url)
+      URL: new URL(page.url, url).toString()
     }
   }
 }

--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -11,12 +11,11 @@ module.exports = function (eleventyConfig) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const siteTitle = eleventyConfig.getFilter('siteTitle')
 
-  const { baseURL } = eleventyConfig.globalData.config
-
   const {
     contributor: publicationContributors,
     pub_date: pubDate,
     publisher: publishers,
+    url
   } = eleventyConfig.globalData.publication
 
   return function (params) {
@@ -43,7 +42,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: pageTitle(page.data),
       type: 'chapter',
-      URL: new URL(page.url, baseURL)
+      url: new URL(page.url, url)
     }
   }
 }

--- a/packages/11ty/_includes/components/citation/publication.js
+++ b/packages/11ty/_includes/components/citation/publication.js
@@ -16,7 +16,7 @@ module.exports = function (eleventyConfig) {
     pub_type: pubType
   } = eleventyConfig.globalData.publication
 
-  const { baseURL } = eleventyConfig.globalData.config
+  const { url } = eleventyConfig.globalData.publication
 
   return function (params) {
     let { context } = params
@@ -37,7 +37,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: `<em>${siteTitle()}</em>`,
       type: pubType === 'journal-periodical' ? 'article-journal' : 'book',
-      URL: baseURL
+      url
     }
   }
 }

--- a/packages/11ty/_includes/components/citation/publication.js
+++ b/packages/11ty/_includes/components/citation/publication.js
@@ -37,7 +37,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: `<em>${siteTitle()}</em>`,
       type: pubType === 'journal-periodical' ? 'article-journal' : 'book',
-      url
+      URL: url
     }
   }
 }

--- a/packages/11ty/_includes/components/head-tags/dublin-core.js
+++ b/packages/11ty/_includes/components/head-tags/dublin-core.js
@@ -9,7 +9,7 @@ const path = require('path')
  * @return     {String}  HTML meta and link elements
  */
 module.exports = function(eleventyConfig) {
-  const { config, publication } = eleventyConfig.globalData
+  const { publication } = eleventyConfig.globalData
 
   return function (params) {
     const links = [
@@ -19,7 +19,7 @@ module.exports = function(eleventyConfig) {
     const meta = [
       {
         name: 'dcterms.title',
-        content: config.title },
+        content: publication.title },
       {
         name: 'dcterms.date',
         content: publication.pub_date

--- a/packages/11ty/_includes/components/head-tags/jsonld.js
+++ b/packages/11ty/_includes/components/head-tags/jsonld.js
@@ -43,14 +43,14 @@ module.exports = function(eleventyConfig) {
 
     const Book = {
       type: 'Book',
-      name: config.title,
+      name: publication.title,
       description: publicationDescription.replace(/\n/g,' '),
       isbn: isbn && isbn.replace(/-/g, '')
     }
 
     const Periodical = {
       type: 'PublicationIssue',
-      name:  config.title,
+      name:  publication.title,
       description: publicationDescription.replace(/\n/g,' '),
       issueNumber: publication.series_issue_number,
       isPartOf: {
@@ -63,7 +63,7 @@ module.exports = function(eleventyConfig) {
     // publication.pub_type === null
     const WebSite = {
       type: 'WebSite',
-      name: config.title,
+      name: publication.title,
     }
 
     const partOf = (type) => {
@@ -121,7 +121,7 @@ module.exports = function(eleventyConfig) {
           .map((name) => name)
           .toString(),
         publisher: [publisher],
-        url: config.baseURL
+        url: publication.url
       },
       url: canonicalURL
     }

--- a/packages/11ty/_includes/components/head-tags/opengraph.js
+++ b/packages/11ty/_includes/components/head-tags/opengraph.js
@@ -10,17 +10,17 @@ module.exports = function(eleventyConfig) {
   const { config, publication } = eleventyConfig.globalData
 
   return function ({ page }) {
-    const { description, identifier, promo_image, pub_date, pub_type } = publication
+    const { description, identifier, promo_image, pub_date, pub_type, url } = publication
     const pageType = page && page.type
 
     const meta = [
       {
         property: 'og:title',
-        content: pageType != 'essay' ? config.title : page.title
+        content: pageType != 'essay' ? publication.title : page.title
       },
       {
         property: 'og:url',
-        content: pageType != 'essay' ? config.baseURL : permalink
+        content: new URL(page.url, url)
       },
       {
         property: 'og:image',
@@ -44,7 +44,7 @@ module.exports = function(eleventyConfig) {
       meta.push({ property: 'og:book:release_date', content: pub_date })
     } else {
       meta.push({ property: 'og:type', content: 'article' })
-      meta.push({ property: 'og:site_name', content: config.title })
+      meta.push({ property: 'og:site_name', content: publication.title })
       meta.push({ property: 'og:article:published_time', content: pub_date })
     }
 

--- a/packages/11ty/_includes/components/head-tags/opengraph.js
+++ b/packages/11ty/_includes/components/head-tags/opengraph.js
@@ -20,7 +20,7 @@ module.exports = function(eleventyConfig) {
       },
       {
         property: 'og:url',
-        content: new URL(page.url, url)
+        content: new URL(page.url, url).toString()
       },
       {
         property: 'og:image',

--- a/packages/11ty/_includes/components/head-tags/twitter-card.js
+++ b/packages/11ty/_includes/components/head-tags/twitter-card.js
@@ -15,7 +15,7 @@ module.exports = function(eleventyConfig) {
 
   return function({ abstract, cover, layout }) {
     const imagePath = () => {
-      if (!config.baseURL) return
+      if (!publication.url) return
       if (layout !== 'essay' ) {
         return promo_image && path.join(imageDir, promo_image)
       } else {
@@ -31,11 +31,11 @@ module.exports = function(eleventyConfig) {
       },
       {
         name: 'twitter:site',
-        content: layout !== 'essay' ? config.baseURL : null
+        content: layout !== 'essay' ? publication.url : null
       },
       {
         name: 'twitter:title',
-        content: layout !== 'essay' ? config.title : null
+        content: publication.title
       },
       {
         name: 'twitter:description',

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -1,14 +1,14 @@
 const path = require('path')
 
 module.exports = (eleventyConfig) => {
-  const { baseURL } = eleventyConfig.globalData.config
+  const { url } = eleventyConfig.globalData.publication
   const { port } = eleventyConfig.serverOptions
   const { viteOptions } = eleventyConfig.plugins.find(
     ({ options }) => !!options && !!options.viteOptions
   ).options
 
   return {
-    baseURL: process.env.ELEVENTY_ENV === 'production' ? baseURL : `http://localhost:${port}`,
+    baseURL: process.env.ELEVENTY_ENV === 'production' ? url : `http://localhost:${port}`,
     dirs: {
       /**
        * The name of the directory for image tiles and info.json

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -21,10 +21,10 @@ module.exports = (eleventyConfig) => {
     publishers,
     readingLine,
     subtitle,
-    title,
-    url
+    title
   } = eleventyConfig.globalData.publication
-  const { baseURL, epub, params } = eleventyConfig.globalData.config
+  const { epub, params } = eleventyConfig.globalData.config
+  const { url } = eleventyConfig.globalData.publication
 
   /**
    * Contributor name, filtered by type

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -7,7 +7,7 @@ const { warn } = chalkFactory('eleventyComputed')
  * Global computed data
  */
 module.exports = {
-  canonicalURL: ({ config, page }) => page.url && path.join(config.baseURL, page.url),
+  canonicalURL: ({ publication, page }) => page.url && path.join(publication.url, page.url),
   eleventyNavigation: {
     /**
      * Explicitly define page data properties used in the TOC

--- a/packages/11ty/content/_data/config.yaml
+++ b/packages/11ty/content/_data/config.yaml
@@ -1,6 +1,3 @@
-baseURL: 'http://localhost:8080'
-
-title: Quire Starter
 languageCode: en-us
 theme: default
 publishDir: site

--- a/packages/11ty/content/_data/publication.yaml
+++ b/packages/11ty/content/_data/publication.yaml
@@ -8,6 +8,10 @@
 # publication.
 
 # ------------------------------------------------------------------------------
+# The publication's base URL, i.e. 'https://www.my-publication.org'
+url: 'http://localhost:8080'
+
+# ------------------------------------------------------------------------------
 # Title & Description
 title: New Deal Photography
 subtitle: The Works of Dorothea Lange and Walker Evans
@@ -30,7 +34,6 @@ pub_type: book # book | journal-periodical | other
 
 identifier:
   isbn:
-  url:
 
 publisher:
   - name: J. Paul Getty Trust


### PR DESCRIPTION
Separates concerns of publication data and configuration data:

Changes:
Removes `config.baseURL` and `publication.identifier.url` in favor of `publication.url`. 
Removes `config.title` in favor of `publication.title`. Not sure why these both existed, `config.title` was only being used (and incorrectly) in meta tags. 