### PR TITLE
Refactor `getVersionFromStarter` function to parse `latest` version of `@thegetty/quire-cli` peer dependency

### DIFF
--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -75,6 +75,7 @@ async function getVersionFromStarter(projectPath) {
  * Clone or copy a Quire starter project
  *
  * @param    {String}   starter   A repository URL or an absolute path to local starter
+ * @TODO resolve both absolute and relative paths to local starter repositories 
  * @param    {String}   projectPath  Absolute system path to the project root
  *
  * @return   {String}   quireVersion  A string indicating the current version

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -62,17 +62,19 @@ function getVersion(projectPath) {
  * (i.e `^1.0.0-pre-release.0` => `1.0.0-pre-release.2`) so this string-trimming
  * logic can be removed
  */
-function getVersionFromStarter(projectPath) {
+async function getVersionFromStarter(projectPath) {
   const packageConfig = fs.readFileSync(path.join(projectPath, 'package.json'), { encoding:'utf8' })
   const { peerDependencies } = JSON.parse(packageConfig)
   const version = peerDependencies[PACKAGE_NAME]
-  return version.substr(version.search(/\d/))
+  return version === 'latest'
+    ? await latest()
+    : version.substr(version.search(/\d/))
 }
 
 /**
  * Clone or copy a Quire starter project
  *
- * @param    {String}   starter   A repository URL or path to local starter
+ * @param    {String}   starter   A repository URL or an absolute path to local starter
  * @param    {String}   projectPath  Absolute system path to the project root
  *
  * @return   {String}   quireVersion  A string indicating the current version
@@ -112,7 +114,7 @@ async function initStarter (starter, projectPath) {
    * Determine `quire-11ty` version required by the starter project
    * and write a `.quire` file with the semantic version string.
    */
-  const quireVersion = getVersionFromStarter(projectPath) || await latest()
+  const quireVersion = await getVersionFromStarter(projectPath)
   setVersion(projectPath, quireVersion)
 
   // Re-initialize project directory as a new git repository


### PR DESCRIPTION
If `quire-starter-default` is set to use `peerDependencies: { '@thegetty/quire-11ty': 'latest' }`, the `getVersionFromStarter()` function in `lib/quire` erroneously returns `t` as a version (`'latest'.substr('latest'.search(/\d/)) => 't'`). This update calls now calls `latest()` from `getVersionFromStarter()` if the version returned from starter `package.json` is `latest`

**NOTE!!!** This is still hacky -- using `npm view @thegetty/quire-11ty version` does indeed return a single semver version string, but since this is intended for human view, there's no future guarantee that `npm` won't reformat the text readout of `npm view [package] version`. We still need to find a programmatic way to parse versions from packages.