### PR TITLE
Fix: Multiple instantiations of IIIF Config

### DIFF
--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -10,7 +10,6 @@ module.exports = (eleventyConfig) => {
 
   const projectRoot = path.resolve(eleventyConfig.dir.input, '..')
 
-  // @todo resolve why iiifConfig() is called for each image
   // logger.debug(`projectRoot: ${projectRoot}`)
 
   const resolveInputPath = () => {

--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -10,7 +10,8 @@ const logger = chalkFactory('Figures', 'DEBUG')
  * for all figures in `figures.yaml` and updates global data
  */
 module.exports = function (eleventyConfig, options = {}) {
-  const figureFactory = new FigureFactory(iiifConfig(eleventyConfig))
+  const config = iiifConfig(eleventyConfig)
+  const figureFactory = new FigureFactory(config)
 
   eleventyConfig.on('eleventy.before', async () => {
     const { figure_list: figureList } = eleventyConfig.globalData.figures
@@ -30,6 +31,7 @@ module.exports = function (eleventyConfig, options = {}) {
       )
     }
 
+    eleventyConfig.globalData.iiifConfig = config
     /**
      * Update global figures data to only have properties for Quire shortcodes
      */

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -1,5 +1,4 @@
 const filterOutputs = require('../filter.js')
-const getIIIFConfig = require('../../../figures/iiif/config')
 const jsdom = require('jsdom')
 const layout = require('./layout')
 const path = require('path')
@@ -11,11 +10,11 @@ const { JSDOM } = jsdom
  * Content transforms for EPUB output
  */
 module.exports = function(eleventyConfig, collections, content) {
-  const { output: iiifOutputDir } = getIIIFConfig(eleventyConfig).dirs
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const slugify = eleventyConfig.getFilter('slugify')
   const slugifyIds = eleventyConfig.getFilter('slugifyIds')
   const { imageDir } = eleventyConfig.globalData.config.figures
+  const { outputPath: iiifOutputDir } = eleventyConfig.globalData.iiifConfig.dirs
   const { language } = eleventyConfig.globalData.publication
   const { assets, readingOrder } = eleventyConfig.globalData.epub
   const { outputDir } = eleventyConfig.globalData.config.epub


### PR DESCRIPTION
Previously the method to create the iiifConfig was being imported and called on every page in the EPUB transform to get the value of the IIIF output directory. 

Changes:
- Add `iiifConfig` to global data
- Get `iiifConfig` from global data in epub transform
- Fix `outputPath` property name in epub transform