### PR TITLE
Fix/DEV-13676: Set eleventy env in `build` and `serve` commands

### DIFF
--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -94,6 +94,7 @@ export default {
     console.info('[CLI:11ty] running eleventy build')
     console.info(`[CLI:11ty] projectRoot ${projectRoot}`)
 
+    process.env.ELEVENTY_ENV = 'production'
     if (options.debug) process.env.DEBUG = 'Eleventy*'
 
     const eleventy = await factory(options)
@@ -105,6 +106,7 @@ export default {
   serve: async (options = {}) => {
     console.info('[CLI:11ty] running development server')
 
+    process.env.ELEVENTY_ENV = 'development'
     if (options.debug) process.env.DEBUG = 'Eleventy*'
 
     const eleventy = await factory(options)

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -49,7 +49,9 @@ export default {
      * Set execa environment variables
      * @see https://github.com/sindresorhus/execa#env
      */
-    const execaEnv = {}
+    const execaEnv = {
+      ELEVENTY_ENV: 'production'
+    }
 
     if (options.debug) execaEnv.DEBUG = 'Eleventy*'
 
@@ -74,7 +76,9 @@ export default {
      * Set execa environment variables
      * @see https://github.com/sindresorhus/execa#env
      */
-    const execaEnv = {}
+    const execaEnv = {
+      ELEVENTY_ENV: 'development'
+    }
 
     if (options.debug) execaEnv.DEBUG = 'Eleventy*'
 

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -43,7 +43,7 @@ export default {
   build: async (options = {}) => {
     console.info('[CLI:11ty] running eleventy build')
 
-    const eleventyCommand = factory()
+    const eleventyCommand = factory(options)
 
     /**
      * Set execa environment variables


### PR DESCRIPTION
Internally, `quire-11ty` uses the `ELEVENTY_ENV` environment variable with a value of `production` or `development` for conditional handling of writing files (for example: pdf files, search index) directly to the output directory in the `eleventy.after` hook so that they are not removed by vite. Previously `ELEVENTY_ENV` was set using `cross-env` in the npm `dev` and `build` scripts, and now needs to be included in the `execa` environment.