### PR TITLE
Quire CLI Plan B

### DIFF
--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -23,7 +23,7 @@ export default class CreateCommand extends Command {
     ],
     options: [
       [ '--debug', 'debug the `quire new` command' ],
-      [ '--eject', 'install quire-11ty into the project directory' ],
+      [ '--eject', 'install quire-11ty into the project directory', 'true' ],
     ],
   }
 

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -53,6 +53,9 @@ export default class CreateCommand extends Command {
       // `git clone starter path`
     } else {
       const version = await quire.initStarter(starter, projectPath)
+      // @TODO we will want to abstract the test for emptiness to prevent further install steps on error
+      if (!version) return
+
       if (options.eject) {
         await quire.installInProject(projectPath, version, options)
       }

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -23,6 +23,7 @@ export default class CreateCommand extends Command {
     ],
     options: [
       [ '--debug', 'debug the `quire new` command' ],
+      [ '--eject', 'create new quire project with 11ty files committed directly' ],
     ],
   }
 

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -58,8 +58,9 @@ export default class CreateCommand extends Command {
 
       if (options.eject) {
         await quire.installInProject(projectPath, version, options)
+      } else {
+        await quire.install(version, options)
       }
-      await quire.install(version, options)
     }
   }
 }

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -23,7 +23,7 @@ export default class CreateCommand extends Command {
     ],
     options: [
       [ '--debug', 'debug the `quire new` command' ],
-      [ '--eject', 'create new quire project with 11ty files committed directly' ],
+      [ '--eject', 'install quire-11ty into the project directory' ],
     ],
   }
 

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -53,7 +53,10 @@ export default class CreateCommand extends Command {
       // `git clone starter path`
     } else {
       const version = await quire.initStarter(starter, projectPath)
-      await quire.install(version)
+      if (options.eject) {
+        await quire.installInProject(projectPath, version, options)
+      }
+      await quire.install(version, options)
     }
   }
 }

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -39,7 +39,7 @@ export default class CreateCommand extends Command {
    */
   async action(projectPath, starter, options = {}) {
     if (options.debug) {
-      console.info('Command \'%s\' called with options %o', this.name, options)
+      console.info('Command \'%s\' called with options %o', CreateCommand.name, options)
     }
 
     if (!projectPath && !starter) {

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -233,7 +233,13 @@ async function installInProject(projectPath, version, options={}) {
    * the final `_site` package when running `quire build`
    */
   await execaCommand('npm cache clean --force', { cwd: projectPath })
-  await execaCommand('npm install --save-dev', { cwd: projectPath })
+  try {
+    await execaCommand('npm install --save-dev', { cwd: projectPath })
+  } catch(error) {
+    console.warn(`[CLI:error]`, error)
+    fs.removeSync(projectPath)
+    return
+  }
 
   const eleventyFilesToCommit = fs
     .readdirSync(path.join(projectPath, temp11tyDirectory))

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -185,6 +185,74 @@ async function install(version, options={}) {
 }
 
 /**
+ * Install a specific version of `quire-11ty` directly into a quire project
+ *
+ * @param  {String}  projectPath  Absolute system path to the project root
+ * @param  {String}  version  Quire-11ty semantic version
+ * @param  {Object}  options  options passed from `quire new` command
+ * @return  {Promise}
+ */
+async function installInProject(projectPath, version, options={}) {
+  console.debug(`[CLI:quire] installing quire-11ty@${version} into ${projectPath}`)
+
+  /**
+   * delete `package.json` from starter project, as it will be replaced with
+   * `package.json` from `@thegetty/quire-11ty`
+   */
+  await git
+    .cwd(projectPath)
+    .rm(['package.json'])
+    .catch((error) => console.error('[CLI:error] ', error))
+
+  const temp11tyDirectory = '.temp'
+  /**
+   * `Destination` is relative to `node_modules` of the working-directory
+   * so we have included a relative path to parent directory in order to
+   * install versions to a different local path.
+   * @see https://github.com/scott-lin/install-npm-version
+   */
+  const installOptions = {
+    Destination: path.join('..', temp11tyDirectory),
+    Debug: false,
+    Overwrite: options.force || options.overwrite || false,
+    Verbosity: options.debug ? 'Debug' : 'Silent',
+    WorkingDirectory: projectPath
+  }
+  await inv.Install(`${PACKAGE_NAME}@${version}`, installOptions)
+
+  // delete empty `node_modules` directory that `install-npm-version` creates
+  const invNodeModulesDir = path.join(projectPath, 'node_modules')
+  if (fs.existsSync(invNodeModulesDir)) fs.rmdir(invNodeModulesDir)
+
+  // Copy all files installed in `.temp` to projectPath
+  fs.copySync(path.join(projectPath, '.temp'), projectPath)
+
+  console.debug('[CLI:quire] installing dev dependencies into quire project')
+  /**
+   * Manually install necessary dev dependencies to run 11ty;
+   * these must be `devDependencies` so that they are not bundled into
+   * the final `_site` package when running `quire build`
+   */
+  await execaCommand('npm cache clean --force', { cwd: projectPath })
+  await execaCommand('npm install --save-dev', { cwd: projectPath })
+
+  const eleventyFilesToCommit = fs
+    .readdirSync(path.join(projectPath, temp11tyDirectory))
+    .filter((filePath) => filePath !== 'node_modules')
+
+  eleventyFilesToCommit.push('package-lock.json')
+
+  /**
+   * Create an additional commit of new `@thegetty/quire-11ty` files in repository
+   * @todo use a localized string for the commit message
+   */
+  await git.add(eleventyFilesToCommit).commit('Adds `@thegetty/quire-11ty` files')
+
+  // remove temporary 11ty install directory
+  fs.removeSync(path.join(projectPath, temp11tyDirectory))
+}
+
+/**
  * Retrieve latest published version of the `quire-11ty` package
  * Nota bene: `npm view [<@scope>/]<name>[@<version>] version`
  * @see https://docs.npmjs.com/cli/v7/commands/npm-view
@@ -317,6 +385,7 @@ export const quire = {
   getVersion,
   initStarter,
   install,
+  installInProject,
   latest,
   list,
   remove,

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -141,9 +141,8 @@ async function initStarter (starter, projectPath) {
 /**
  * Install a specific version of `quire-11ty`
  *
- * If a `version` argument is not given `latest` is assumed.
- *
  * @param  {String}  version  Quire-11ty semantic version
+ * @param  {Object}  options  options passed from `quire new` command
  * @return  {Promise}
  */
 async function install(version, options={}) {

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -197,6 +197,8 @@ async function installInProject(projectPath, version, options={}) {
   /**
    * delete `package.json` from starter project, as it will be replaced with
    * `package.json` from `@thegetty/quire-11ty`
+   * @TODO If a user runs quire eject at a later date we may want to merge their
+   * package.json with the `quire-11ty` dev dependencies, scripts, etc
    */
   await git
     .cwd(projectPath)

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -156,7 +156,7 @@ async function install(version, options={}) {
    * @see https://github.com/scott-lin/install-npm-version
    */
   const installOptions = {
-    Destination: path.join('../', version),
+    Destination: path.join('..', version),
     Debug: false,
     Overwrite: options.force || options.overwrite || false,
     Verbosity: options.debug ? 'Debug' : 'Silent',


### PR DESCRIPTION
This PR implements our "Plan B" -- running quire projects with `@thegetty/quire-11ty` package decoupled from user content files has a few outstanding pathing issues, so this update allows users to create a new quire project where the `@thegetty/quire-11ty` files are added directly to the project and committed.

**Note:** the install process in `installInProject()`has to first install `@thegetty/quire-11ty` into a `.temp` directory in the `projectRoot`, then copy those files into the `projectRoot` as `install-npm-version` will not let you install things into a non-empty directory.

To use, run `quire new --eject [project name]` (open to suggestions on the name, as we are not really "ejecting" while creating)

This likely warrants an entirely new command `quire eject` which can be run on a previously created project.

- Implement and export `quire.installInProject` function in `lib/quire`
- Update JSDoc comment for `quire.install` function
- Remove any OS-specific slash characters from `quire.install`
- Add `--eject` option flag to `quire new` command
- Correctly display command name if `options.debug` is true
- Run `quire.installInProject` if `options.eject` (`--eject` flag) is passed to `quire new`
