### PR TITLE
quire pdf command

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -25,7 +25,7 @@
         "loglevel": "^1.8.0",
         "open": "^8.4.0",
         "ora": "^6.1.2",
-        "pagedjs-cli": "^0.3.0",
+        "pagedjs-cli": "^0.3.1",
         "semver": "^7.3.8",
         "simple-git": "^3.15.0",
         "update-notifier": "^6.0.2"
@@ -7906,9 +7906,9 @@
       }
     },
     "node_modules/pagedjs-cli": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pagedjs-cli/-/pagedjs-cli-0.3.0.tgz",
-      "integrity": "sha512-SiG2M60r3KMHBoOUu3kaV9fRDLlYefoNijkf1lfxLwNmNaixgZOqRxCQ+2Uo1Ml7PRNYk+bvcsBAoJacprLg3g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pagedjs-cli/-/pagedjs-cli-0.3.1.tgz",
+      "integrity": "sha512-L6SOiISUPHLkYKGkidxZSh2FOeizv7tv0TT6FNH2XydreM6KMoSGqQRxJWYEUzYWb37GStC7pQp1uimpAbAUZg==",
       "dependencies": {
         "commander": "^9.3.0",
         "express": "^4.18.1",
@@ -15210,9 +15210,9 @@
       }
     },
     "pagedjs-cli": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pagedjs-cli/-/pagedjs-cli-0.3.0.tgz",
