### PR TITLE
Refactor dynamic imports to support Windows OS

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "1.0.0-pre-release.8",
+  "version": "1.0.0-pre-release.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-pre-release.8",
+      "version": "1.0.0-pre-release.9",
       "license": "J Paul Getty Trust",
       "dependencies": {
         "boxen": "^7.0.0",
@@ -4816,6 +4816,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -4830,16 +4831,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4853,6 +4857,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -4868,6 +4873,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -11435,7 +11441,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -11447,15 +11454,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -11466,7 +11476,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -11478,7 +11489,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-pre-release.8",
+  "version": "1.0.0-pre-release.9",
   "author": "Getty Digital",
   "license": "J Paul Getty Trust",
   "bugs": {

--- a/packages/cli/src/commands/index.js
+++ b/packages/cli/src/commands/index.js
@@ -1,4 +1,5 @@
-import { fileURLToPath } from 'node:url'
+import { IS_WINDOWS } from '#helpers/os-utils.js'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import fs from 'fs-extra'
 import path from 'node:path'
 
@@ -14,7 +15,10 @@ const thisfile = path.basename(__filename)
 const commands = await Promise.all(
   fs.readdirSync(__dirname)
     .filter((file) => file !== thisfile && file.match(/^.*\.js$/))
-    .map((file) => import(path.resolve(__dirname, file)))
+    .map((file) => IS_WINDOWS
+      ? import(pathToFileURL(path.resolve(__dirname, file)))
+      : import(path.resolve(__dirname, file))
+    )
 ).then((modules) => {
   return modules.map(({ default: CommandClass }) => new CommandClass())
 })

--- a/packages/cli/src/helpers/os-utils.js
+++ b/packages/cli/src/helpers/os-utils.js
@@ -1,0 +1,5 @@
+/**
+ * Determine if the process is running on Windows operating system
+ */
+export const IS_WINDOWS =
+  process.platform === 'win32' || /^(cygwin|msys)$/.test(process.env.OSTYPE)

--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -1,3 +1,5 @@
+import { IS_WINDOWS } from '#helpers/os-utils.js'
+import { pathToFileURL } from 'node:url'
 import path from 'node:path'
 import paths, { eleventyRoot, projectRoot } from './paths.js'
 
@@ -18,7 +20,10 @@ const factory = async (options = {}) => {
   /**
    * Dynamically import the correct version of Eleventy from `lib/quire/versions`
    */
-  const { default: Eleventy } = await import(path.join(eleventyRoot, 'node_modules', '@11ty', 'eleventy', 'src', 'Eleventy.js'))
+  const modulePath = path.join(eleventyRoot, 'node_modules', '@11ty', 'eleventy', 'src', 'Eleventy.js')
+  const { default: Eleventy } = IS_WINDOWS
+    ? await import(pathToFileURL(modulePath))
+    : await import(modulePath)
 
   /**
    * Set Eleventy passthrough copy options

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -1,3 +1,4 @@
+import { IS_WINDOWS } from '#helpers/os-utils.js'
 import { chdir, cwd } from 'node:process'
 import { execa, execaCommand } from 'execa'
 import { fileURLToPath } from 'node:url'
@@ -16,9 +17,6 @@ const INSTALL_PATH = path.join('src', 'lib', 'quire', 'versions')
 const PACKAGE_NAME = '@thegetty/quire-11ty'
 const VERSION_FILE = '.quire'
 
-const IS_WINDOWS =
-  process.platform === 'win32' || /^(cygwin|msys)$/.test(process.env.OSTYPE)
-
 /**
  * Return an absolute path to an installed `quire-11ty` version
  *
@@ -30,7 +28,7 @@ function getPath(version='latest') {
     console.error(`[CLI:quire] \`quire-11ty@${version}\` is not installed`)
     return null
   }
-  console.debug(`[CLI:quire] \%`, absolutePath)
+  console.debug(`[CLI:quire] %s`, absolutePath)
   return absolutePath
 }
 


### PR DESCRIPTION
## Changes

Updates `import` expressions to use the `file://` URL scheme when the process is running on a Windows operating system.

Nota bene: changes not yet tested on a Windows operating system.
