### PR TITLE
Output projectRoot and paths only when debugging

### DIFF
--- a/packages/cli/src/lib/11ty/api.js
+++ b/packages/cli/src/lib/11ty/api.js
@@ -13,9 +13,9 @@ import paths, { eleventyRoot, projectRoot } from './paths.js'
 const factory = async (options = {}) => {
   const { config, input, output } = paths
 
-  console.info(`[CLI:11ty] projectRoot ${projectRoot}`)
-
-  console.debug('[CLI:11ty] %o', paths)
+  if (options.debug) {
+    console.debug('[CLI:11ty] projectRoot %s\n%o', projectRoot, paths)
+  }
 
   /**
    * Dynamically import the correct version of Eleventy

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -11,9 +11,9 @@ import paths, { eleventyRoot, projectRoot } from './paths.js'
 const factory = (options = {}) => {
   const { config, input, output } = paths
 
-  console.info(`[CLI:11ty] projectRoot ${projectRoot}`)
-
-  console.debug('[CLI:11ty] %o', paths)
+  if (options.debug) {
+    console.debug('[CLI:11ty] projectRoot %s\n%o', projectRoot, paths)
+  }
 
   /**
    * Use the version of Eleventy installed to `lib/quire/versions`


### PR DESCRIPTION
Update Quire CLI output of project paths only when using the `--debug` flag.