### PR TITLE
Test current working directory is a project

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,6 +1,7 @@
 import Command from '#src/Command.js'
 import { api, cli, paths, projectRoot  } from '#lib/11ty/index.js'
 import { clean } from '#helpers/clean.js'
+import testcwd from '#helpers/test-cwd.js'
 
 /**
  * Quire CLI `build` Command
@@ -56,6 +57,8 @@ export default class BuildCommand extends Command {
   }
 
   preAction(command) {
+    testcwd(command)
+
     const options = command.opts()
     if (options.debug) {
       console.debug('[CLI] Calling \'build\' command pre-action with options', options)

--- a/packages/cli/src/commands/clean.js
+++ b/packages/cli/src/commands/clean.js
@@ -1,6 +1,7 @@
 import Command from '#src/Command.js'
 import { clean } from '#helpers/clean.js'
 import { paths, projectRoot  } from '#lib/11ty/index.js'
+import testcwd from '#helpers/test-cwd.js'
 
 /**
  * Quire CLI `clean` Command
@@ -52,5 +53,9 @@ export default class CleanCommand extends Command {
       : 'no files to delete'
 
     console.debug(`[CLI] ${message} ${deletedPaths}`)
+  }
+
+  preAction(command) {
+    testcwd(command)
   }
 }

--- a/packages/cli/src/commands/preview.js
+++ b/packages/cli/src/commands/preview.js
@@ -1,5 +1,6 @@
 import Command from '#src/Command.js'
 import { api, cli, paths, projectRoot  } from '#lib/11ty/index.js'
+import testcwd from '#helpers/test-cwd.js'
 
 /**
  * Quire CLI `preview` Command
@@ -52,5 +53,9 @@ export default class PreviewCommand extends Command {
       console.debug('[CLI] running eleventy using lib/11ty api')
       api.serve(options)
     }
+  }
+
+  preAction(command) {
+    testcwd(command)
   }
 }

--- a/packages/cli/src/commands/version.js
+++ b/packages/cli/src/commands/version.js
@@ -1,5 +1,7 @@
 import Command from '#src/Command.js'
+import { paths, projectRoot  } from '#lib/11ty/index.js'
 import * as quire from '#lib/quire/index.js'
+import testcwd from '#helpers/test-cwd.js'
 
 /**
  * Quire CLI `version` Command
@@ -21,7 +23,7 @@ export default class VersionCommand extends Command {
       [ '<version>', 'the local quire version to use' ],
     ],
     options: [
-      [ '-g', '--global', 'set the quire version globally' ],
+      // [ '-g', '--global', 'set the quire version globally' ],
     ],
   }
 
@@ -29,9 +31,13 @@ export default class VersionCommand extends Command {
     super(VersionCommand.definition)
   }
 
-  async action(path, starter, options = {}) {
+  action(args, options = {}) {
     if (options.debug) {
       console.info('Command \'%s\' called with options %o', this.name, options)
     }
+  }
+
+  preAction(command) {
+    testcwd(command)
   }
 }

--- a/packages/cli/src/helpers/is-quire.js
+++ b/packages/cli/src/helpers/is-quire.js
@@ -20,8 +20,8 @@ const QUIRE_DOT_FILES = Object.freeze([
  * @param    {String}   dirpath   path to a local directory
  * @return   {Promise}
  */
-export function isQuire (dirpath) {
+export default function (dirpath) {
   return fs.readdirSync(dirpath)
-    .includes((file) => QUIRE_DOT_FILES.includes(file))
+    .find((entry) => QUIRE_DOT_FILES.includes(entry))
 }
 

--- a/packages/cli/src/helpers/test-cwd.js
+++ b/packages/cli/src/helpers/test-cwd.js
@@ -6,7 +6,7 @@ import isQuire from '#helpers/is-quire.js'
  * @param  {Command}  command  the command from which testcwd was called
  */
 export default (command) => {
-  const message = `[CLI] ${ command ? command.name() : '' } command must be run from a Quire project directory`
+  const message = `[CLI] ${ command ? command.name() : '' } command must be run while in a Quire project directory. Use 'cd' to navigate to your project directory and re-run the 'quire ${ command ? command.name() : '' }' command.`
 
   if (!isQuire(process.cwd())) {
     console.error(message)

--- a/packages/cli/src/helpers/test-cwd.js
+++ b/packages/cli/src/helpers/test-cwd.js
@@ -1,0 +1,15 @@
+import isQuire from '#helpers/is-quire.js'
+
+/**
+ * Test current working directory is a Quire project directory
+ *
+ * @param  {Command}  command  the command from which testcwd was called
+ */
+export default (command) => {
+  const message = `[CLI] ${ command ? command.name() : '' } command must be run from a Quire project directory`
+
+  if (!isQuire(process.cwd())) {
+    console.error(message)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Outputs a console message when a `quire` command must be run from the project directory.

## Added

- CLI helper to test the current working directory is a project root or exit the process with a failure code `1`.

## Changed

- CLI commands `build`, `clean`, `preview`, `version` run `testcwd` in a `preAction`

