### PR TITLE
Implement `lib/quire` `getVersion()` function

### DIFF
--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -37,7 +37,7 @@ function getPath(version='latest') {
  */
 function getVersion(projectPath) {
   projectPath = projectPath || path.resolve(cwd())
-  const version = fs.readFileSync(path.join(projectPath, '.quire'), { encoding:'utf8' })
+  const version = fs.readFileSync(path.join(projectPath, VERSION_FILE), { encoding:'utf8' })
   const projectName = path.basename(projectPath)
   console.debug(`${projectName} set to use quire-11ty@${version}`)
   return version

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -36,7 +36,7 @@ function getPath(version='latest') {
  * @return  {String}  version  Quire-11ty semantic version
  */
 function getVersion(projectPath) {
-  projectPath = projectPath || path.resolve('.')
+  projectPath = projectPath || path.resolve(cwd())
   const version = fs.readFileSync(path.join(projectPath, '.quire'), { encoding:'utf8' })
   const projectName = path.basename(projectPath)
   console.debug(`${projectName} set to use quire-11ty@${version}`)

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -33,9 +33,12 @@ function getPath(version='latest') {
  *
  * @return  {String}  version  Quire-11ty semantic version
  */
-function getVersion() {
-  // console.debug(`${projectName} set to use quire-11ty@${version}`)
-  // return version
+function getVersion(projectPath) {
+  projectPath = projectPath || '.'
+  const version = fs.readFileSync(path.join(projectPath, '.quire'), { encoding:'utf8' })
+  const projectName = path.basename((path.resolve(projectPath)))
+  console.debug(`${projectName} set to use quire-11ty@${version}`)
+  return version
 }
 
 /**

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -31,12 +31,14 @@ function getPath(version='latest') {
 /**
  * Read the required `quire-11ty` version for the project `.quire` file
  *
+ * @param    {String}   projectPath  Absolute system path to the project root
+ *
  * @return  {String}  version  Quire-11ty semantic version
  */
 function getVersion(projectPath) {
-  projectPath = projectPath || '.'
+  projectPath = projectPath || path.resolve('.')
   const version = fs.readFileSync(path.join(projectPath, '.quire'), { encoding:'utf8' })
-  const projectName = path.basename((path.resolve(projectPath)))
+  const projectName = path.basename(projectPath)
   console.debug(`${projectName} set to use quire-11ty@${version}`)
   return version
 }


### PR DESCRIPTION
Implements the `getVersion()` function in `packages/cli/src/lib/quire/index.js` which returns the version string listed in a starter project `.quire` file (the `VERSION_FILE`). `getVersion()` accepts an optional single argument `projectPath`, an absolute path to a project. If no `projectPath` is specified, `getVersion()` uses the current working directory as the location for `.quire`.