### PR TITLE
WIP commit fixing projectRoot and eleventyRoot paths

### DIFF
--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -8,12 +8,12 @@ module.exports = (eleventyConfig) => {
   const { url } = eleventyConfig.globalData.publication
   const { port } = eleventyConfig.serverOptions
 
-  const projectRoot = path.resolve(__dirname, '../../../')
+  const projectRoot = path.resolve(eleventyConfig.dir.input, '..')
 
   logger.debug(`projectRoot: ${projectRoot}`)
 
   const resolveInputPath = () => {
-    const resolvedPath = path.resolve(projectRoot, eleventyConfig.dir.input)
+    const resolvedPath = path.resolve(eleventyConfig.dir.input)
     logger.debug(`inputPath: ${resolvedPath}`)
     return resolvedPath
   }

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -37,12 +37,13 @@ const checkForDuplicateIds = function (data, filename) {
 
 /**
  * Programmatically load global data from files
+ *
  * Nota bene: data is not loaded from the `eleventyConfig.dir.data` directory
  *
  * @param  {EleventyConfig}  eleventyConfig
  */
 module.exports = function(eleventyConfig) {
-  const dataDir = path.resolve('../11ty/content/_data')
+  const dataDir = path.resolve(eleventyConfig.dir.input, '_data')
   const files = fs.readdirSync(dataDir)
   const parseFile = parser(eleventyConfig)
 

--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -41,11 +41,16 @@ export default {
     console.info('[CLI:11ty] running eleventy build')
     console.info(`[CLI:11ty] projectRoot ${projectRoot}`)
 
+    if (options.debug) process.env.DEBUG = 'Eleventy*'
+
     const eleventy = await factory(options)
     await eleventy.executeBuild()
   },
   serve: async (options = {}) => {
     console.info('[CLI:11ty] running development server')
+
+    if (options.debug) process.env.DEBUG = 'Eleventy*'
+
     const eleventy = await factory(options)
     await eleventy.serve()
   }

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -1,10 +1,7 @@
 import { execa } from 'execa'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
-import paths from './paths.js'
-
-// const projectRoot = path.resolve('../../packages/11ty')
-const projectRoot = '/Users/apollack/Desktop/blard'
+import paths, { projectRoot } from './paths.js'
 
 /**
  * A factory function to configure an Eleventy CLI command

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -35,10 +35,22 @@ export default {
 
     const eleventyOptions = factory()
 
+    /**
+     * Set execa environment variables
+     * @see https://github.com/sindresorhus/execa#env
+     */
+    const execaEnv = {}
+
+    if (options.debug) execaEnv.DEBUG = 'Eleventy*'
     if (options.dryRun) eleventyOptions.push('--dryrun')
     if (options.quiet) eleventyOptions.push('--quiet')
 
-    await execa('npx', eleventyOptions, { all: true, cwd: projectRoot, execPath: process.execPath }).all.pipe(process.stdout)
+    await execa('npx', eleventyOptions, {
+      all: true,
+      cwd: projectRoot,
+      env: execaEnv,
+      execPath: process.execPath
+    }).all.pipe(process.stdout)
   },
 
   serve: async (options = {}) => {
@@ -48,10 +60,22 @@ export default {
 
     eleventyOptions.push('--serve')
 
+    /**
+     * Set execa environment variables
+     * @see https://github.com/sindresorhus/execa#env
+     */
+    const execaEnv = {}
+
+    if (options.debug) execaEnv.DEBUG = 'Eleventy*'
     if (options.port) eleventyOptions.push(`--port=${options.port}`)
     if (options.quiet) eleventyOptions.push('--quiet')
     if (options.verbose) eleventyOptions.push('--verbose')
 
-    await execa('npx', eleventyOptions, { all: true, cwd: projectRoot, execPath: process.execPath }).all.pipe(process.stdout)
+    await execa('npx', eleventyOptions, {
+      all: true,
+      cwd: projectRoot,
+      env: execaEnv,
+      execPath: process.execPath
+    }).all.pipe(process.stdout)
   }
 }

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -3,7 +3,8 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import paths from './paths.js'
 
-const projectRoot = path.resolve('../../packages/11ty')
+// const projectRoot = path.resolve('../../packages/11ty')
+const projectRoot = '/Users/apollack/Desktop/blard'
 
 /**
  * A factory function to configure an Eleventy CLI command
@@ -40,7 +41,7 @@ export default {
     if (options.dryRun) eleventyOptions.push('--dryrun')
     if (options.quiet) eleventyOptions.push('--quiet')
 
-    await execa('npx', eleventyOptions, { cwd: projectRoot }).stdout.pipe(process.stdout)
+    await execa('npx', eleventyOptions, { all: true, cwd: projectRoot, execPath: process.execPath }).all.pipe(process.stdout)
   },
 
   serve: async (options = {}) => {
@@ -54,6 +55,6 @@ export default {
     if (options.quiet) eleventyOptions.push('--quiet')
     if (options.verbose) eleventyOptions.push('--verbose')
 
-    await execa('npx', eleventyOptions, { cwd: projectRoot }).stdout.pipe(process.stdout)
+    await execa('npx', eleventyOptions, { all: true, cwd: projectRoot, execPath: process.execPath }).all.pipe(process.stdout)
   }
 }

--- a/packages/cli/src/lib/11ty/paths.js
+++ b/packages/cli/src/lib/11ty/paths.js
@@ -16,15 +16,17 @@ const __dirname = path.dirname(__filename)
  * to the correct version of the quire/11ty package, for example:
  *   eleventyRoot = `#lib/quire/versions/${config.version}/11ty`
  */
-// export const eleventyRoot = '../../packages/11ty'
-// export const projectRoot = '../../packages/11ty'
-// export const eleventyRoot = '../cli/src/lib/quire/versions/1.0.0-pre-release.2'
-export const eleventyRoot = '../cli/src/lib/quire/versions/TESTING'
-export const projectRoot = '/Users/apollack/Desktop/blard'
+const version = 'latest'
+// Absolute path to the current version of quire-11ty
+export const eleventyRoot = path.resolve(
+  __dirname,
+  path.join('..', 'quire', 'versions', version)
+)
+export const projectRoot = process.cwd()
 
 export default {
-  config: path.resolve(eleventyRoot, '.eleventy.js'),
-  input: `${projectRoot}/content`,
+  config: path.join(eleventyRoot, '.eleventy.js'),
+  input: path.relative(path.join(projectRoot, 'content'), eleventyRoot),
   output: './_site',
   public: './public',
 }

--- a/packages/cli/src/lib/11ty/paths.js
+++ b/packages/cli/src/lib/11ty/paths.js
@@ -16,8 +16,11 @@ const __dirname = path.dirname(__filename)
  * to the correct version of the quire/11ty package, for example:
  *   eleventyRoot = `#lib/quire/versions/${config.version}/11ty`
  */
-export const eleventyRoot = '../../packages/11ty'
-export const projectRoot = '../../packages/11ty'
+// export const eleventyRoot = '../../packages/11ty'
+// export const projectRoot = '../../packages/11ty'
+// export const eleventyRoot = '../cli/src/lib/quire/versions/1.0.0-pre-release.2'
+export const eleventyRoot = '../cli/src/lib/quire/versions/TESTING'
+export const projectRoot = '/Users/apollack/Desktop/blard'
 
 export default {
   config: path.resolve(eleventyRoot, '.eleventy.js'),

--- a/packages/cli/src/lib/11ty/paths.js
+++ b/packages/cli/src/lib/11ty/paths.js
@@ -18,7 +18,7 @@ const __dirname = path.dirname(__filename)
  *   this needs to use the correct `quire-11ty` version for the project
  *   and correctly resolve the path to the target of the 'latest' symlink
  */
-const cliRoot = path.resolve(__dirname, '../..')
+const cliRoot = path.resolve(__dirname, path.join('..', '..'))
 const version = 'latest'
 
 // Absolute path to the current version of quire-11ty

--- a/packages/cli/src/lib/11ty/paths.js
+++ b/packages/cli/src/lib/11ty/paths.js
@@ -29,6 +29,6 @@ export const projectRoot = process.cwd()
 export default {
   config: path.join(eleventyRoot, '.eleventy.js'),
   input: path.relative(eleventyRoot, path.join(projectRoot, 'content')),
-  output: './_site',
+  output: path.relative(eleventyRoot, path.join(projectRoot, '_site')),
   public: './public',
 }

--- a/packages/cli/src/lib/11ty/paths.js
+++ b/packages/cli/src/lib/11ty/paths.js
@@ -12,21 +12,23 @@ const __dirname = path.dirname(__filename)
  * `eleventyRoot` is _relative_ to `main.js`, the CLI entry point.
  * Both `input` and `output` are _relative_ to the `config` module.
  *
- * @todo read paths from the Quire project configuration and resolve path
- * to the correct version of the quire/11ty package, for example:
- *   eleventyRoot = `#lib/quire/versions/${config.version}/11ty`
+ * @todo
+ * - refactor the paths module as a concern of the `lib/quire` module
+ * - refactor resolving an absolute path to the correct eleventy version root;
+ *   this needs to use the correct `quire-11ty` version for the project
+ *   and correctly resolve the path to the target of the 'latest' symlink
  */
+const cliRoot = path.resolve(__dirname, '../..')
 const version = 'latest'
+
 // Absolute path to the current version of quire-11ty
-export const eleventyRoot = path.resolve(
-  __dirname,
-  path.join('..', 'quire', 'versions', version)
-)
+export const eleventyRoot =
+  path.resolve(__dirname, path.join(cliRoot, 'lib', 'quire', 'versions', version))
 export const projectRoot = process.cwd()
 
 export default {
   config: path.join(eleventyRoot, '.eleventy.js'),
-  input: path.relative(path.join(projectRoot, 'content'), eleventyRoot),
+  input: path.relative(eleventyRoot, path.join(projectRoot, 'content')),
   output: './_site',
   public: './public',
 }

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -1,6 +1,7 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-warnings
 import { Command } from 'commander'
 import commands from './commands/index.js'
+import packageConfig from '../package.json' assert { type: 'json' }
 
 /**
  * Quire CLI implements the command pattern.
@@ -14,7 +15,7 @@ const program = new Command()
 program
   .name('quire-cli')
   .description('Quire command-line interface')
-  .version('1.0.0')
+  .version(packageConfig.version)
   .configureHelp({
     helpWidth: 80,
     sortOptions: false,


### PR DESCRIPTION
## Added

- Sets the shell environment `DEBUG` option from the `quire-cli` `build` and `preview` command `--debug` flag is used.

## Changed

- Refactors Eleventy configuration paths.
- Sets the `quire-cli` version to the package config `version`
- Updates sorting installed `quire-11ty` versions; filtering dir entries that are not valid `semver` strings.

