### PR TITLE
Set EleventyWatch to ignore build artifacts

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -271,10 +271,20 @@ module.exports = function(eleventyConfig) {
   /**
    * Watch the following additional files for changes and rerun server
    * @see https://www.11ty.dev/docs/config/#add-your-own-watch-targets
+   * @see https://www.11ty.dev/docs/watch-serve/#ignore-watching-files
    */
   eleventyConfig.addWatchTarget('./**/*.css')
   eleventyConfig.addWatchTarget('./**/*.js')
   eleventyConfig.addWatchTarget('./**/*.scss')
+
+  /**
+   * Ignore changes to programmatic build artifacts
+   * @see https://www.11ty.dev/docs/watch-serve/#ignore-watching-files
+   * @todo refactor to move these statements to the tranform plugins
+   */
+  eleventyConfig.watchIgnores.add('_epub')
+  eleventyConfig.watchIgnores.add('_pdf')
+  eleventyConfig.watchIgnores.add('_temp')
 
   return {
     /**

--- a/packages/11ty/.gitignore
+++ b/packages/11ty/.gitignore
@@ -1,5 +1,6 @@
 # Eleventy build artifacts
 _epub/
+_pdf/
 _site/
 _temp/
 


### PR DESCRIPTION
Configures eleventy to ignore changes to programmatic build artifacts,
for example the _epub directory, when running preview; this prevents
content changes that have build artifacts from causing an endless loop.

Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [ ] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [ ] I have made my changes in a new branch and not directly in the main branch

- [ ] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?



### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.


### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

