### PR TITLE
Fix options object passed to cli libs

### DIFF
--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -48,8 +48,8 @@ export default class EpubCommand extends Command {
 
     const output = path.join(projectRoot, `${options.lib}.epub`)
 
-    const epubLib = await libEpub(options.lib, { ...options.debug })
-    await epubLib(input, output, { ...options.debug })
+    const epubLib = await libEpub(options.lib, { debug: options.debug })
+    await epubLib(input, output, { debug: options.debug })
 
     if (fs.existsSync(output) && options.open) open(output)
   }

--- a/packages/cli/src/commands/epub.js
+++ b/packages/cli/src/commands/epub.js
@@ -49,7 +49,7 @@ export default class EpubCommand extends Command {
     const output = path.join(projectRoot, `${options.lib}.epub`)
 
     const epubLib = await libEpub(options.lib, { debug: options.debug })
-    await epubLib(input, output, { debug: options.debug })
+    await epubLib(input, output)
 
     if (fs.existsSync(output) && options.open) open(output)
   }

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -51,7 +51,7 @@ export default class PDFCommand extends Command {
     const output = path.join(projectRoot, `${options.lib}.pdf`)
 
     const pdfLib = await libPdf(options.lib, { debug: options.debug })
-    await pdfLib(input, output, { debug: options.debug })
+    await pdfLib(input, output)
 
     try {
       if (fs.existsSync(output) && options.open) open(output)

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -50,8 +50,8 @@ export default class PDFCommand extends Command {
 
     const output = path.join(projectRoot, `${options.lib}.pdf`)
 
-    const pdfLib = await libPdf(options.lib, { ...options.debug })
-    await pdfLib(input, output, { ...options.debug })
+    const pdfLib = await libPdf(options.lib, { debug: options.debug })
+    await pdfLib(input, output, { debug: options.debug })
 
     try {
       if (fs.existsSync(output) && options.open) open(output)

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -7,10 +7,11 @@ import { pathToFileURL } from 'node:url'
  * @see https://github.com/futurepress/epubjs-cli
  */
 export default async (input, output, options) => {
-
   try {
     console.info(`[CLI:lib/epub/epubjs] Generating ePub from ${input}`)
-    const url = pathToFileURL(`${input}/manifest.json`).href
+
+    const url = pathToFileURL(`${input}/manifest.json`).toString()
+
     const epub = await new ManifestToEpub(url)
       .catch((error) => console.error(error))
 
@@ -23,5 +24,4 @@ export default async (input, output, options) => {
   } catch (ERR_FILE_NOT_FOUND) {
     console.error(`[CLI:lib/epub/epubjs] file not found ${input}`)
   }
-
 }

--- a/packages/cli/src/lib/epub/epub.js
+++ b/packages/cli/src/lib/epub/epub.js
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url'
  * A façade module for the EPUB.js library
  * @see https://github.com/futurepress/epubjs-cli
  */
-export default async (input, output, options) => {
+export default async (input, output, options = {}) => {
   try {
     console.info(`[CLI:lib/epub/epubjs] Generating ePub from ${input}`)
 

--- a/packages/cli/src/lib/epub/index.js
+++ b/packages/cli/src/lib/epub/index.js
@@ -8,29 +8,31 @@ const __dirname = path.dirname(__filename)
 /**
  * A façade delegation module for EPUB libraries
  */
-export default async (lib = 'epubjs', options = {}) => {
-  let libName, libPath
+export default async (name = 'epubjs', options = {}) => {
+  const lib = { name, options, path }
 
   switch (lib.toLowerCase()) {
     case 'epubjs': {
-      libName = 'Epub.js'
-      libPath = path.join(__dirname, 'epub.js')
+      lib.name = 'Epub.js'
+      lib.options = {}
+      lib.path = path.join(__dirname, 'epub.js')
       break
     }
     case 'pandoc': {
-      libName = 'Pandoc'
-      libPath = path.join(__dirname, 'pandoc.js')
+      lib.name = 'Pandoc'
+      lib.options = {}
+      lib.path = path.join(__dirname, 'pandoc.js')
       break
     }
     default:
-      console.error(`[CLI:lib/pdf] Unrecognized EPUB library '${lib}'`)
+      console.error(`[CLI:lib/pdf] Unrecognized EPUB library '${name}'`)
       return
   }
 
-  const { default: epubLib } = await dynamicImport(libPath)
+  const { default: epubLib } = await dynamicImport(lib.path)
 
-  return async (input, output, options = {}) => {
-    console.info(`[CLI:lib/epub] generating EPUB using ${libName}`)
-    return await epubLib(input, output, options)
+  return async (input, output) => {
+    console.info(`[CLI:lib/epub] generating EPUB using ${lib.name}`)
+    return await epubLib(input, output, lib.options)
   }
 }

--- a/packages/cli/src/lib/epub/pandoc.js
+++ b/packages/cli/src/lib/epub/pandoc.js
@@ -20,7 +20,7 @@ const xhtmlFiles = (dirent) => {
  * A façade module for interacting with Pandoc CLI.
  * @see https://pandoc.org/MANUAL.html#general-options
  */
-export default async (input, output, options) => {
+export default async (input, output, options = {}) => {
   which('pandoc')
 
   const inputs = fs.readdirSync(input)

--- a/packages/cli/src/lib/pdf/index.js
+++ b/packages/cli/src/lib/pdf/index.js
@@ -22,7 +22,7 @@ export default async (name = 'pagedjs', options = {}) => {
     case 'prince':
     case 'princexml': {
       lib.name = 'Prince'
-      lib.options = { debug: options.debug }
+      lib.options = { debug: options.debug, verbose: options.verbose }
       lib.path = path.join(__dirname, 'prince.js')
       break
     }

--- a/packages/cli/src/lib/pdf/index.js
+++ b/packages/cli/src/lib/pdf/index.js
@@ -8,31 +8,33 @@ const __dirname = path.dirname(__filename)
 /**
  * A façade delegation module for PDF generation libraries
  */
-export default async (lib = 'pagedjs', options = {}) => {
-  let libName, libPath
+export default async (name = 'pagedjs', options = {}) => {
+  const lib = { name, options, path }
 
-  switch (lib.toLowerCase()) {
+  switch (name.toLowerCase()) {
     case 'paged':
     case 'pagedjs': {
-      libName = 'Paged.js'
-      libPath = path.join(__dirname, 'paged.js')
+      lib.name = 'Paged.js'
+      lib.options = { debug: options.debug }
+      lib.path = path.join(__dirname, 'paged.js')
       break
     }
     case 'prince':
     case 'princexml': {
-      libName = 'Prince'
-      libPath = path.join(__dirname, 'prince.js')
+      lib.name = 'Prince'
+      lib.options = { debug: options.debug }
+      lib.path = path.join(__dirname, 'prince.js')
       break
     }
     default:
-      console.error(`[CLI:lib/pdf] Unrecognized PDF library '${lib}'`)
+      console.error(`[CLI:lib/pdf] Unrecognized PDF library '${name}'`)
       return
   }
 
-  const { default: pdfLib } = await dynamicImport(libPath)
+  const { default: pdfLib } = await dynamicImport(lib.path)
 
-  return async (input, output, options = {}) => {
-    console.info(`[CLI:lib/pdf] generating PDF using ${libName}`)
-    return await pdfLib(input, output, options)
+  return async (input, output) => {
+    console.info(`[CLI:lib/pdf] generating PDF using ${lib.name}`)
+    return await pdfLib(input, output, lib.options)
   }
 }

--- a/packages/cli/src/lib/pdf/paged.js
+++ b/packages/cli/src/lib/pdf/paged.js
@@ -16,6 +16,11 @@ export default async (input, output, options = {}) => {
     enableWarnings: options.debug || false,
   }
 
+  if (options.debug) {
+    const optionsOutput = JSON.stringify(printerOptions, null, 2)
+    console.debug(`[CLI:lib/pdf/pagedjs] Printer options\n${optionsOutput}`)
+  }
+
   const printer = new Printer(printerOptions)
 
   printer.on('page', (page) => {
@@ -41,6 +46,11 @@ export default async (input, output, options = {}) => {
    */
   const pdfOptions = {
     outlineTags: options.outlineTags || ['h1'],
+  }
+
+  if (options.debug) {
+    const optionsOutput = JSON.stringify(pdfOptions, null, 2)
+    console.debug(`[CLI:lib/pdf/pagedjs] PDF options\n${optionsOutput}`)
   }
 
   try {

--- a/packages/cli/src/lib/pdf/prince.js
+++ b/packages/cli/src/lib/pdf/prince.js
@@ -8,9 +8,15 @@ import which from '#helpers/which.js'
 export default async (input, output, options = {}) => {
   which('prince')
 
+  /**
+   * @see https://www.princexml.com/doc/command-line/#options
+   */
   const cmdOptions = [
     `--output=${output}`,
   ]
+
+  if (options.debug) cmdOptions.push('--debug')
+  if (options.verbose) cmdOptions.push('--verbose')
 
   const { stderror, stdout } = await execa('prince', [...cmdOptions, input])
   return { stderror, stdout }


### PR DESCRIPTION
### Changed

- Allows the `quire-cli` `lib/epub` and `lib/pagedjs` to use cli command `options`.
- Refactors the `lib/epub` and `lib/pdf` façades to handle the concern of adapting `options` passed from cli commands to the expected options object shape for each lib.
- Output the `options` object passed to Paged.js `Printer` and to the `pdf` function when `options.debug` is `true`


