### PR TITLE
Feature/DEV-14279 quire publications with path prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 # Eleventy
-_includes/
-_layouts/
-_plugins/
 _site/
 .eleventy.js
 

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -33,8 +33,8 @@ const shortcodesPlugin = require('~plugins/shortcodes')
 const syntaxHighlightPlugin = require('@11ty/eleventy-plugin-syntaxhighlight')
 const transformsPlugin = require('~plugins/transforms')
 
-const inputDir = 'content'
-const outputDir = '_site'
+const inputDir = process.env.ELEVENTY_INPUT || 'content'
+const outputDir = process.env.ELEVENTY_OUTPUT || '_site'
 const publicDir = 'public'
 
 /**
@@ -303,8 +303,8 @@ module.exports = function(eleventyConfig) {
      */
     dir: {
       // ⚠️ input and output dirs are _relative_ to the `.eleventy.js` module
-      input: process.env.ELEVENTY_INPUT || inputDir,
-      output: process.env.ELEVENTY_OUTPUT || outputDir,
+      input: inputDir,
+      output: outputDir,
       // ⚠️ the following directories are _relative_ to the `input` directory
       data: process.env.ELEVENTY_DATA || '_computed',
       includes: process.env.ELEVENTY_INCLUDES || path.join('..', '_includes'),

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -5,7 +5,6 @@ const fs = require('fs-extra')
 const packageJSON = require('./package.json');
 const path = require('path')
 const scss = require('rollup-plugin-scss')
-const yaml = require('js-yaml');
 
 const chalkFactory = require('~lib/chalk')
 
@@ -16,7 +15,6 @@ const {
   EleventyHtmlBasePlugin,
   EleventyRenderPlugin
 } = require('@11ty/eleventy')
-const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
 const citationsPlugin = require('~plugins/citations')
 const collectionsPlugin = require('~plugins/collections')
 const componentsPlugin = require('~plugins/components')
@@ -35,40 +33,13 @@ const searchPlugin = require('~plugins/search')
 const shortcodesPlugin = require('~plugins/shortcodes')
 const syntaxHighlightPlugin = require('@11ty/eleventy-plugin-syntaxhighlight')
 const transformsPlugin = require('~plugins/transforms')
+const vitePlugin = require('~plugins/vite')
 
 const { error } = chalkFactory('eleventy config')
 
 const inputDir = process.env.ELEVENTY_INPUT || 'content'
 const outputDir = process.env.ELEVENTY_OUTPUT || '_site'
 const publicDir = 'public'
-
-/**
- * Nota bene: Data cascade isn't available at config time,
- * load publication data manually so that prefix can be used in config
- * @todo refactor global data plugin to return global data for use in config
- */
-const getPublicationPath = () => {
-  const publicationConfigPath = path.join(
-    inputDir,
-    '_data',
-    'publication.yaml'
-  )
-  const publication = yaml.load(fs.readFileSync(publicationConfigPath))
-  const { url } = publication
-  try {
-    let publicationPath = new URL(url).pathname
-    // Add trailing '/'
-    return !publicationPath.endsWith('/')
-      ? (publicationPath += '/')
-      : publicationPath
-  } catch (errorMessage) {
-    error(
-      `Publication.yaml url property must be a valid url. Current url value: "${url}"`
-    )
-    throw new Error(errorMessage)
-  }
-}
-const publicationPath = getPublicationPath()
 
 /**
  * Eleventy configuration
@@ -108,12 +79,6 @@ module.exports = function(eleventyConfig) {
   //   }
   // }
 
-  // Data cascade isn't available at config time(?), so load publication data manually
-  // NB: try / catch are uncaught here and in URL(), but presumably those should fail (or fail elsewhere in config validation)
-  const publicationConfigPath = path.join(inputDir,'_data','publication.yaml')
-  const publicationConfig = yaml.load(fs.readFileSync(publicationConfigPath)) 
-  const publicationPath = publicationConfig.url ? new URL(publicationConfig.url).pathname : '/';
-
   eleventyConfig.addGlobalData('application', {
     name: 'Quire',
     version: packageJSON.version
@@ -151,11 +116,20 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin)
 
   /**
-   * Plugins are loaded in order of the `addPlugin` statements,
-   * plugins that mutate globalData must be added before other plugins
+   * Plugins are loaded in this order: 
+   *   1) immediately invoked
+   *   2) addPlugin statements
+   * Plugins that mutate globalData must be added before other plugins
+   *
+   * Note: The config does **not** have access to collections or global,
+   * to get around this we invoke some plugins immediately and return a value
+   * so that data can be provided to the config or another plugin.
    */
-  eleventyConfig.addPlugin(dataExtensionsPlugin)
-  eleventyConfig.addPlugin(globalDataPlugin)
+  dataExtensionsPlugin(eleventyConfig)
+  const globalData = globalDataPlugin(eleventyConfig, { inputDir })
+  const collections = collectionsPlugin(eleventyConfig)
+  vitePlugin(eleventyConfig, { inputDir, outputDir, globalData })
+
   eleventyConfig.addPlugin(i18nPlugin)
   eleventyConfig.addPlugin(figuresPlugin)
 
@@ -163,11 +137,6 @@ module.exports = function(eleventyConfig) {
    * Load plugin for custom configuration of the markdown library
    */
   eleventyConfig.addPlugin(markdownPlugin)
-
-  /**
-   * Add collections
-   */
-  const collections = collectionsPlugin(eleventyConfig)
 
   /**
    * Load plugins for the Quire template shortcodes and filters
@@ -219,91 +188,6 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(transformsPlugin, collections)
 
   /**
-   * Use Vite to bundle JavaScript
-   * @see https://github.com/11ty/eleventy-plugin-vite
-   *
-   * Runs Vite as Middleware in the Eleventy Dev Server
-   * Runs Vite build to postprocess the Eleventy build output
-   */
-  
-  const pathResolutionAliases = publicationPath === '/' ? [] : [{find: publicationPath, replacement: '/'}]
-
-  eleventyConfig.addPlugin(EleventyVitePlugin, {
-    tempFolderName: '.11ty-vite',
-    viteOptions: {
-      publicDir: process.env.ELEVENTY_ENV === 'production'
-        ? publicDir
-        : false,
-      /**
-       * @see https://vitejs.dev/config/#build-options
-       */
-      root: outputDir,
-      base:  publicationPath, 
-      resolve: {
-        alias: pathResolutionAliases
-      },
-      build: {
-        assetsDir: '_assets',
-        emptyOutDir: process.env.ELEVENTY_ENV !== 'production',
-        manifest: true,
-        mode: 'production',
-        outDir: outputDir,
-        rollupOptions: {
-          output: {
-            assetFileNames: ({ name }) => {
-              const fullFilePathSegments = name.split('/').slice(0, -1)
-              let filePath = '_assets/';
-              ['_assets', 'node_modules'].forEach((assetDir) => {
-                if (name.includes(assetDir)) {
-                  filePath +=
-                    fullFilePathSegments
-                      .slice(fullFilePathSegments.indexOf(assetDir) + 1)
-                      .join('/') + '/'
-                }
-              })
-              return `${filePath}[name][extname]`
-            }
-          },
-          plugins: [
-            copy({
-              targets: [
-                { 
-                  src: 'public/*', 
-                  dest: outputDir,
-                },
-                {
-                  src: path.join(inputDir, '_assets', 'images', '*'),
-                  dest: path.join(outputDir, '_assets', 'images')
-                },
-                {
-                  src: path.join(inputDir, '_assets', 'fonts', '*'),
-                  dest: path.join(outputDir, '_assets', 'fonts')
-                }
-              ]
-            })
-          ]
-        },
-        sourcemap: true
-      },
-      /**
-       * Set to false to prevent Vite from clearing the terminal screen
-       * and have Vite logging messages rendered alongside Eleventy output.
-       */
-      clearScreen: false,
-      /**
-       * @see https://vitejs.dev/config/#server-host
-       */
-      server: {
-        hmr: {
-          overlay: false
-        },
-        middlewareMode: true,
-        mode: 'development'
-      }
-    }
-  })
-
-  /**
    * Set eleventy dev server options
    * @see https://www.11ty.dev/docs/dev-server/
    */
@@ -341,6 +225,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.watchIgnores.add('_pdf')
   eleventyConfig.watchIgnores.add('_temp')
 
+  const { pathname: pathPrefix } = globalData.publication
   return {
     /**
      * @see {@link https://www.11ty.dev/docs/config/#configuration-options}
@@ -375,7 +260,7 @@ module.exports = function(eleventyConfig) {
     /**
      * @see {@link https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix}
      */
-    pathPrefix: publicationPath,
+    pathPrefix,
     /**
      * All of the following template formats support universal shortcodes.
      *

--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -42,7 +42,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: pageTitle(page.data),
       type: 'chapter',
-      URL: new URL(page.url, url).toString()
+      URL: page.data.canonicalURL
     }
   }
 }

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -36,27 +36,45 @@ const checkForDuplicateIds = function (data, filename) {
 }
 
 /**
+ * @todo replace with ajv schema validation
+ */
+const validatePublication = (publication) => {
+  try {
+    const { url } = publication
+    publication.url = url.endsWith('/') ? url : url + '/'
+    publication.pathname = new URL(publication.url).pathname
+  } catch (errorMessage) {
+    logger.error(
+      `Publication.yaml url property must be a valid url. Current url value: "${url}"`
+    )
+    throw new Error(errorMessage)
+  }
+  return publication
+}
+
+/**
  * Eleventy plugin to programmatically load global data from files
  * so that it is available to shortcode components.
  * Nota bene: data is loaded from a sub directory of the `input` directory,
  * distinct from the `eleventyConfig.dir.data` directory.
  */
-module.exports = {
-  configFunction: function(eleventyConfig, options = {}) {
-    const dir = path.resolve(eleventyConfig.dir.input, '_data')
-    // console.debug(`[plugins:globalData] ${dir}`)
-    const files = fs.readdirSync(dir)
-      .filter((file) => path.extname(file) !== '.md')
-    const parse = parser(eleventyConfig)
+module.exports = function(eleventyConfig, { inputDir }) {
+  const dir = path.resolve(inputDir, '_data')
+  // console.debug(`[plugins:globalData] ${dir}`)
+  const files = fs.readdirSync(dir)
+    .filter((file) => path.extname(file) !== '.md')
+  const parse = parser(eleventyConfig)
 
-    for (const file of files) {
-      const { name: key } = path.parse(file)
-      const value = parse(path.join(dir, file))
-      if (key && value) {
-        checkForDuplicateIds(value, file)
-        eleventyConfig.addGlobalData(key, value)
-      }
+  for (const file of files) {
+    const { name: key } = path.parse(file)
+    let value = parse(path.join(dir, file))
+    if (key === 'publication') {
+      value = validatePublication(value)
     }
-  },
-  initArguments: {}
+    if (key && value) {
+      checkForDuplicateIds(value, file)
+      eleventyConfig.addGlobalData(key, value)
+    }
+  }
+  return eleventyConfig.globalData
 }

--- a/packages/11ty/_plugins/search/write.js
+++ b/packages/11ty/_plugins/search/write.js
@@ -15,16 +15,17 @@ module.exports = function(collections) {
     return content.split(' ').length
   }
 
-  const contentIndex = collections.html.map(({ data, templateContent, url }) => {
+  const contentIndex = collections.html.map(({ data, templateContent }) => {
+    const { abstract, canonicalURL, contributor, subtitle, title, layout } = data
     return {
-      abstract: data.abstract,
+      abstract,
       content: templateContent,
-      contributor: data.contributor,
+      contributor,
       length: wordcount(templateContent),
-      subtitle: data.subtitle,
-      title: data.title,
-      type: data.layout,
-      url
+      subtitle,
+      title,
+      type: layout,
+      url: canonicalURL
     }
   })
 

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -1,0 +1,88 @@
+const copy = require('rollup-plugin-copy')
+const path = require('path')
+const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
+
+/**
+ * Use Vite to bundle JavaScript
+ * @see https://github.com/11ty/eleventy-plugin-vite
+ *
+ * Runs Vite as Middleware in the Eleventy Dev Server
+ * Runs Vite build to postprocess the Eleventy build output
+ */
+module.exports = function (eleventyConfig, pluginConfig) {
+  const { inputDir, outputDir, globalData } = pluginConfig
+  const { pathname } = globalData.publication 
+
+  eleventyConfig.addPlugin(EleventyVitePlugin, {
+    tempFolderName: '.11ty-vite',
+    viteOptions: {
+      publicDir: process.env.ELEVENTY_ENV === 'production' ? publicDir : false,
+      /**
+       * @see https://vitejs.dev/config/#build-options
+       */
+      root: outputDir,
+      base: pathname, 
+      resolve: {
+        alias: pathname === '/' ? [] : [{ find: pathname, replacement: '/' }]
+      },
+      build: {
+        assetsDir: '_assets',
+        emptyOutDir: process.env.ELEVENTY_ENV !== 'production',
+        manifest: true,
+        mode: 'production',
+        outDir: outputDir,
+        rollupOptions: {
+          output: {
+            assetFileNames: ({ name }) => {
+              const fullFilePathSegments = name.split('/').slice(0, -1)
+              let filePath = '_assets/';
+              ['_assets', 'node_modules'].forEach((assetDir) => {
+                if (name.includes(assetDir)) {
+                  filePath +=
+                    fullFilePathSegments
+                      .slice(fullFilePathSegments.indexOf(assetDir) + 1)
+                      .join('/') + '/'
+                }
+              })
+              return `${filePath}[name][extname]`
+            }
+          },
+          plugins: [
+            copy({
+              targets: [
+                { 
+                  src: 'public/*', 
+                  dest: outputDir,
+                },
+                {
+                  src: path.join(inputDir, '_assets', 'images', '*'),
+                  dest: path.join(outputDir, '_assets', 'images')
+                },
+                {
+                  src: path.join(inputDir, '_assets', 'fonts', '*'),
+                  dest: path.join(outputDir, '_assets', 'fonts')
+                }
+              ]
+            })
+          ]
+        },
+        sourcemap: true
+      },
+      /**
+       * Set to false to prevent Vite from clearing the terminal screen
+       * and have Vite logging messages rendered alongside Eleventy output.
+       */
+      clearScreen: false,
+      /**
+       * @see https://vitejs.dev/config/#server-host
+       */
+      server: {
+        hmr: {
+          overlay: false
+        },
+        middlewareMode: true,
+        mode: 'development'
+      }
+    }
+  })
+}


### PR DESCRIPTION
Changes:
- Include `EleventyHtmlBasePlugin`
- Provide canonicalURL to citations, search
- Move vite config into `~plugins/vite`
- Refactor globalData plugin to provide global data to eleventy config

Also requires update to `quire-starter-default` on https://github.com/thegetty/quire-starter-default/pull/16