### PR TITLE
Quire CLI version command

### DIFF
--- a/packages/cli/src/commands/README.md
+++ b/packages/cli/src/commands/README.md
@@ -176,6 +176,8 @@ quire version 1.0.0 --global
 
 #### `info`
 
+Display the local and global `quire-11ty` version; this is the *default* subcommand (running `quire version` invokes the `info` subcommand).
+
 ```sh
 quire version info
 ```

--- a/packages/cli/src/commands/README.md
+++ b/packages/cli/src/commands/README.md
@@ -159,3 +159,53 @@ Start a local web server to serve a previously built Quire site.
 ```sh
 quire server --port 8080
 ```
+
+### `version`
+
+Sets the Quire version to use when running commands on the project.
+
+```sh
+quire version 1.0.0
+```
+
+To set the quire version globally use the `--global` command flag.
+
+```sh
+quire version 1.0.0 --global
+```
+
+#### `info`
+
+```sh
+quire version info
+```
+
+#### `install`
+
+```sh
+quire version install <version>
+```
+
+To reinstall a `quire-11ty` version run
+
+```sh
+quire version install <version> --force
+```
+
+#### `list`
+
+List installed versions of `quire-11ty`
+
+```sh
+quire version list
+```
+
+#### `remove` (alias `uninstall`)
+
+```sh
+quire version remove <version>
+```
+
+```sh
+quire version uninstall <version>
+```

--- a/packages/cli/src/commands/version.js
+++ b/packages/cli/src/commands/version.js
@@ -4,9 +4,9 @@ import * as quire from '#lib/quire/index.js'
 /**
  * Quire CLI `version` Command
  *
- * Running `quire version` start a new project at the specified local path;
- * when the local path does not exist it is created,
- * when `path` exists but is not an empty directory an error is thrown.
+ * Running `quire version` sets the `quire-11ty` version for a project.
+ * The version is written to a `.quire` file in the project directory
+ * or to the `quire-cli` package `.quire` when the `global` flag is used.
  *
  * @class      VersionCommand
  * @extends    {Command}

--- a/packages/cli/src/commands/version.js
+++ b/packages/cli/src/commands/version.js
@@ -1,0 +1,37 @@
+import Command from '#src/Command.js'
+import * as quire from '#lib/quire/index.js'
+
+/**
+ * Quire CLI `version` Command
+ *
+ * Running `quire version` start a new project at the specified local path;
+ * when the local path does not exist it is created,
+ * when `path` exists but is not an empty directory an error is thrown.
+ *
+ * @class      VersionCommand
+ * @extends    {Command}
+ */
+export default class VersionCommand extends Command {
+  static definition = {
+    name: 'version',
+    description: 'Sets the Quire version to use when running commands on the project.',
+    summary: 'set the @thegetty/quire-11ty version',
+    version: '1.0.0',
+    args: [
+      [ '<version>', 'the local quire version to use' ],
+    ],
+    options: [
+      [ '-g', '--global', 'set the quire version globally' ],
+    ],
+  }
+
+  constructor() {
+    super(VersionCommand.definition)
+  }
+
+  async action(path, starter, options = {}) {
+    if (options.debug) {
+      console.info('Command \'%s\' called with options %o', this.name, options)
+    }
+  }
+}

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -6,6 +6,7 @@ import path from 'node:path'
 import semver from 'semver'
 
 const INSTALL_PATH = path.join('./', 'versions')
