### PR TITLE
DEV-13317: Display embedded media URLs in figure captions in print output

### DIFF
--- a/packages/11ty/_includes/components/figure/audio/element.js
+++ b/packages/11ty/_includes/components/figure/audio/element.js
@@ -23,7 +23,7 @@ module.exports = function (eleventyConfig) {
         return ''
       }
 
-      const { mediaEmbedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+      const { embedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
 
       return html`
         <iframe
@@ -31,7 +31,7 @@ module.exports = function (eleventyConfig) {
           frameborder="no"
           height="166"
           scrolling="no"
-          src="${mediaEmbedUrl}"
+          src="${embedUrl}"
           width="100%"
         ></iframe>
       `

--- a/packages/11ty/_includes/components/figure/audio/element.js
+++ b/packages/11ty/_includes/components/figure/audio/element.js
@@ -2,39 +2,6 @@ const { html } = require('~lib/common-tags')
 const chalkFactory = require('~lib/chalk')
 
 const logger = chalkFactory('Figure Video')
-
-const audioElements = {
-  soundcloud({ id, mediaId }) {
-    if (!mediaId) {
-      logger.error(`Cannot render SoundCloud component without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
-      return ''
-    }
-
-    const src = new URL('https://w.soundcloud.com/player/')
-    const params = new URLSearchParams({
-      auto_play: 'false',
-      color: encodeURIComponent('#ff5500'),
-      hide_related: 'true',
-      show_comments: 'false',
-      show_reposts: 'false',
-      show_teaser: 'false',
-      show_user: 'false',
-      url: encodeURIComponent(`https://api.soundcloud.com/tracks/${mediaId}`)
-    })
-    src.search = `?${params.toString()}`
-
-    return html`
-      <iframe
-        allow="autoplay"
-        frameborder="no"
-        height="166"
-        scrolling="no"
-        src="${src.href}"
-        width="100%"
-      ></iframe>
-    `
-  }
-}
 /**
  * Renders an embedded soundcloud audio player
  *
@@ -42,12 +9,35 @@ const audioElements = {
  *
  * @param      {Object}  figure          The figure object
  * @param      {String}  id              The id of the figure
- * @param      {String}  mediaId        An id for a soundcloud embed
+ * @param      {String}  mediaId         An id for a soundcloud embed
+ * @param      {String}  mediaType       The type of tag video ('video', 'vimeo' or 'youtube')
  *
  * @return     {String}  An embedded soundcloud player
  */
 module.exports = function (eleventyConfig) {
+  const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
+  const audioElements = {
+    soundcloud({ id, mediaId, mediaType }) {
+      if (!mediaId) {
+        logger.error(`Cannot render SoundCloud component without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
+        return ''
+      }
+
+      const { mediaEmbedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+
+      return html`
+        <iframe
+          allow="autoplay"
+          frameborder="no"
+          height="166"
+          scrolling="no"
+          src="${mediaEmbedUrl}"
+          width="100%"
+        ></iframe>
+      `
+    }
+  }
   return function ({ id, mediaId, mediaType }) {
-    return audioElements[mediaType]({ id, mediaId })
+    return audioElements[mediaType]({ id, mediaId, mediaType })
   }
 }

--- a/packages/11ty/_includes/components/figure/audio/html.js
+++ b/packages/11ty/_includes/components/figure/audio/html.js
@@ -1,0 +1,30 @@
+const { html } = require('~lib/common-tags')
+const chalkFactory = require('~lib/chalk')
+
+/**
+ * Renders an iframe element with the SoundCloud audio player
+ *
+ * @param      {Object}  eleventyConfig  eleventy configuration
+ * @param      {Object}  figure          The figure
+ *
+ * @return     {String}  An embedded SoundCloud player and a caption
+ */
+module.exports = function(eleventyConfig) {
+  const figureCaption = eleventyConfig.getFilter('figureCaption')
+  const figureImage = eleventyConfig.getFilter('figureImage')
+  const figureLabel = eleventyConfig.getFilter('figureLabel')
+  const figureAudioElement = eleventyConfig.getFilter('figureAudioElement')
+
+  return function({ caption, credit, id, label, mediaId, mediaType }) {
+    const audioElement = figureAudioElement({ id, mediaId, mediaType })
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
+
+    return html`
+      <div class="q-figure__media-wrapper">
+        ${audioElement}
+      </div>
+      ${captionElement}
+    `
+  }
+}

--- a/packages/11ty/_includes/components/figure/audio/index.js
+++ b/packages/11ty/_includes/components/figure/audio/index.js
@@ -1,30 +1,6 @@
-const { html } = require('~lib/common-tags')
-const chalkFactory = require('~lib/chalk')
-
-/**
- * Renders an iframe element with the SoundCloud audio player
- *
- * @param      {Object}  eleventyConfig  eleventy configuration
- * @param      {Object}  figure          The figure
- *
- * @return     {String}  An embedded SoundCloud player and a caption
- */
 module.exports = function(eleventyConfig) {
-  const figureCaption = eleventyConfig.getFilter('figureCaption')
-  const figureImage = eleventyConfig.getFilter('figureImage')
-  const figureLabel = eleventyConfig.getFilter('figureLabel')
-  const figureAudioElement = eleventyConfig.getFilter('figureAudioElement')
-
-  return function({ caption, credit, id, label, mediaId, mediaType }) {
-    const audioElement = figureAudioElement({ id, mediaId, mediaType })
-    const labelElement = figureLabel({ caption, id, label })
-    const captionElement = figureCaption({ caption, content: labelElement, credit })
-
-    return html`
-      <div class="q-figure__media-wrapper">
-        ${audioElement}
-      </div>
-      ${captionElement}
-    `
+  const renderOutputs = eleventyConfig.getFilter('renderOutputs')
+  return function(params) {
+    return renderOutputs(__dirname, params)
   }
 }

--- a/packages/11ty/_includes/components/figure/audio/print.js
+++ b/packages/11ty/_includes/components/figure/audio/print.js
@@ -1,0 +1,30 @@
+const { html } = require('~lib/common-tags')
+const chalkFactory = require('~lib/chalk')
+
+/**
+ * Renders an iframe element with the SoundCloud audio player
+ *
+ * @param      {Object}  eleventyConfig  eleventy configuration
+ * @param      {Object}  figure          The figure
+ *
+ * @return     {String}  An embedded SoundCloud player and a caption
+ */
+module.exports = function(eleventyConfig) {
+  const figureCaption = eleventyConfig.getFilter('figureCaption')
+  const figureImage = eleventyConfig.getFilter('figureImage')
+  const figureLabel = eleventyConfig.getFilter('figureLabel')
+  const figureAudioElement = eleventyConfig.getFilter('figureAudioElement')
+
+  return function({ caption, credit, id, label, mediaId, mediaType }) {
+    const audioElement = figureAudioElement({ id, mediaId, mediaType })
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit, mediaId, mediaType })
+
+    return html`
+      <div class="q-figure__media-wrapper">
+        ${audioElement}
+      </div>
+      ${captionElement}
+    `
+  }
+}

--- a/packages/11ty/_includes/components/figure/caption.js
+++ b/packages/11ty/_includes/components/figure/caption.js
@@ -12,9 +12,19 @@ const { oneLine } = require('~lib/common-tags')
 module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  return function({ caption, credit, content='' }) {
+  return function({ caption, credit, content='', mediaId, mediaType }) {
+    const getEmbeddedMediaSrc = (({ mediaId, mediaType }) => {
+      // @TODO implement utility for generating correct media embed URLs
+      // for a given hosting service: youtube, soundcloud, vimeo
+      return null;
+    })
+    const embeddedMediaSrc = getEmbeddedMediaSrc({ mediaId, mediaType })
+    const embedLink = embeddedMediaSrc
+      ? `<span class="q-figure__caption-embed-link"><a href="${embeddedMediaSrc}"><em>${embeddedMediaSrc}</em></a></span>`
+      : ''
     return oneLine`
       <figcaption class="q-figure__caption">
+        ${embedLink}
         ${markdownify(content)}
         <span class="q-figure__caption-content">${markdownify(caption || '')}</span>
         <span class="q-figure__credit">${markdownify(credit || '')}</span>

--- a/packages/11ty/_includes/components/figure/caption.js
+++ b/packages/11ty/_includes/components/figure/caption.js
@@ -13,13 +13,13 @@ module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
   return function({ caption, credit, content='', mediaId, mediaType}) {
-    const { mediaSourceUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
-    const embedLink = mediaSourceUrl
-      ? `<span class="q-figure__caption-embed-link"><a href="${mediaSourceUrl}"><em>${mediaSourceUrl}</em></a></span>`
+    const { sourceUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+    const mediaSourceLink = sourceUrl
+      ? `<span class="q-figure__caption-embed-link"><a href="${sourceUrl}"><em>${sourceUrl}</em></a></span>`
       : ''
     return oneLine`
       <figcaption class="q-figure__caption">
-        ${embedLink}
+        ${mediaSourceLink}
         ${markdownify(content)}
         <span class="q-figure__caption-content">${markdownify(caption || '')}</span>
         <span class="q-figure__credit">${markdownify(credit || '')}</span>

--- a/packages/11ty/_includes/components/figure/caption.js
+++ b/packages/11ty/_includes/components/figure/caption.js
@@ -3,7 +3,7 @@ const { oneLine } = require('~lib/common-tags')
 /**
  * Figure caption and credit
  * @param      {Object} eleventyConfig  eleventy configuration
- * 
+ *
  * @param      {Object} params
  * @property   {String} figure
  * @property   {String} content
@@ -11,16 +11,11 @@ const { oneLine } = require('~lib/common-tags')
  */
 module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
-
-  return function({ caption, credit, content='', mediaId, mediaType }) {
-    const getEmbeddedMediaSrc = (({ mediaId, mediaType }) => {
-      // @TODO implement utility for generating correct media embed URLs
-      // for a given hosting service: youtube, soundcloud, vimeo
-      return null;
-    })
-    const embeddedMediaSrc = getEmbeddedMediaSrc({ mediaId, mediaType })
-    const embedLink = embeddedMediaSrc
-      ? `<span class="q-figure__caption-embed-link"><a href="${embeddedMediaSrc}"><em>${embeddedMediaSrc}</em></a></span>`
+  const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
+  return function({ caption, credit, content='', mediaId, mediaType}) {
+    const { mediaSourceUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+    const embedLink = mediaSourceUrl
+      ? `<span class="q-figure__caption-embed-link"><a href="${mediaSourceUrl}"><em>${mediaSourceUrl}</em></a></span>`
       : ''
     return oneLine`
       <figcaption class="q-figure__caption">

--- a/packages/11ty/_includes/components/figure/media-embed-url.js
+++ b/packages/11ty/_includes/components/figure/media-embed-url.js
@@ -1,0 +1,57 @@
+const chalkFactory = require('~lib/chalk')
+
+const logger = chalkFactory('Figure Media Embed URL')
+
+module.exports = function (eleventyConfig) {
+  const embedUrlByMediaType = {
+    soundcloud(mediaId) {
+      const baseUrl = 'https://w.soundcloud.com/player/'
+      const embedUrl = new URL(baseUrl)
+      const embedParams = new URLSearchParams({
+        auto_play: 'false',
+        color: encodeURIComponent('#ff5500'),
+        hide_related: 'true',
+        show_comments: 'false',
+        show_reposts: 'false',
+        show_teaser: 'false',
+        show_user: 'false',
+        url: encodeURIComponent(`https://api.soundcloud.com/tracks/${mediaId}`)
+      })
+      embedUrl.search = `?${embedParams.toString()}`
+
+      const sourceUrl = new URL(baseUrl)
+      const sourceParams = new URLSearchParams({
+        url: encodeURIComponent(`https://api.soundcloud.com/tracks/${mediaId}`)
+      })
+      sourceUrl.search = `?${sourceParams.toString()}`
+
+
+      return {
+        mediaEmbedUrl: embedUrl.href,
+        mediaSourceUrl: sourceUrl.href
+      }
+    },
+    vimeo(mediaId) {
+      const baseUrl = 'https://player.vimeo.com/video/'
+      // Sample Vimeo id: 672853278/b3f8d29d53
+      const embedId = mediaId.replace('/', '?h=')
+      return {
+        mediaEmbedUrl: `${baseUrl}${embedId}`,
+        mediaSourceUrl: `${baseUrl}${embedId}`
+      }
+    },
+    youtube(mediaId) {
+      const embedBaseUrl = 'https://www.youtube-nocookie.com/embed/'
+      const mediaSourceBaseUrl = 'https://www.youtube.com/watch?v='
+      return {
+        mediaEmbedUrl: `${embedBaseUrl}${mediaId}`,
+        mediaSourceUrl: `${mediaSourceBaseUrl}${mediaId}`
+      }
+    }
+  }
+  return function ({ mediaId, mediaType }) {
+    if (!Object.keys(embedUrlByMediaType).includes(mediaType)) return ''
+
+    return embedUrlByMediaType[mediaType](mediaId)
+  }
+}

--- a/packages/11ty/_includes/components/figure/media-embed-url.js
+++ b/packages/11ty/_includes/components/figure/media-embed-url.js
@@ -27,8 +27,8 @@ module.exports = function (eleventyConfig) {
 
 
       return {
-        mediaEmbedUrl: embedUrl.href,
-        mediaSourceUrl: sourceUrl.href
+        embedUrl: embedUrl.href,
+        sourceUrl: sourceUrl.href
       }
     },
     vimeo(mediaId) {
@@ -36,16 +36,16 @@ module.exports = function (eleventyConfig) {
       // Sample Vimeo id: 672853278/b3f8d29d53
       const embedId = mediaId.replace('/', '?h=')
       return {
-        mediaEmbedUrl: `${baseUrl}${embedId}`,
-        mediaSourceUrl: `${baseUrl}${embedId}`
+        embedUrl: `${baseUrl}${embedId}`,
+        sourceUrl: `${baseUrl}${embedId}`
       }
     },
     youtube(mediaId) {
       const embedBaseUrl = 'https://www.youtube-nocookie.com/embed/'
-      const mediaSourceBaseUrl = 'https://www.youtube.com/watch?v='
+      const sourceBaseUrl = 'https://www.youtube.com/watch?v='
       return {
-        mediaEmbedUrl: `${embedBaseUrl}${mediaId}`,
-        mediaSourceUrl: `${mediaSourceBaseUrl}${mediaId}`
+        embedUrl: `${embedBaseUrl}${mediaId}`,
+        sourceUrl: `${sourceBaseUrl}${mediaId}`
       }
     }
   }

--- a/packages/11ty/_includes/components/figure/video/element.js
+++ b/packages/11ty/_includes/components/figure/video/element.js
@@ -3,66 +3,6 @@ const chalkFactory = require('~lib/chalk')
 const path = require('path')
 
 const logger = chalkFactory('Figure Video')
-
-const videoElements = {
-  video({ id, poster='', src }) {
-    if (!src) {
-      logger.error(`Cannot render Video without 'src'. Check that figures data for id: ${id} has a valid 'src'`)
-      return ''
-    }
-
-    if (!poster) {
-      logger.warn(`Figure '${id}' does not have a 'poster' property. A poster image for id: ${id} will not be rendered`)
-    }
-
-    const unsupported = 'Sorry, your browser does not support embedded videos.'
-    return html`
-      <video
-        class="q-figure-video-element"
-        controls
-        poster="${poster}"
-      >
-        <source src="${src}" type="video/mp4"/>
-        ${unsupported}
-      </video>
-    `
-  },
-  vimeo({ id, mediaId }) {
-    if (!mediaId) {
-      logger.error(`Cannot render Vimeo embed without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
-      return ''
-    }
-
-    // Sample Vimeo id: 672853278/b3f8d29d53
-    const embedId = mediaId.replace('/', '?h=')
-    return html`
-      <iframe
-        allow="fullscreen; picture-in-picture"
-        allowfullscreen
-        class="q-figure-video-element q-figure-video-element--embed"
-        frameborder="0"
-        src="https://player.vimeo.com/video/${embedId}"
-      ></iframe>
-    `
-  },
-  youtube({ id, mediaId }) {
-    if (!mediaId) {
-      logger.error(`Cannot render Youtube component without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
-      return ''
-    }
-
-    return html`
-      <iframe
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        class="q-figure-video-element q-figure-video-element--embed"
-        frameborder="0"
-        src="https://www.youtube-nocookie.com/embed/${mediaId}"
-      ></iframe>
-    `
-  }
-}
-
 /**
  * Renders a native or embedded video player
  *
@@ -70,8 +10,8 @@ const videoElements = {
  *
  * @param      {Object}  figure          The figure object
  * @param      {String}  id              The id of the figure
- * @param      {String}  mediaId        An id for a youtube or vimeo embed
- * @param      {String}  mediaType      The type of tag video ('video', 'vimeo' or 'youtube')
+ * @param      {String}  mediaId         An id for a youtube or vimeo embed
+ * @param      {String}  mediaType       The type of tag video ('video', 'vimeo' or 'youtube')
  * @param      {String}  poster          Poster image url for a static video file
  * @param      {String}  src             Source url for a static video file
  *
@@ -79,6 +19,67 @@ const videoElements = {
  */
 module.exports = function (eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
+  const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
+  const videoElements = {
+    video({ id, poster='', src }) {
+      if (!src) {
+        logger.error(`Cannot render Video without 'src'. Check that figures data for id: ${id} has a valid 'src'`)
+        return ''
+      }
+
+      if (!poster) {
+        logger.warn(`Figure '${id}' does not have a 'poster' property. A poster image for id: ${id} will not be rendered`)
+      }
+
+      const unsupported = 'Sorry, your browser does not support embedded videos.'
+      return html`
+        <video
+          class="q-figure-video-element"
+          controls
+          poster="${poster}"
+        >
+          <source src="${src}" type="video/mp4"/>
+          ${unsupported}
+        </video>
+      `
+    },
+    vimeo({ id, mediaId, mediaType }) {
+      if (!mediaId) {
+        logger.error(`Cannot render Vimeo embed without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
+        return ''
+      }
+
+      const { mediaEmbedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+
+      return html`
+        <iframe
+          allow="fullscreen; picture-in-picture"
+          allowfullscreen
+          class="q-figure-video-element q-figure-video-element--embed"
+          frameborder="0"
+          src="${mediaEmbedUrl}"
+        ></iframe>
+      `
+    },
+    youtube({ id, mediaId, mediaType }) {
+      if (!mediaId) {
+        logger.error(`Cannot render Youtube component without 'media_id'. Check that figures data for id: ${id} has a valid 'media_id'`)
+        return ''
+      }
+
+      const { mediaEmbedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+
+      return html`
+        <iframe
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+          class="q-figure-video-element q-figure-video-element--embed"
+          frameborder="0"
+          src="${mediaEmbedUrl}"
+        ></iframe>
+      `
+    }
+  }
 
   return function ({
     id,
@@ -94,6 +95,6 @@ module.exports = function (eleventyConfig) {
       src = src.startsWith('http') ? src : path.join(imageDir, src)
     }
 
-    return videoElements[mediaType]({ id, mediaId, poster, src })
+    return videoElements[mediaType]({ id, mediaId, mediaType, poster, src })
   }
 }

--- a/packages/11ty/_includes/components/figure/video/element.js
+++ b/packages/11ty/_includes/components/figure/video/element.js
@@ -49,7 +49,7 @@ module.exports = function (eleventyConfig) {
         return ''
       }
 
-      const { mediaEmbedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+      const { embedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
 
       return html`
         <iframe
@@ -57,7 +57,7 @@ module.exports = function (eleventyConfig) {
           allowfullscreen
           class="q-figure-video-element q-figure-video-element--embed"
           frameborder="0"
-          src="${mediaEmbedUrl}"
+          src="${embedUrl}"
         ></iframe>
       `
     },
@@ -67,7 +67,7 @@ module.exports = function (eleventyConfig) {
         return ''
       }
 
-      const { mediaEmbedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+      const { embedUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
 
       return html`
         <iframe
@@ -75,7 +75,7 @@ module.exports = function (eleventyConfig) {
           allowfullscreen
           class="q-figure-video-element q-figure-video-element--embed"
           frameborder="0"
-          src="${mediaEmbedUrl}"
+          src="${embedUrl}"
         ></iframe>
       `
     }

--- a/packages/11ty/_includes/components/figure/video/print.js
+++ b/packages/11ty/_includes/components/figure/video/print.js
@@ -18,7 +18,16 @@ module.exports = function(eleventyConfig) {
 
   const { imageDir } = eleventyConfig.globalData.config.figures
 
-  return function({ aspect_ratio: aspectRatio, caption, credit, id, label, mediaType, poster=''}) {
+  return function({
+    aspect_ratio: aspectRatio,
+    caption,
+    credit,
+    id,
+    label,
+    mediaId,
+    mediaType,
+    poster=''
+  }) {
     if (!poster) {
       logger.warn(`Figure '${id}' does not have a 'poster' property. Print media will not render a fallback image for id: ${id}`)
     }
@@ -27,11 +36,13 @@ module.exports = function(eleventyConfig) {
       ? poster
       : path.join(imageDir, poster)
     const labelElement = figureLabel({ caption, id, label })
-    const captionElement = figureCaption({ caption, content: labelElement,  credit })
+    const captionElement = figureCaption({ caption, content: labelElement,  credit, mediaId, mediaType })
+
+    const trimLeadingSlash = (string) => string.startsWith('/') ? string.substr(1) : string
 
     return html`
       <div class="q-figure__media-wrapper--${ aspectRatio || 'widescreen' }">
-        <img src="${posterSrc}" />
+        <img src="${trimLeadingSlash(posterSrc)}" />
       </div>
       ${captionElement}
     `

--- a/packages/11ty/_includes/components/index.js
+++ b/packages/11ty/_includes/components/index.js
@@ -21,6 +21,7 @@ module.exports = {
   figureImageElement: require('./figure/image/element'),
   figureLabel: require('./figure/label'),
   figureModalLink: require('./figure/modal-link'),
+  figureMediaEmbedUrl: require('./figure/media-embed-url'),
   figureOption: require('./figure/annotations-ui/option'),
   figurePlaceholder: require('./figure/placeholder'),
   figureAudio: require('./figure/audio'),


### PR DESCRIPTION
This PR implements a new figure sub-component, `media-embed-url` which creates an embedded media player `src` URL and an original source URL for each media host (soundcloud, vimeo, youtube). The audio and video `element.js` sub-components have been refactored to use `media-embed-url`.

Figure captions now use `media-embed-url` to optionally display a link to the original source of the embedded media. This only displays when passing `mediaId` and `mediaType` kwargs to `figureCaption` -- the `video/print.js` and `audio/print.js` outputs use this to display media source links in print output only. I had originally tried to split `figureCaption` into separate `print.js` and `html.js` outputs, but since `figureCaption` is composed in output-specific figure components (`video/print.js / video/html.js` and `audio/print.js / audio/html.js`), it renders both print and html variants -- something to look into in the future perhaps.

- Audio figures now have separate `print.js` and `html.js` outputs

Please also review corresponding style changes to display media embed links on their own line: https://github.com/thegetty/quire/pull/646