### PR TITLE
Override Eleventy addPassthroughCopy

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -63,7 +63,10 @@ module.exports = function(eleventyConfig) {
       console.debug('[11ty:config] passthrough copy %o', entry)
       entry = Object.fromEntries(
         Object.entries(entry).map(([ src, dest ]) => {
-          return [ path.join(__dirname, src), path.resolve(dest) ]
+          return [
+            path.join(__dirname, src),
+            path.resolve(path.join(outputDir, dest))
+          ]
         })
       )
       console.debug('[11ty:config] passthrough copy %o', entry)

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -57,16 +57,16 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy = (entry) => {
     if (typeof entry === 'string') {
       const filePath = path.resolve(entry)
-      console.debug('[11ty:API] passthrough copy %s', filePath)
+      console.debug('[11ty:config] passthrough copy %s', filePath)
       return addPassthroughCopy(filePath, { expand: true })
     } else {
-      console.debug('[11ty:API] passthrough copy %o', entry)
+      console.debug('[11ty:config] passthrough copy %o', entry)
       entry = Object.fromEntries(
         Object.entries(entry).map(([ src, dest ]) => {
           return [ path.join(__dirname, src), path.resolve(dest) ]
         })
       )
-      console.debug('[11ty:API] passthrough copy %o', entry)
+      console.debug('[11ty:config] passthrough copy %o', entry)
       return addPassthroughCopy(entry, { expand: true })
     }
   }

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -251,13 +251,13 @@ module.exports = function(eleventyConfig) {
    * Set eleventy dev server options
    * @see https://www.11ty.dev/docs/dev-server/
    */
-  // eleventyConfig.setServerOptions({
-  //   port: 8080
-  // })
+  eleventyConfig.setServerOptions({
+    port: 8080
+  })
 
   // @see https://www.11ty.dev/docs/copy/#passthrough-during-serve
   // @todo resolve error when set to the default behavior 'passthrough'
-  // eleventyConfig.setServerPassthroughCopyBehavior('copy')
+  eleventyConfig.setServerPassthroughCopyBehavior('copy')
 
   /**
    * Copy static assets to the output directory

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -45,6 +45,32 @@ const publicDir = 'public'
  * @return     {Object}  A modified eleventy configuation
  */
 module.exports = function(eleventyConfig) {
+  /**
+   * Override addPassthroughCopy to use _absolute_ system paths.
+   * @see https://www.11ty.dev/docs/copy/#passthrough-file-copy
+   * Nota bene: Eleventy addPassthroughCopy assumes paths are _relative_
+   * to the `config` file however the quire-cli separates 11ty from the
+   * project directory (`input`) and needs to use absolute system paths.
+   */
+  const addPassthroughCopy = eleventyConfig.addPassthroughCopy.bind(eleventyConfig)
+
+  eleventyConfig.addPassthroughCopy = (entry) => {
+    if (typeof entry === 'string') {
+      const filePath = path.resolve(entry)
+      console.debug('[11ty:API] passthrough copy %s', filePath)
+      return addPassthroughCopy(filePath, { expand: true })
+    } else {
+      console.debug('[11ty:API] passthrough copy %o', entry)
+      entry = Object.fromEntries(
+        Object.entries(entry).map(([ src, dest ]) => {
+          return [ path.join(__dirname, src), path.resolve(dest) ]
+        })
+      )
+      console.debug('[11ty:API] passthrough copy %o', entry)
+      return addPassthroughCopy(entry, { expand: true })
+    }
+  }
+
   eleventyConfig.addGlobalData('application', {
     name: 'Quire',
     version: packageJSON.version
@@ -222,13 +248,13 @@ module.exports = function(eleventyConfig) {
    * Set eleventy dev server options
    * @see https://www.11ty.dev/docs/dev-server/
    */
-  eleventyConfig.setServerOptions({
-    port: 8080
-  })
+  // eleventyConfig.setServerOptions({
+  //   port: 8080
+  // })
 
   // @see https://www.11ty.dev/docs/copy/#passthrough-during-serve
   // @todo resolve error when set to the default behavior 'passthrough'
-  eleventyConfig.setServerPassthroughCopyBehavior('copy')
+  // eleventyConfig.setServerPassthroughCopyBehavior('copy')
 
   /**
    * Copy static assets to the output directory

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -18,6 +18,7 @@ module.exports = (eleventyConfig) => {
     return resolvedPath
   }
 
+  // @todo abstract this concern to decouple this plugin from vite
   const resolveOutputPath = () => {
     const { viteOptions } = eleventyConfig.plugins.find(
       ({ options }) => !!options && !!options.viteOptions

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -6,7 +6,7 @@ const logger = chalkFactory('Figures:IIIF:Config', 'DEBUG')
 
 module.exports = (eleventyConfig) => {
   const { url } = eleventyConfig.globalData.publication
-  const { port } = eleventyConfig.serverOptions
+  const { port=8080 } = eleventyConfig.serverOptions
 
   const projectRoot = path.resolve(eleventyConfig.dir.input, '..')
 

--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -30,6 +30,17 @@ const factory = async (options = {}) => {
     expand: true,
   }
 
+  /**
+   * Get an instance of the runtime of eleventy.
+   * @see https://github.com/11ty/eleventy/blob/src/Eleventy.js
+   *
+   * @param {String} input  Path from which to read content templates
+   * @param {String} output  Path where rendered files will be written
+   * @param {Object} options  Options are merged with the Eleventy UserConfig
+   * @param {Object} config  An eleventy configurtion object
+   *
+   * @returns {module:11ty/eleventy/Eleventy~Eleventy}
+   */
   return new Eleventy(input, output, {
     config: (eleventyConfig) => {
       /**

--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -22,7 +22,24 @@ const factory = async (options) => {
 
   return new Eleventy(input, output, {
     config: (eleventyConfig) => {
-      // custom configuration
+      /**
+       * Override addPassthroughCopy to use absolute system paths.
+       * Nota bene: Eleventy addPassthroughCopy assumes paths are relative to
+       * the `config` file path however the quire-cli separates 11ty from the
+       * project directory (`input`) and needs to use absolute system paths.
+       */
+      const addPassthroughCopy = eleventyConfig.addPassthroughCopy.bind(eleventyConfig)
+      eleventyConfig.addPassthroughCopy = (file) => {
+        if (typeof file === 'string') {
+          const filePath = path.join(projectRoot, file)
+          console.debug('[11ty:API] passthrough copy %s', filePath)
+          return addPassthroughCopy(filePath)
+        } else {
+          console.debug('[11ty:API] passthrough copy %o', file)
+          return addPassthroughCopy(file)
+        }
+      }
+      return eleventyConfig
     },
     configPath: options.config || config,
     quietMode: options.quiet || false,

--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -41,7 +41,7 @@ const factory = async (options = {}) => {
    *
    * @returns {module:11ty/eleventy/Eleventy~Eleventy}
    */
-  return new Eleventy(input, output, {
+  const eleventy = new Eleventy(input, output, {
     config: (eleventyConfig) => {
       /**
        * Override addPassthroughCopy to use _absolute_ system paths.
@@ -71,7 +71,10 @@ const factory = async (options = {}) => {
     },
     configPath: options.config || config,
     quietMode: options.quiet || false,
+    // source: 'script',
   })
+
+  return eleventy
 }
 
 /**
@@ -89,6 +92,9 @@ export default {
     if (options.debug) process.env.DEBUG = 'Eleventy*'
 
     const eleventy = await factory(options)
+
+    eleventy.setDryRun(options.dryrun)
+
     await eleventy.executeBuild()
   },
   serve: async (options = {}) => {
@@ -97,6 +103,7 @@ export default {
     if (options.debug) process.env.DEBUG = 'Eleventy*'
 
     const eleventy = await factory(options)
-    await eleventy.serve()
+
+    await eleventy.serve(options.port)
   }
 }

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -9,20 +9,25 @@ import paths, { projectRoot } from './paths.js'
  * @param  {Object}  options  Eleventy configuration options
  * @return  {Array} Eleventy CLI options
  */
-const factory = () => {
+const factory = (options = {}) => {
   const { config, input, output } = paths
 
   console.info(`[CLI:11ty] projectRoot ${projectRoot}`)
 
   console.debug('[CLI:11ty] %o', paths)
 
-  return [
+  const command = [
     `@11ty/eleventy`,
     `--config=${config}`,
     `--input=${input}`,
     `--output=${output}`,
     `--incremental`,
   ]
+
+  if (options.quiet) command.push('--quiet')
+  if (options.verbose) command.push('--verbose')
+
+  return command
 }
 
 /**
@@ -42,8 +47,8 @@ export default {
     const execaEnv = {}
 
     if (options.debug) execaEnv.DEBUG = 'Eleventy*'
+
     if (options.dryRun) eleventyCommand.push('--dryrun')
-    if (options.quiet) eleventyCommand.push('--quiet')
 
     await execa('npx', eleventyCommand, {
       all: true,
@@ -56,9 +61,9 @@ export default {
   serve: async (options = {}) => {
     console.info(`[CLI:11ty] running eleventy serve`)
 
-    const eleventyOptions = factory()
+    const eleventyCommand = factory(options)
 
-    eleventyOptions.push('--serve')
+    eleventyCommand.push('--serve')
 
     /**
      * Set execa environment variables
@@ -67,11 +72,10 @@ export default {
     const execaEnv = {}
 
     if (options.debug) execaEnv.DEBUG = 'Eleventy*'
-    if (options.port) eleventyOptions.push(`--port=${options.port}`)
-    if (options.quiet) eleventyOptions.push('--quiet')
-    if (options.verbose) eleventyOptions.push('--verbose')
 
-    await execa('npx', eleventyOptions, {
+    if (options.port) eleventyCommand.push(`--port=${options.port}`)
+
+    await execa('npx', eleventyCommand, {
       all: true,
       cwd: projectRoot,
       env: execaEnv,

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -33,7 +33,7 @@ export default {
   build: async (options = {}) => {
     console.info('[CLI:11ty] running eleventy build')
 
-    const eleventyOptions = factory()
+    const eleventyCommand = factory()
 
     /**
      * Set execa environment variables
@@ -42,10 +42,10 @@ export default {
     const execaEnv = {}
 
     if (options.debug) execaEnv.DEBUG = 'Eleventy*'
-    if (options.dryRun) eleventyOptions.push('--dryrun')
-    if (options.quiet) eleventyOptions.push('--quiet')
+    if (options.dryRun) eleventyCommand.push('--dryrun')
+    if (options.quiet) eleventyCommand.push('--quiet')
 
-    await execa('npx', eleventyOptions, {
+    await execa('npx', eleventyCommand, {
       all: true,
       cwd: projectRoot,
       env: execaEnv,

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -1,7 +1,6 @@
 import { execa } from 'execa'
-import { fileURLToPath } from 'node:url'
 import path from 'node:path'
-import paths, { projectRoot } from './paths.js'
+import paths, { eleventyRoot, projectRoot } from './paths.js'
 
 /**
  * A factory function to configure an Eleventy CLI command
@@ -16,8 +15,14 @@ const factory = (options = {}) => {
 
   console.debug('[CLI:11ty] %o', paths)
 
+  /**
+   * Use the version of Eleventy installed to `lib/quire/versions`
+   */
+  const eleventy =
+    path.join(eleventyRoot, 'node_modules', '@11ty', 'eleventy', 'cmd.js')
+
   const command = [
-    `@11ty/eleventy`,
+    eleventy,
     `--config=${config}`,
     `--input=${input}`,
     `--output=${output}`,
@@ -50,7 +55,7 @@ export default {
 
     if (options.dryRun) eleventyCommand.push('--dryrun')
 
-    await execa('npx', eleventyCommand, {
+    await execa('node', eleventyCommand, {
       all: true,
       cwd: projectRoot,
       env: execaEnv,
@@ -75,7 +80,7 @@ export default {
 
     if (options.port) eleventyCommand.push(`--port=${options.port}`)
 
-    await execa('npx', eleventyCommand, {
+    await execa('node', eleventyCommand, {
       all: true,
       cwd: projectRoot,
       env: execaEnv,


### PR DESCRIPTION
Overrides the Eleventy `addPassthroughCopy` method to resolve an absolute path to an input file or absolute paths for both the source and destination when copying and renaming a file in `_includes` for example.

@todo refactor this override as a separate module that is included in the `11ty/.eleventy.js` configuration file _or_ that is shared by the `quire-cli` `lib/11ty` modules to injected into the config.