-      "integrity": "sha512-SiG2M60r3KMHBoOUu3kaV9fRDLlYefoNijkf1lfxLwNmNaixgZOqRxCQ+2Uo1Ml7PRNYk+bvcsBAoJacprLg3g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pagedjs-cli/-/pagedjs-cli-0.3.1.tgz",
+      "integrity": "sha512-L6SOiISUPHLkYKGkidxZSh2FOeizv7tv0TT6FNH2XydreM6KMoSGqQRxJWYEUzYWb37GStC7pQp1uimpAbAUZg==",
       "requires": {
         "commander": "^9.3.0",
         "express": "^4.18.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
     "loglevel": "^1.8.0",
     "open": "^8.4.0",
     "ora": "^6.1.2",
-    "pagedjs-cli": "^0.3.0",
+    "pagedjs-cli": "^0.3.1",
     "semver": "^7.3.8",
     "simple-git": "^3.15.0",
     "update-notifier": "^6.0.2"

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -1,0 +1,64 @@
+import Command from '#src/Command.js'
+import { paths, projectRoot  } from '#lib/11ty/index.js'
+import fs from 'fs-extra'
+import libPdf from '#lib/pdf/index.js'
+import open from 'open'
+import path from 'node:path'
+
+/**
+ * Quire CLI `pdf` Command
+ *
+ * Generate PDF from Eleventy `build` output.
+ *
+ * @class      PDFCommand
+ * @extends    {Command}
+ */
+export default class PDFCommand extends Command {
+  static definition = {
+    name: 'pdf',
+    description: 'Generate publication PDF',
+    summary: 'run build pdf',
+    version: '1.0.0',
+    args: [
+    ],
+    options: [
+      [
+        '--lib <module>', 'use the specified pdf module', 'pagedjs',
+        { choices: ['pagedjs', 'prince'], default: 'pagedjs' }
+      ],
+      // [ '--open', 'open PDF in default application' ],
+      // [ '--debug', 'run build with debug output to console' ],
+    ],
+  }
+
+  constructor() {
+    super(PDFCommand.definition)
+  }
+
+  async action(options, command) {
+    if (options.debug) {
+      console.debug('[CLI] Command \'%s\' called with options %o', this.name(), options)
+    }
+
+    const input = path.join(paths.output, 'pdf.html')
+
+    if (fs.existsSync(!input)) {
+      console.error(`Unable to find PDF input.\nPlease first run the 'quire build' command.`)
+      return
+    }
+
+    const pdfLib = await libPdf(options.lib)
+    await pdfLib(input)
+  }
+
+  /**
+   * test if build has already be run and output can be reused
+   * @todo
+   */
+  preAction(command) {
+    const options = command.opts()
+    if (options.debug) {
+      console.debug('[CLI] Calling \'build\' command pre-action with options', options)
+    }
+  }
+}

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -52,7 +52,13 @@ export default class PDFCommand extends Command {
 
     const pdfLib = await libPdf(options.lib, { ...options.debug })
     const pdf = await pdfLib(input, output, { ...options.debug })
-    if (options.open) open(pdf)
+
+    try {
+      if (options.open) open(pdf)
+    } catch (error) {
+      console.error(error)
+      process.exit(1)
+    }
   }
 
   /**

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -47,8 +47,10 @@ export default class PDFCommand extends Command {
       return
     }
 
+    const output = path.join(projectRoot, `${options.lib}.pdf`)
+
     const pdfLib = await libPdf(options.lib)
-    await pdfLib(input)
+    await pdfLib(input, output)
   }
 
   /**

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -26,8 +26,8 @@ export default class PDFCommand extends Command {
         '--lib <module>', 'use the specified pdf module', 'pagedjs',
         { choices: ['pagedjs', 'prince'], default: 'pagedjs' }
       ],
-      // [ '--open', 'open PDF in default application' ],
-      // [ '--debug', 'run build with debug output to console' ],
+      [ '--open', 'open PDF in default application' ],
+      [ '--debug', 'run build with debug output to console' ],
     ],
   }
 
@@ -49,8 +49,9 @@ export default class PDFCommand extends Command {
 
     const output = path.join(projectRoot, `${options.lib}.pdf`)
 
-    const pdfLib = await libPdf(options.lib)
-    await pdfLib(input, output)
+    const pdfLib = await libPdf(options.lib, { ...options.debug })
+    const pdf = await pdfLib(input, output, { ...options.debug })
+    if (options.open) open(pdf)
   }
 
   /**

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -40,10 +40,10 @@ export default class PDFCommand extends Command {
       console.debug('[CLI] Command \'%s\' called with options %o', this.name(), options)
     }
 
-    const input = path.join(paths.output, 'pdf.html')
+    const input = path.join(projectRoot, paths.output, 'pdf.html')
 
-    if (fs.existsSync(!input)) {
-      console.error(`Unable to find PDF input.\nPlease first run the 'quire build' command.`)
+    if (!fs.existsSync(input)) {
+      console.error(`Unable to find PDF input at ${input}\nPlease first run the 'quire build' command.`)
       return
     }
 

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -4,6 +4,7 @@ import fs from 'fs-extra'
 import libPdf from '#lib/pdf/index.js'
 import open from 'open'
 import path from 'node:path'
+// import testcwd from '#helpers/test-cwd.js'
 
 /**
  * Quire CLI `pdf` Command
@@ -55,13 +56,9 @@ export default class PDFCommand extends Command {
   }
 
   /**
-   * test if build has already be run and output can be reused
-   * @todo
+   * @todo test if build has already be run and output can be reused
    */
   preAction(command) {
-    const options = command.opts()
-    if (options.debug) {
-      console.debug('[CLI] Calling \'build\' command pre-action with options', options)
-    }
+    // testcwd(command)
   }
 }

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -51,10 +51,10 @@ export default class PDFCommand extends Command {
     const output = path.join(projectRoot, `${options.lib}.pdf`)
 
     const pdfLib = await libPdf(options.lib, { ...options.debug })
-    const pdf = await pdfLib(input, output, { ...options.debug })
+    await pdfLib(input, output, { ...options.debug })
 
     try {
-      if (options.open) open(pdf)
+      if (fs.existsSync(output) && options.open) open(output)
     } catch (error) {
       console.error(error)
       process.exit(1)

--- a/packages/cli/src/helpers/clean.js
+++ b/packages/cli/src/helpers/clean.js
@@ -11,6 +11,7 @@ export async function clean (projectRoot, paths, options = {}) {
   const pathsToClean = [
     path.join(projectRoot, paths.epub),
     path.join(projectRoot, paths.output),
+    path.join(projectRoot, '*.pdf'),
   ]
 
   /**

--- a/packages/cli/src/lib/epub/index.js
+++ b/packages/cli/src/lib/epub/index.js
@@ -9,26 +9,28 @@ const __dirname = path.dirname(__filename)
  * A façade delegation module for EPUB libraries
  */
 export default async (lib = 'epubjs', options = {}) => {
-  let libPath
+  let libName, libPath
 
   switch (lib.toLowerCase()) {
     case 'epubjs': {
+      libName = 'Epub.js'
       libPath = path.join(__dirname, 'epub.js')
       break
     }
     case 'pandoc': {
+      libName = 'Pandoc'
       libPath = path.join(__dirname, 'pandoc.js')
       break
     }
     default:
-      console.error('[CLI:lib/epub] Unrecognized EPUB library ${lib}')
+      console.error(`[CLI:lib/pdf] Unrecognized EPUB library '${lib}'`)
       return
   }
 
   const { default: epubLib } = await dynamicImport(libPath)
 
   return async (input, output, options = {}) => {
-    console.info(`[CLI:lib/epub] generating EPUB using ${lib}`)
+    console.info(`[CLI:lib/epub] generating EPUB using ${libName}`)
     return await epubLib(input, options)
   }
 }

--- a/packages/cli/src/lib/pdf/index.js
+++ b/packages/cli/src/lib/pdf/index.js
@@ -31,6 +31,6 @@ export default async (lib = 'pagedjs', options = {}) => {
 
   return async (input, output, options = {}) => {
     console.info(`[CLI:lib/pdf] generating PDF using ${lib}`)
-    return await pdfLib(input, options)
+    return await pdfLib(input, output, options)
   }
 }

--- a/packages/cli/src/lib/pdf/index.js
+++ b/packages/cli/src/lib/pdf/index.js
@@ -9,28 +9,30 @@ const __dirname = path.dirname(__filename)
  * A façade delegation module for PDF generation libraries
  */
 export default async (lib = 'pagedjs', options = {}) => {
-  let libPath
+  let libName, libPath
 
   switch (lib.toLowerCase()) {
     case 'paged':
     case 'pagedjs': {
+      libName = 'Paged.js'
       libPath = path.join(__dirname, 'paged.js')
       break
     }
     case 'prince':
     case 'princexml': {
+      libName = 'Prince'
       libPath = path.join(__dirname, 'prince.js')
       break
     }
     default:
-      console.error('[CLI:lib/pdf] Unrecognized PDF library ${lib}')
+      console.error(`[CLI:lib/pdf] Unrecognized PDF library '${lib}'`)
       return
   }
 
   const { default: pdfLib } = await dynamicImport(libPath)
 
   return async (input, output, options = {}) => {
-    console.info(`[CLI:lib/pdf] generating PDF using ${lib}`)
+    console.info(`[CLI:lib/pdf] generating PDF using ${libName}`)
     return await pdfLib(input, output, options)
   }
 }

--- a/packages/cli/src/lib/pdf/paged.js
+++ b/packages/cli/src/lib/pdf/paged.js
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
  * A façade module for interacting with Paged.js
  * @see https://gitlab.coko.foundation/pagedjs/
  */
-export default async (input, output, options) => {
+export default async (input, output, options = {}) => {
   /**
    * Configure the Paged.js Printer options
    * @see https://gitlab.coko.foundation/pagedjs/pagedjs-cli/-/blob/main/src/cli.js

--- a/packages/cli/src/lib/pdf/paged.js
+++ b/packages/cli/src/lib/pdf/paged.js
@@ -25,8 +25,10 @@ export default async (input, options) => {
   }
 
   try {
-    return await printer.pdf(input, pdfOptions)
+    console.info(`[CLI:lib/pdf/pagedjs] printing ${input}`)
+    const file = await printer.pdf(input, pdfOptions)
+    // @todo write file
   } catch (ERR_FILE_NOT_FOUND) {
-    console.error(`[CLI:lib/pdf] input file ${input} could not be found`)
+    console.error(`[CLI:lib/pdf/pagedjs] file not found ${input}`)
   }
 }

--- a/packages/cli/src/lib/pdf/paged.js
+++ b/packages/cli/src/lib/pdf/paged.js
@@ -20,9 +20,12 @@ export default async (input, output, options = {}) => {
   /**
    * Configure the Paged.js PDF options
    * @see
+   *
+   * @todo verify options before setting them
+   * @todo catch errors thrown by the printer
    */
   const pdfOptions = {
-    outlineTags: options.outlineTags || 'h1',
+    outlineTags: options.outlineTags || ['h1'],
   }
 
   try {

--- a/packages/cli/src/lib/pdf/paged.js
+++ b/packages/cli/src/lib/pdf/paged.js
@@ -1,10 +1,11 @@
 import Printer from 'pagedjs-cli'
+import fs from 'fs-extra'
 
 /**
  * A façade module for interacting with Paged.js
  * @see https://gitlab.coko.foundation/pagedjs/
  */
-export default async (input, options) => {
+export default async (input, output, options) => {
   /**
    * Configure the Paged.js Printer options
    * @see https://gitlab.coko.foundation/pagedjs/pagedjs-cli/-/blob/main/src/cli.js
@@ -27,7 +28,11 @@ export default async (input, options) => {
   try {
     console.info(`[CLI:lib/pdf/pagedjs] printing ${input}`)
     const file = await printer.pdf(input, pdfOptions)
-    // @todo write file
+      .catch((error) => console.error(error))
+
+    if (file && output) {
+      fs.writeFile(output, file, (error) => { if (error) throw error })
+    }
   } catch (ERR_FILE_NOT_FOUND) {
     console.error(`[CLI:lib/pdf/pagedjs] file not found ${input}`)
   }

--- a/packages/cli/src/lib/pdf/prince.js
+++ b/packages/cli/src/lib/pdf/prince.js
@@ -4,7 +4,7 @@ import which from '#helpers/which.js'
 /**
  * A façade module for interacting with Prince CLI.
  */
-export default async (input, output, options) => {
+export default async (input, output, options = {}) => {
   which('prince')
 
   const defaults = [

--- a/packages/cli/src/lib/pdf/prince.js
+++ b/packages/cli/src/lib/pdf/prince.js
@@ -1,15 +1,12 @@
 import { execa } from 'execa'
-import path from 'node:path'
-import paths, { projectRoot } from '#lib/11ty/paths.js'
 import which from '#helpers/which.js'
 
 /**
  * A façade module for interacting with Prince CLI.
  */
-export default async (input, options) => {
+export default async (input, output, options) => {
   which('prince')
 
-  const output = path.join(projectRoot, `prince.pdf`)
   const defaults = [
     `--outline-tags 'h1'`,
     `--output ${output}`,

--- a/packages/cli/src/lib/pdf/prince.js
+++ b/packages/cli/src/lib/pdf/prince.js
@@ -2,7 +2,8 @@ import { execa } from 'execa'
 import which from '#helpers/which.js'
 
 /**
- * A façade module for interacting with Prince CLI.
+ * A façade module for interacting with the Prince CLI.
+ * @see https://www.princexml.com/doc/command-line/
  */
 export default async (input, output, options = {}) => {
   which('prince')

--- a/packages/cli/src/lib/pdf/prince.js
+++ b/packages/cli/src/lib/pdf/prince.js
@@ -7,11 +7,10 @@ import which from '#helpers/which.js'
 export default async (input, output, options = {}) => {
   which('prince')
 
-  const defaults = [
-    `--outline-tags 'h1'`,
-    `--output ${output}`,
+  const cmdOptions = [
+    `--output=${output}`,
   ]
-  const cmdOptions = Object.assign(defaults, options)
-  const { stderror, stdout } = execa('prince', [...cmdOptions, input])
+
+  const { stderror, stdout } = await execa('prince', [...cmdOptions, input])
   return { stderror, stdout }
 }


### PR DESCRIPTION

## Added

- `quire-cli` `pdf` command to build the publication PDF.

## Caveats

The `quire pdf` currently generates the PDF file though the Paged.js `printer` instance hangs on an error (see pull-request comments below).


