### PR TITLE
Docs/ Remo `quire preview --verbose` from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -59,12 +59,12 @@ body:
   id: logs
   attributes:
     label: Relevant Terminal/Shell output
-    description: Please copy and paste all relevant messaging from your Terminal/Shell. If you encountered a preview issue run `quire preview --verbose` and inclue the output below.
+    description: Please copy and paste all relevant messaging from your Terminal/Shell.
     render: shell
 - type: textarea
   id: supporting_info
   attributes:
     label: Supporting Information
-    description: If you have additional files that would be useful in describing the issue (Terminal output, screenshots, Quire output files, related issue) attach them by dragging and dropping in the comments below.
+    description: If you have additional files that would be useful in describing the issue (Screenshots, Quire output files, related issue) attach them by dragging and dropping in the comments below.
   validations:
     required: false


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [existing issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

No

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Remove reference to old Hugo command in bug report form

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Removed `quire preview --verbose` since this is now the default behavior. 

### Does this pull request necessitate changes to Quire's documentation?

No

### Include screenshots of before/after if applicable.



### Additional Comments

