### PR TITLE
quire epub command

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -23,6 +23,7 @@
         "inquirer": "^9.1.4",
         "install-npm-version": "^1.0.8",
         "loglevel": "^1.8.0",
+        "open": "^8.4.0",
         "ora": "^6.1.2",
         "pagedjs-cli": "^0.3.0",
         "semver": "^7.3.8",
@@ -1291,6 +1292,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/del": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-7.0.0.tgz",
@@ -2126,15 +2135,15 @@
         "node": ">= 14.17"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.0.0.tgz",
-      "integrity": "sha512-4YxRvMi4P5C3WQTvdRfrv5UVqbISpqjORFQAW5QPiKAauaxNCwrEdIi6pG3tDFhKKpMen+enEhHIzB/tvIO+/w==",
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -2684,6 +2693,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2828,6 +2851,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-yarn-global": {
@@ -7694,6 +7728,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -10327,6 +10377,11 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "del": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-7.0.0.tgz",
@@ -11346,6 +11401,11 @@
         "has": "^1.0.3"
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11430,6 +11490,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "is-yarn-global": {
       "version": "0.4.0",
@@ -15020,6 +15088,16 @@
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         }
+      }
+    },
+    "open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "optionator": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,6 +59,7 @@
     "inquirer": "^9.1.4",
     "install-npm-version": "^1.0.8",
     "loglevel": "^1.8.0",
