### PR TITLE
Fix: Missing video poster image

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -223,7 +223,11 @@ module.exports = function(eleventyConfig) {
           plugins: [
             copy({
               targets: [
-                { src: 'public/*', dest: '_site' }
+                { src: 'public/*', dest: outputDir },
+                {
+                  src: path.join(inputDir, '_assets', 'images', '*'),
+                  dest: path.join(outputDir, '_assets', 'images')
+                }
               ]
             })
           ]

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -223,7 +223,10 @@ module.exports = function(eleventyConfig) {
           plugins: [
             copy({
               targets: [
-                { src: 'public/*', dest: outputDir },
+                { 
+                  src: 'public/*', 
+                  dest: outputDir,
+                },
                 {
                   src: path.join(inputDir, '_assets', 'images', '*'),
                   dest: path.join(outputDir, '_assets', 'images')


### PR DESCRIPTION
Explicitly copy image assets using `copy` plugin in Vite config. Vite removes images not referenced in the `_site/index.html` output generated by a build, including non-IIIF print-only images such as video poster images. The print fallbacks for IIIF assets are included in the `public` directory copied on line 226.