### PR TITLE
Fix undeclared function name error

### DIFF
--- a/packages/11ty/_plugins/filters/slugifyIds.js
+++ b/packages/11ty/_plugins/filters/slugifyIds.js
@@ -16,7 +16,7 @@ module.exports = (content, eleventyConfig) => {
   Array
     .from(document.querySelectorAll('[id]'))
     .forEach((element) => {
-      element.id = slugifyFn(element.id)
+      element.id = slugify(element.id)
     })
 
   return dom.serialize()


### PR DESCRIPTION
## Fixed

- Corrects incorrect 11ty filter function name in `filters/slugifyIds`
 