### PR TITLE
DEV-14144: Process image sequence files

### DIFF
--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -4,7 +4,12 @@ const AnnotationFactory = require('../annotation/factory')
 const Manifest = require('../iiif/manifest')
 const path = require('path')
 const sharp = require('sharp')
-const { isCanvas, isImageService } = require('../helpers')
+const {
+  getSequenceFiles,
+  isCanvas,
+  isImageService,
+  isSequence
+} = require('../helpers')
 
 const logger = chalkFactory('Figures:Figure', 'DEBUG')
 
@@ -12,7 +17,7 @@ const logger = chalkFactory('Figures:Figure', 'DEBUG')
  * @param {Object} iiifConfig
  * @param {Function} processImage  Function to generate IIIF assets
  * @param {Object} data  Figure data from and entry in `figures.yaml`
- * 
+ *
  * @typedef {Object} Figure
  * @property {Array<AnnotationSet>} annotations
  * @property {String} canvasId ID of IIIF canvas
@@ -45,7 +50,7 @@ module.exports = class Figure {
       mediaType: 'image'
     }
 
-    const { 
+    const {
       id,
       label,
       media_id: mediaId,
@@ -61,12 +66,18 @@ module.exports = class Figure {
     this.iiifConfig = iiifConfig
     this.isCanvas = isCanvas(data)
     this.isImageService = isImageService(data)
+    this.isSequence = isSequence(data)
     this.label = label
     this.manifestId = manifestId
     this.mediaType = mediaType || defaults.mediaType
     this.mediaId = mediaId
     this.outputDir = outputDir
     this.processImage = imageProcessor
+    if (this.isSequence) {
+      this.sequenceDir = data.sequence[0].id
+      this.sequenceFiles = getSequenceFiles(data, iiifConfig)
+      this.sequenceRegex = data.sequence[0].regex
+    }
     this.src = src
     this.zoom = zoom
   }
@@ -190,7 +201,11 @@ module.exports = class Figure {
 
     await this.calcCanvasDimensions()
     await this.processAnnotationImages()
-    await this.processFigureImage()
+    if (this.isSequence) {
+      await this.processFigureSequence()
+    } else {
+      await this.processFigureImage()
+    }
     await this.createManifest()
 
     return { errors: this.errors }
@@ -223,6 +238,19 @@ module.exports = class Figure {
       transformations
     })
     if (errors) this.errors = this.errors.concat(errors)
+  }
+
+  async processFigureSequence() {
+    if (!this.isSequence || !this.sequenceFiles) return
+    const results = await Promise.all(this.sequenceFiles.map((sequenceItemFilename) => {
+      logger.debug(`processing sequence image ${sequenceItemFilename}`)
+      const inputPath = path.join(this.sequenceDir, sequenceItemFilename)
+      return this.processImage(inputPath, this.outputDir, {
+        tile: true
+      })
+    }))
+    const errors = results.flatMap(({ errors }) => errors || [])
+    if (errors.length) this.errors = this.errors.concat(errors)
   }
 
   /**

--- a/packages/11ty/_plugins/figures/helpers/get-sequence-files.js
+++ b/packages/11ty/_plugins/figures/helpers/get-sequence-files.js
@@ -1,0 +1,21 @@
+const fs = require('fs')
+const path = require('path')
+const isSequence = require('./is-sequence.js')
+
+/**
+ * Figure `getSequenceFiles` helper
+ *
+ *
+ * @param  {Object} figure     Figure data
+ * @param  {Object} iiifConfig IIIF Config data
+ * @return {Array<string>}     An array of filenames
+ */
+module.exports = (figure, iiifConfig) => {
+  if (!isSequence(figure)) return
+
+  const { sequence } = figure
+  const { dirs } = iiifConfig
+  const { imagesDir, inputRoot } = dirs
+  const sequenceDir = path.join(inputRoot, imagesDir, sequence[0].id)
+  return fs.readdirSync(sequenceDir)
+}

--- a/packages/11ty/_plugins/figures/helpers/index.js
+++ b/packages/11ty/_plugins/figures/helpers/index.js
@@ -1,4 +1,6 @@
 module.exports = {
+  getSequenceFiles: require('./get-sequence-files'),
   isCanvas: require('./is-canvas'),
-  isImageService: require('./is-image-service')
+  isImageService: require('./is-image-service'),
+  isSequence: require('./is-sequence')
 }

--- a/packages/11ty/_plugins/figures/helpers/is-sequence.js
+++ b/packages/11ty/_plugins/figures/helpers/is-sequence.js
@@ -1,0 +1,11 @@
+/**
+ * Figure `isSequence` helper
+ * A figure is a sequence if it has a sequence
+ *
+ * @param  {Object} figure Figure data
+ * @return {Boolean}       True if figure contains a canvas
+ */
+module.exports = (figure) => {
+  const { sequence } = figure
+  return !!sequence
+}


### PR DESCRIPTION
This implements a `processFigureSequence` instance method for the `Figure` class to generate tiles for image sequences. Additionally, there are now 2 more helpers:
- `isSequence` determines if a figure has a `sequence` property
- `getSequenceFiles` looks in the directory matching the `sequence` id to fetch all sequence image file names

**Note:** The branching logic introduced here feels a little hacky, and the `Figure` should probably get split into sub-classes once all of the manifest-generation logic for image sequences is working, but I wanted to open a PR for this so all this 360 stuff doesn't end up in a massive mega-PR.