### PR TITLE
Fix `filterSymlinkLatest()`

### DIFF
--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -249,7 +249,7 @@ function setVersion(projectPath, version) {
 function symlinkLatest() {
   const latestInstalledVersion = fs
     .readdirSync(path.join(__dirname, 'versions'))
-    .filter((filename) => !['.DS_Store', 'desktop.ini', 'thumbs.db', 'latest'].includes(filename))
+    .filter((dirent) => semver.valid(semver.coerce(dirent))
     .sort(semver.rcompare)[0]
   const target = path.join(__dirname, 'versions', latestInstalledVersion)
   const source = path.join(__dirname, 'versions', 'latest')

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -249,6 +249,7 @@ function setVersion(projectPath, version) {
 function symlinkLatest() {
   const latestInstalledVersion = fs
     .readdirSync(path.join(__dirname, 'versions'))
+    .filter((filename) => !['.DS_Store', 'desktop.ini', 'thumbs.db', 'latest'].includes(filename))
     .sort(semver.rcompare)[0]
   const target = path.join(__dirname, 'versions', latestInstalledVersion)
   const source = path.join(__dirname, 'versions', 'latest')


### PR DESCRIPTION
Not sure if this is a necessary extra step, since I have been monitoring the install process in `quire new` from my Finder (which will create `.DS_Store`s that normally wouldn't ever get made) but aside from `.DS_Store` being the thing returned from
``` js
  const latestInstalledVersion = fs
    .readdirSync(path.join(__dirname, 'versions'))
    .sort(semver.rcompare)[0] // <-- right here
```
`latest` was causing problems as not being a `semver.rcompare`-able thing