### PR TITLE
Fix pathing issues in `quire new` command and `lib/quire` functions

### DIFF
--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -51,9 +51,9 @@ export default class CreateCommand extends Command {
       // const starter = starters['default']
       // `git clone starter path`
     } else {
+      await quire.initStarter(starter, projectPath)
       const version = await quire.latest()
       await quire.install(version)
-      await quire.initStarter(starter, projectPath)
     }
   }
 }

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -51,8 +51,7 @@ export default class CreateCommand extends Command {
       // const starter = starters['default']
       // `git clone starter path`
     } else {
-      await quire.initStarter(starter, projectPath)
-      const version = await quire.latest()
+      const version = await quire.initStarter(starter, projectPath)
       await quire.install(version)
     }
   }

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -95,18 +95,6 @@ async function initStarter (starter, projectPath) {
   const versionFilePath = path.join(projectPath, VERSION_FILE)
   fs.writeFileSync(versionFilePath, quireVersion)
 
-  // @TODO Remove 11ty file copying code (lines 79-88) once CLI pathing issues have been sorted out
-  // Copy 11ty files
-  // const fullProjectPath = path.resolve(projectPath)
-  // const eleventyPath = path.resolve(path.join(INSTALL_PATH, quireVersion))
-  // const eleventyFiles = fs.readdirSync(eleventyPath)
-
-  // copies all files in `quire/packages/11ty`
-  // eleventyFiles.forEach((filePath) => {
-  //   const fileToCopy = path.resolve(eleventyPath, filePath)
-  //   fs.copySync(fileToCopy, path.join(fullProjectPath, path.basename(filePath)))
-  // })
-
   // Reinitialize project as a new git repository
   await fs.remove(path.join(projectPath, '.git'))
 

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -142,9 +142,9 @@ async function install(version='latest', options={}) {
 
   console.debug('[CLI:quire] installing dev dependencies')
   /**
-   * Install dev dependencies manually, as they are necessary to run 11ty.
-   * They should be kept as dev dependencies so that they don't get bundled into
-   * the final compiled `_site` package when running `quire build`
+   * Manually install necessary dev dependencies to run 11ty;
+   * these must be `devDependencies` so that they are not bundled into
+   * the final `_site` package when running `quire build`
    */
   const currentWorkingDirectory = cwd()
   const versionDir = path.join(absoluteInstallPath, version)

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -220,13 +220,14 @@ async function remove(version) {
  *
  * @param  {String}  version  Quire-11ty semantic version
  */
-function setVersion(version) {
+function setVersion(projectPath, version) {
   if (!version) {
-    console.error('No version specified')
-    // return version from config
-    // version =
+    console.error('[CLI] no version specified')
   }
+  const projectName = path.basename(projectPath)
   console.info(`${projectName} set to use quire-11ty@${version}`)
+  const versionFilePath = path.join(projectPath, VERSION_FILE)
+  fs.writeFileSync(versionFilePath, version)
 }
 
 /**

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -112,7 +112,7 @@ async function initStarter (starter, projectPath) {
    * writes the quire-11ty semantic version to a `.quire` file
    */
   const quireVersion =
-    getVersionFromStarterPeerDependencies(projectPath) ||
+    getVersionFromStarter(projectPath) ||
     await latest()
   setVersion(projectPath, quireVersion)
 

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -62,7 +62,7 @@ function getVersion(projectPath) {
  * (i.e `^1.0.0-pre-release.0` => `1.0.0-pre-release.2`) so this string-trimming
  * logic can be removed
  */
-function getVersionFromStarterPeerDependencies(projectPath) {
+function getVersionFromStarter(projectPath) {
   const packageConfig = fs.readFileSync(path.join(projectPath, 'package.json'), { encoding:'utf8' })
   const { peerDependencies } = JSON.parse(packageConfig)
   const version = peerDependencies[PACKAGE_NAME]

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -175,12 +175,8 @@ async function install(version, options={}) {
   const currentWorkingDirectory = cwd()
   const versionDir = path.join(absoluteInstallPath, version)
   chdir(versionDir)
-  await execaCommand(
-    'npm cache clean --force'
-  ).stdout.pipe(process.stdout)
-  await execaCommand(
-    'npm install --save-dev'
-  ).stdout.pipe(process.stdout)
+  await execaCommand('npm cache clean --force')
+  await execaCommand('npm install --save-dev')
 }
 
 /**

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -50,6 +50,26 @@ function getVersion(projectPath) {
 }
 
 /**
+ * Read the required `quire-11ty` version from starter `package.json` `peerDependencies`
+ *
+ * @param    {String}   projectPath  Absolute system path to the project root
+ *
+ * @return  {String}  version  Quire-11ty semantic version with caret or other
+ * comparators trimmed off the beginning
+ *
+ * @TODO refactor `latest()` function to programmatically return a specific
+ * version of `@thegetty/quire-11ty` from a semantic version string
+ * (i.e `^1.0.0-pre-release.0` => `1.0.0-pre-release.2`) so this string-trimming
+ * logic can be removed
+ */
+function getVersionFromStarterPeerDependencies(projectPath) {
+  const packageConfig = fs.readFileSync(path.join(projectPath, 'package.json'), { encoding:'utf8' })
+  const { peerDependencies } = JSON.parse(packageConfig)
+  const version = peerDependencies[PACKAGE_NAME]
+  return version.substr(version.search(/\d/))
+}
+
+/**
  * Clone or copy a Quire starter project
  *
  * @param    {String}   starter   A repository URL or path to local starter

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -181,9 +181,10 @@ async function install(version, options={}) {
 
 /**
  * Retrieve latest published version of the `quire-11ty` package
- * Nota bene: `npm view [package name]@[semver version range] version` returns
- * a list of versions that satisfy the range specifier. However, execa stdout
- * will have only the last line of output
+ * Nota bene: `npm view [<@scope>/]<name>[@<version>] version` 
+ * @see https://docs.npmjs.com/cli/v7/commands/npm-view
+ * returns a list of versions that satisfy the `<version>` range specifier, 
+ * piping this to execa `stdout` we get only the last line of output.
  *
  * @return {String} `quire-11ty@latest` semantic version string
  *


### PR DESCRIPTION
This PR:
- Fixes `quire new` pathing issues; `quire new` was previously installing `@thegetty/quire-11ty` in strange locations outside of `quire/packages/cli`
- Fixes broken paths in `symlinkLatest()` function
- Implements `getVersionFromStarterPeerDependencies()` to retrieve version of `@thegetty/quire-11ty` to install from the `peerDependencies` key of [`quire-starter-default`](https://github.com/thegetty/quire-starter-default) `package.json` (the version listed in that repository has been updated to `1.0.0-pre-release.2` to match the published version of `@thegetty/quire-11ty`)
- Implements `setVersion()` function to write the current version of `@thegetty/quire-11ty` being used with a new project to a `.quire` config file
- Adds notes and documentation of various `lib/quire` functions