+const VERSION_FILE = '.quire'
 
 /**
  * Return full path to the required `quire-11ty` version

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -1,1 +1,149 @@
+import { cwd } from 'node:process'
+import fs from 'fs-extra'
+import hostedGitInfo from 'hosted-git-info'
+import installNpmVersion from 'install-npm-version'
+import path from 'node:path'
 import semver from 'semver'
+
+const INSTALL_PATH = path.join('./', 'versions')
+
+/**
+ * Return full path to the required `quire-11ty` version
+ *
+ * @return  {String}  version  Quire-11ty semantic version
+ */
+function getPath(version='latest') {
+  // console.debug(`${projectName} set to use quire-11ty@${version}`)
+  // return versionPath
+}
+
+/**
+ * Read the required `quire-11ty` version for the project `.quire` file
+ *
+ * @return  {String}  version  Quire-11ty semantic version
+ */
+function getVersion() {
+  // console.debug(`${projectName} set to use quire-11ty@${version}`)
+  // return version
+}
+
+/**
+ * Install a specific version of `quire-11ty`
+ *
+ * If a `version` argument is not given `latest` is assumed.
+ *
+ * @param  {String}  version  Quire-11ty semantic version
+ * @return  {Promise}
+ */
+async function install(version='latest') {
+  fs.ensureDirSync(INSTALL_PATH)
+
+  await installNpmVersion.Install(
+    `${quirePackageName}@${quireVersion}`,
+    {
+      Destination: `${INSTALL_PATH}/${version}`,
+      Debug: true
+    }
+  )
+
+  fs.symlink(`${INSTALL_PATH}/latest`, latest, 'dir', (error) => {
+    console.error(error)
+  })
+}
+
+/**
+ * Retrieves version from quire repository `packages/11ty/package.json`
+ *
+ * Note: This does not currently work, as quire-11ty work is not on the main
+ * branch yet, and `hosted-git-info` does not provide a mechanism for
+ * retrieving file URLs on specific code branches. But it will!
+ *
+ * @TODO Once 11ty work is merged into main, this static method should replace
+ * the `quireVersion` import, and should be refactored to use npm instead of
+ *  hosted-git-info
+ *
+ * @return {String} the current version of thegetty/quire/packages/11ty
+ */
+async function latest() {
+  const latestQuirePackageJsonUrl = hostedGitInfo
+    .fromUrl('git@github.com:thegetty/quire.git')
+    .file('packages/11ty/package.json')
+  const latestQuirePackageJsonRequest = await fetch(latestQuirePackageJsonUrl)
+  const latestQuirePackageJson = await latestQuirePackageJsonRequest.json()
+  const { version } = latestQuirePackageJson
+  return version
+}
+
+/**
+ * List installed versions of the `quire-11ty` package
+ */
+function list() {
+  return fs.readDirSync(INSTALL_PATH)
+}
+
+/**
+ * Removes the specified version.
+ *
+ * @param  {String}  version  Quire-11ty semantic version
+ * @return  {Promise}
+ */
+async function remove(version) {
+  if (!version) {
+    console.error('No version specified.')
+  }
+  const dir = `${INSTALL_PATH}/${version}`
+  fs.rmdir(dir, { recursive: true }, (error) => {
+    if (error) {
+      throw error
+    }
+    console.info(`deleted ${dir}`)
+  })
+  // update symlink to `latest` version
+}
+
+/**
+ * Sets the quire-11ty version for a project
+ *
+ * @param  {String}  version  Quire-11ty semantic version
+ */
+function setVersion(version) {
+  if (!version) {
+    console.error('No version specified')
+    // return version from config
+    // version =
+  }
+  console.info(`${projectName} set to use quire-11ty@${version}`)
+}
+
+/**
+ * Tests if a `quire-11ty` version is already installed
+ * and installs the version if it is not already installed.
+ *
+ * @param  {String}  version  Quire-11ty semantic version
+ */
+function testVersion(version) {
+  version ||= getVersion()
+  if (!versions.includes(version)) {
+    install(version)
+  }
+}
+
+/**
+ * List known versions of the `quire-11ty` package
+ * @todo use npm for this
+ */
+function versions() {
+  console.info(`Known versions of @thegetty/quire-11ty...`)
+}
+
+export const quire = {
+  getPath,
+  getVersion,
+  install,
+  latest,
+  list,
+  remove,
+  setVersion,
+  testVersion,
+  versions,
+}


### PR DESCRIPTION
Implementation of a `quire version` command to set the current version of `quire-11ty` to use for a project.

*Work-in-progress*

The `version` command sets the local version of `quire-11ty` for a project by calling the `lib/quire` module, which determines if the requested version is valid, is installed (if no, the version is installed), writes the version to a `<projectRoot>/.quire` file, and returns an instance of `Quire` object.

`lib/quire` implements and instance of a `Quire` object with properties: 

`version` - the `quire-11ty` semantic version string

`versionPath` - the full path to the installed `quire-11ty` version (example: `/Users/mph/.node_modules/@thegetty/quire/lib/quire/versions/1.0.0/`)