+    "open": "^8.4.0",
     "ora": "^6.1.2",
     "pagedjs-cli": "^0.3.0",
     "semver": "^7.3.8",

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -41,8 +41,8 @@ export default class EpubCommand extends Command {
 
     const input = path.join(projectRoot, paths.epub)
 
-    if (fs.existsSync(!input)) {
-      console.error(`Unable to find Epub input.\nPlease first run the 'quire build' command.`)
+    if (!fs.existsSync(input)) {
+      console.error(`Unable to find Epub input at ${input}\nPlease first run the 'quire build' command.`)
       return
     }
 

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -49,9 +49,9 @@ export default class EpubCommand extends Command {
     const output = path.join(projectRoot, `${options.lib}.epub`)
 
     const epubLib = await libEpub(options.lib, { ...options.debug })
-    const epub = await epubLib(input, output, { ...options.debug })
+    await epubLib(input, output, { ...options.debug })
 
-    if (epub && options.open) open(epub)
+    if (fs.existsSync(output) && options.open) open(output)
   }
 
   /**

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -22,8 +22,8 @@ export default class EpubCommand extends Command {
     args: [],
     options: [
       [
-        '--lib <module>', 'use the specified epub library', 'epub',
-        { choices: ['epub', 'pandoc'], default: 'epub' }
+        '--lib <module>', 'use the specified epub library', 'epubjs',
+        { choices: ['epubjs', 'pandoc'], default: 'epubjs' }
       ],
       // [ '--open', 'open EPUB in default application' ],
       // [ '--debug', 'run epub with debug output' ],
@@ -46,8 +46,10 @@ export default class EpubCommand extends Command {
       return
     }
 
+    const output = path.join(projectRoot, `${options.lib}.epub`)
+
     const epubLib = await libEpub('epubjs')
-    await epubLib(input)
+    await epubLib(input, output)
   }
 
   /**

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -51,7 +51,7 @@ export default class EpubCommand extends Command {
     const epubLib = await libEpub(options.lib, { ...options.debug })
     const epub = await epubLib(input, output, { ...options.debug })
 
-    if (options.open) open(epub)
+    if (epub && options.open) open(epub)
   }
 
   /**

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -1,0 +1,63 @@
+import Command from '#src/Command.js'
+import { paths, projectRoot  } from '#lib/11ty/index.js'
+import fs from 'fs-extra'
+import libEpub from '#lib/epub/index.js'
+import open from 'open'
+import path from 'node:path'
+
+/**
+ * Quire CLI `build epub` Command
+ *
+ * Generate EPUB from Eleventy `build` output.
+ *
+ * @class      EpubCommand
+ * @extends    {Command}
+ */
+export default class EpubCommand extends Command {
+  static definition = {
+    name: 'epub',
+    description: 'Generate publication EPUB',
+    summary: 'run build epub',
+    version: '1.0.0',
+    args: [],
+    options: [
+      [
+        '--lib <module>', 'use the specified epub library', 'epub',
+        { choices: ['epub', 'pandoc'], default: 'epub' }
+      ],
+      // [ '--open', 'open EPUB in default application' ],
+      // [ '--debug', 'run epub with debug output' ],
+    ],
+  }
+
+  constructor() {
+    super(EpubCommand.definition)
+  }
+
+  async action(options, command) {
+    if (options.debug) {
+      console.debug('[CLI] Command \'%s\' called with options %o', this.name(), options)
+    }
+
+    const input = path.join(projectRoot, paths.epub)
+
+    if (fs.existsSync(!input)) {
+      console.error(`Unable to find Epub input.\nPlease first run the 'quire build' command.`)
+      return
+    }
+
+    const epubLib = await libEpub('epubjs')
+    await epubLib(input)
+  }
+
+  /**
+   * test if build site has already be run and output can be reused
+   * @todo
+   */
+  preAction(command) {
+    const options = command.opts()
+    if (options.debug) {
+      console.debug('[CLI] Calling \'epub\' command pre-action with options', options)
+    }
+  }
+}

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -48,7 +48,7 @@ export default class EpubCommand extends Command {
 
     const output = path.join(projectRoot, `${options.lib}.epub`)
 
-    const epubLib = await libEpub('epubjs', { ...options.debug })
+    const epubLib = await libEpub(options.lib, { ...options.debug })
     const epub = await epubLib(input, output, { ...options.debug })
 
     if (options.open) open(epub)

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -25,8 +25,8 @@ export default class EpubCommand extends Command {
         '--lib <module>', 'use the specified epub library', 'epubjs',
         { choices: ['epubjs', 'pandoc'], default: 'epubjs' }
       ],
-      // [ '--open', 'open EPUB in default application' ],
-      // [ '--debug', 'run epub with debug output' ],
+      [ '--open', 'open EPUB in default application' ],
+      [ '--debug', 'run epub with debug output' ],
     ],
   }
 
@@ -48,8 +48,10 @@ export default class EpubCommand extends Command {
 
     const output = path.join(projectRoot, `${options.lib}.epub`)
 
-    const epubLib = await libEpub('epubjs')
-    await epubLib(input, output)
+    const epubLib = await libEpub('epubjs', { ...options.debug })
+    const epub = await epubLib(input, output, { ...options.debug })
+
+    if (options.open) open(epub)
   }
 
   /**

--- a/packages/cli/src/helpers/clean.js
+++ b/packages/cli/src/helpers/clean.js
@@ -11,6 +11,7 @@ export async function clean (projectRoot, paths, options = {}) {
   const pathsToClean = [
     path.join(projectRoot, paths.epub),
     path.join(projectRoot, paths.output),
+    path.join(projectRoot, '*.epub'),
   ]
 
   /**

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -1,4 +1,4 @@
-import epub from 'epubjs'
+// import epub from 'epubjs'
 
 /**
  * A façade module for the EPUB.js library

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -4,6 +4,6 @@ import epub from 'epubjs'
  * A façade module for the EPUB.js library
  * @see https://github.com/futurepress/epub.js
  */
-export default async (input, options) => {
+export default async (input, output, options) => {
   console.info('[CLI:lib/epubjs] integration is not yet implemented.')
 }

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -5,5 +5,5 @@
  * @see https://github.com/futurepress/epub.js
  */
 export default async (input, output, options) => {
-  console.info('[CLI:lib/epubjs] integration wiht epub.js is not yet implemented.')
+  console.info('[CLI:lib/epubjs] integration with epub.js is not yet implemented.')
 }

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -5,5 +5,5 @@
  * @see https://github.com/futurepress/epub.js
  */
 export default async (input, output, options) => {
-  console.info('[CLI:lib/epubjs] integration is not yet implemented.')
+  console.info('[CLI:lib/epubjs] integration wiht epub.js is not yet implemented.')
 }

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -5,5 +5,5 @@ import epub from 'epubjs'
  * @see https://github.com/futurepress/epub.js
  */
 export default async (input, options) => {
-  console.info('[CLI:lib/epub] epub.js integration is not yet implemented.')
+  console.info('[CLI:lib/epubjs] integration is not yet implemented.')
 }

--- a/packages/cli/src/lib/epub/index.js
+++ b/packages/cli/src/lib/epub/index.js
@@ -29,6 +29,6 @@ export default async (lib = 'epubjs', options = {}) => {
 
   return async (input, output, options = {}) => {
     console.info(`[CLI:lib/epub] generating EPUB using ${lib}`)
-    return await epubLib(input, options)
+    return await epubLib(input, output, options)
   }
 }

--- a/packages/cli/src/lib/epub/pandoc.js
+++ b/packages/cli/src/lib/epub/pandoc.js
@@ -7,7 +7,7 @@ import which from '#helpers/which.js'
  * A façade module for interacting with Pandoc CLI.
  * @see https://pandoc.org/MANUAL.html#general-options
  */
-export default async (input, options) => {
+export default async (input, output, options) => {
   which('pandoc')
 
   const inputDir = path.join(projectRoot, paths.epub)
@@ -15,7 +15,7 @@ export default async (input, options) => {
   const defaults = [
     `--from=html-native_divs+native_spans`,
     `--to=epub ${path.join(inputDir, 'epub.xhtml')}`,
-    `--output=${path.join(projectRoot, `pandoc.epub`)}`,
+    `--output=${output}`,
     // `--epub-metadata=${path.join(inputDir, 'dc.xml')}`,
     // `--epub-cover-image=${coverImage}`,
     // `--template=${path.join(inputDir, 'template.xhtml')}`,

--- a/packages/cli/src/lib/epub/pandoc.js
+++ b/packages/cli/src/lib/epub/pandoc.js
@@ -1,7 +1,20 @@
 import { execa } from 'execa'
+import fs from 'fs-extra'
 import path from 'node:path'
 import paths, { projectRoot } from '#lib/11ty/paths.js'
 import which from '#helpers/which.js'
+
+/**
+ * Filter directory entries for XHTML files
+ *
+ * @param    {fs.Dirent}  dirent  directory entry
+ * @return   {fs.Dirent}  XHTML entries
+ */
+const xhtmlFiles = (dirent) => {
+  const stats = fs.lstatSync(dirent)
+  const { ext } = path.parse(dirent)
+  return stats.isFile() && ext === '.xhtml'
+}
 
 /**
  * A façade module for interacting with Pandoc CLI.
@@ -10,20 +23,20 @@ import which from '#helpers/which.js'
 export default async (input, output, options) => {
   which('pandoc')
 
-  const inputDir = path.join(projectRoot, paths.epub)
+  const inputs = fs.readdirSync(input)
+    .map((entry) => path.join(input, entry))
+    .filter(xhtmlFiles)
 
-  const defaults = [
+  const cmdOptions = [
     `--from=html-native_divs+native_spans`,
-    `--to=epub ${path.join(inputDir, 'epub.xhtml')}`,
+    `--to=epub ${inputs.join('\u0020')}`,
     `--output=${output}`,
-    // `--epub-metadata=${path.join(inputDir, 'dc.xml')}`,
+    // `--epub-metadata=${path.join(input, 'dc.xml')}`,
     // `--epub-cover-image=${coverImage}`,
-    // `--template=${path.join(inputDir, 'template.xhtml')}`,
-    `--css=${path.join(inputDir, '_assets', 'epub.css')}`,
+    // `--template=${path.join(input, 'template.xhtml')}`,
+    `--css=${path.join(input, '_assets', 'epub.css')}`,
     `--standalone`
   ]
 
-  const cmdOptions = Object.assign(defaults, options)
-  const { stderror, stdout } = execa('pandoc', cmdOptions)
-  return { stderror, stdout }
+  await execa('pandoc', cmdOptions)
 }

--- a/packages/cli/src/lib/epub/pandoc.js
+++ b/packages/cli/src/lib/epub/pandoc.js
@@ -29,14 +29,14 @@ export default async (input, output, options) => {
 
   const cmdOptions = [
     `--from=html-native_divs+native_spans`,
-    `--to=epub ${inputs.join('\u0020')}`,
+    `--to=epub`,
     `--output=${output}`,
     // `--epub-metadata=${path.join(input, 'dc.xml')}`,
     // `--epub-cover-image=${coverImage}`,
     // `--template=${path.join(input, 'template.xhtml')}`,
     `--css=${path.join(input, '_assets', 'epub.css')}`,
-    `--standalone`
+    `--standalone`,
   ]
 
-  await execa('pandoc', cmdOptions)
+  await execa('pandoc', [...cmdOptions, ...inputs])
 }


### PR DESCRIPTION
## Added

- `quire-cli` `epub` command to build the publication EPUB.

## Caveats

Currently only a façade module for Pandoc is implemented, to generate an epub run

```shell
❯ quire epub --lib=pandoc
```

Integration with the `epub.js` library is not yet implemented.


