### PR TITLE
Fix-#638: Refine publication path handling 

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -38,13 +38,6 @@ const inputDir = 'content'
 const outputDir = '_site'
 const publicDir = 'public'
 
-// Data cascade isn't available at config time(?), so load publication data manually
-// NB: try / catch uncaught here and in URL()
-
-const publicationConfigPath = path.join(inputDir,'_data','publication.yaml')
-const publicationConfig = yaml.load(fs.readFileSync(publicationConfigPath)) 
-const publicationPath = publicationConfig.url ? new URL(publicationConfig.url).pathname : '/';
-
 /**
  * Eleventy configuration
  * @see {@link https://www.11ty.dev/docs/config/ Configuring 11ty}
@@ -82,6 +75,12 @@ module.exports = function(eleventyConfig) {
   //     return addPassthroughCopy(entry, { expand: true })
   //   }
   // }
+
+  // Data cascade isn't available at config time(?), so load publication data manually
+  // NB: try / catch uncaught here and in URL()
+  const publicationConfigPath = path.join(inputDir,'_data','publication.yaml')
+  const publicationConfig = yaml.load(fs.readFileSync(publicationConfigPath)) 
+  const publicationPath = publicationConfig.url ? new URL(publicationConfig.url).pathname : '/';
 
   eleventyConfig.addGlobalData('application', {
     name: 'Quire',

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -77,7 +77,7 @@ module.exports = function(eleventyConfig) {
   // }
 
   // Data cascade isn't available at config time(?), so load publication data manually
-  // NB: try / catch uncaught here and in URL()
+  // NB: try / catch are uncaught here and in URL(), but presumably those should fail (or fail elsewhere in config validation)
   const publicationConfigPath = path.join(inputDir,'_data','publication.yaml')
   const publicationConfig = yaml.load(fs.readFileSync(publicationConfigPath)) 
   const publicationPath = publicationConfig.url ? new URL(publicationConfig.url).pathname : '/';
@@ -193,6 +193,9 @@ module.exports = function(eleventyConfig) {
    * Runs Vite as Middleware in the Eleventy Dev Server
    * Runs Vite build to postprocess the Eleventy build output
    */
+  
+  const pathResolutionAliases = publicationPath === '/' ? [] : [{find: publicationPath, replacement: '/'}]
+
   eleventyConfig.addPlugin(EleventyVitePlugin, {
     tempFolderName: '.11ty-vite',
     viteOptions: {
@@ -203,9 +206,9 @@ module.exports = function(eleventyConfig) {
        * @see https://vitejs.dev/config/#build-options
        */
       root: outputDir,
-      base: process.env.ELEVENTY_ENV === 'production' ? publicationPath : '/', // `base` and `prefixPath` seem to conflict in the dev server, so only set it on prod
+      base:  publicationPath, 
       resolve: {
-        alias: [{find: publicationPath, replacement: "/"}]
+        alias: pathResolutionAliases
       },
       build: {
         assetsDir: '_assets',


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
#642 , Discussion #638 

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.
Allow deployments with URLs rooted to paths other than host root.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.
- AFAICT `eleventyConfig` is instantiated before data cascade init, so it manually parses the publications.yaml file
- ~Something is amiss when running `quire preview`: it should emit the site at `http://localhost:8080/publication-url-path/`, but emits on `http://localhost:8080/publication-url-path` instead (no trailing slash).~

### Does this pull request necessitate changes to Quire's documentation?
Yes, inasmuch as deploy docs are on v0 currently.


### Include screenshots of before/after if applicable.



### Additional Comments

