### PR TITLE
Handle null values for src

### DIFF
--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -1,5 +1,7 @@
 const { html } = require('~lib/common-tags')
 const path = require('path')
+const chalkFactory = require('~lib/chalk')
+const logger = chalkFactory('Figure Annotations UI')
 
 /**
  * Renders an image with a caption in print output
@@ -16,7 +18,9 @@ module.exports = function(eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
 
   return function(figure) {
-    const { alt, caption, credit, id, label, src='' } = figure
+    const { alt, caption, credit, id, label, src } = figure
+
+    if (!src) return ''
 
     const labelElement = figureLabel({ caption, id, label })
 

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -1,7 +1,5 @@
 const { html } = require('~lib/common-tags')
 const path = require('path')
-const chalkFactory = require('~lib/chalk')
-const logger = chalkFactory('Figure Annotations UI')
 
 /**
  * Renders an image with a caption in print output

--- a/packages/11ty/_plugins/figures/helpers/is-image-service.js
+++ b/packages/11ty/_plugins/figures/helpers/is-image-service.js
@@ -7,6 +7,7 @@ const path = require('path')
  * @return {Boolean}
  */
 module.exports = function(figure) {
-  const { src='' } = figure
+  const { src } = figure
+  if (!src) return false
   return path.parse(src) === 'info.json'
 }


### PR DESCRIPTION
Prevents preview from failing due to `null` value for `figure.src`