### PR TITLE
Fix: Widows permissions error when running quire build

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 import cli from '#src/main.js'
 import packageConfig from '#root/package.json' assert { type: 'json' }


### PR DESCRIPTION
## Changed

- Add env command flag to `bin/cli` shebang so that parameters are passed to node; fixes file permission errors on Windows

 