### PR TITLE
Fix annotation option property value

### DIFF
--- a/packages/11ty/_includes/components/figure/annotations-ui/option.js
+++ b/packages/11ty/_includes/components/figure/annotations-ui/option.js
@@ -15,7 +15,7 @@ module.exports = function (eleventyConfig) {
    * @param  {String} name The input name attribute. Prefixed with `lightbox-` when rendered inside a lightbox
    */
   return function ({ annotation, index, input, name }) {
-    const { id, label, selected, type, url } = annotation
+    const { id, label, selected, type, uri } = annotation
 
     if (!label) {
       logger.error(`Annotation label is required. Annotation id: ${id}`)
@@ -38,7 +38,7 @@ module.exports = function (eleventyConfig) {
           id="${inputId}"
           name="${name}"
           type="${input}"
-          value="${url}"
+          value="${uri}"
           data-annotation-id="${id}"
           data-annotation-type="${type}"
           ${checked ? 'checked' : ''}


### PR DESCRIPTION
Updates property name from `url` to `uri`, fixes value attribute missing from input