### PR TITLE
Refactor GlobalData and Vite plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 # Eleventy
-_includes/
-_layouts/
-_plugins/
 _site/
 .eleventy.js
 

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -120,6 +120,10 @@ module.exports = function(eleventyConfig) {
    *   1) immediately invoked
    *   2) addPlugin statements
    * Plugins that mutate globalData must be added before other plugins
+   *
+   * Note: The config does **not** have access to collections or global,
+   * to get around this we invoke some plugins immediately and return a value
+   * so that data can be provided to the config or another plugin.
    */
   dataExtensionsPlugin(eleventyConfig)
   const globalData = globalDataPlugin(eleventyConfig, { inputDir })

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -36,27 +36,45 @@ const checkForDuplicateIds = function (data, filename) {
 }
 
 /**
+ * @todo replace with ajv schema validation
+ */
+const validatePublication = (publication) => {
+  try {
+    const { url } = publication
+    publication.url = url.endsWith('/') ? url : url + '/'
+    publication.pathname = new URL(publication.url).pathname
+  } catch (errorMessage) {
+    logger.error(
+      `Publication.yaml url property must be a valid url. Current url value: "${url}"`
+    )
+    throw new Error(errorMessage)
+  }
+  return publication
+}
+
+/**
  * Eleventy plugin to programmatically load global data from files
  * so that it is available to shortcode components.
  * Nota bene: data is loaded from a sub directory of the `input` directory,
  * distinct from the `eleventyConfig.dir.data` directory.
  */
-module.exports = {
-  configFunction: function(eleventyConfig, options = {}) {
-    const dir = path.resolve(eleventyConfig.dir.input, '_data')
-    // console.debug(`[plugins:globalData] ${dir}`)
-    const files = fs.readdirSync(dir)
-      .filter((file) => path.extname(file) !== '.md')
-    const parse = parser(eleventyConfig)
+module.exports = function(eleventyConfig, { inputDir }) {
+  const dir = path.resolve(inputDir, '_data')
+  // console.debug(`[plugins:globalData] ${dir}`)
+  const files = fs.readdirSync(dir)
+    .filter((file) => path.extname(file) !== '.md')
+  const parse = parser(eleventyConfig)
 
-    for (const file of files) {
-      const { name: key } = path.parse(file)
-      const value = parse(path.join(dir, file))
-      if (key && value) {
-        checkForDuplicateIds(value, file)
-        eleventyConfig.addGlobalData(key, value)
-      }
+  for (const file of files) {
+    const { name: key } = path.parse(file)
+    let value = parse(path.join(dir, file))
+    if (key === 'publication') {
+      value = validatePublication(value)
     }
-  },
-  initArguments: {}
+    if (key && value) {
+      checkForDuplicateIds(value, file)
+      eleventyConfig.addGlobalData(key, value)
+    }
+  }
+  return eleventyConfig.globalData
 }

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -2,30 +2,28 @@ const copy = require('rollup-plugin-copy')
 const path = require('path')
 const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
 
-module.exports = function(eleventyConfig, { inputDir, outputDir, globalData }) {
-  /**
-   * Use Vite to bundle JavaScript
-   * @see https://github.com/11ty/eleventy-plugin-vite
-   *
-   * Runs Vite as Middleware in the Eleventy Dev Server
-   * Runs Vite build to postprocess the Eleventy build output
-   */
-  const { pathname } = globalData.publication
-  const pathResolutionAliases = pathname === '/' ? [] : [{ find: pathname, replacement: '/' }]
+/**
+ * Use Vite to bundle JavaScript
+ * @see https://github.com/11ty/eleventy-plugin-vite
+ *
+ * Runs Vite as Middleware in the Eleventy Dev Server
+ * Runs Vite build to postprocess the Eleventy build output
+ */
+module.exports = function (eleventyConfig, pluginConfig) {
+  const { inputDir, outputDir, globalData } = pluginConfig
+  const { pathname } = globalData.publication 
 
   eleventyConfig.addPlugin(EleventyVitePlugin, {
     tempFolderName: '.11ty-vite',
     viteOptions: {
-      publicDir: process.env.ELEVENTY_ENV === 'production'
-        ? publicDir
-        : false,
+      publicDir: process.env.ELEVENTY_ENV === 'production' ? publicDir : false,
       /**
        * @see https://vitejs.dev/config/#build-options
        */
       root: outputDir,
-      base:  pathname, 
+      base: pathname, 
       resolve: {
-        alias: pathResolutionAliases
+        alias: pathname === '/' ? [] : [{ find: pathname, replacement: '/' }]
       },
       build: {
         assetsDir: '_assets',

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -1,0 +1,90 @@
+const copy = require('rollup-plugin-copy')
+const path = require('path')
+const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
+
+module.exports = function(eleventyConfig, { inputDir, outputDir, globalData }) {
+  /**
+   * Use Vite to bundle JavaScript
+   * @see https://github.com/11ty/eleventy-plugin-vite
+   *
+   * Runs Vite as Middleware in the Eleventy Dev Server
+   * Runs Vite build to postprocess the Eleventy build output
+   */
+  const { pathname } = globalData.publication
+  const pathResolutionAliases = pathname === '/' ? [] : [{ find: pathname, replacement: '/' }]
+
+  eleventyConfig.addPlugin(EleventyVitePlugin, {
+    tempFolderName: '.11ty-vite',
+    viteOptions: {
+      publicDir: process.env.ELEVENTY_ENV === 'production'
+        ? publicDir
+        : false,
+      /**
+       * @see https://vitejs.dev/config/#build-options
+       */
+      root: outputDir,
+      base:  pathname, 
+      resolve: {
+        alias: pathResolutionAliases
+      },
+      build: {
+        assetsDir: '_assets',
+        emptyOutDir: process.env.ELEVENTY_ENV !== 'production',
+        manifest: true,
+        mode: 'production',
+        outDir: outputDir,
+        rollupOptions: {
+          output: {
+            assetFileNames: ({ name }) => {
+              const fullFilePathSegments = name.split('/').slice(0, -1)
+              let filePath = '_assets/';
+              ['_assets', 'node_modules'].forEach((assetDir) => {
+                if (name.includes(assetDir)) {
+                  filePath +=
+                    fullFilePathSegments
+                      .slice(fullFilePathSegments.indexOf(assetDir) + 1)
+                      .join('/') + '/'
+                }
+              })
+              return `${filePath}[name][extname]`
+            }
+          },
+          plugins: [
+            copy({
+              targets: [
+                { 
+                  src: 'public/*', 
+                  dest: outputDir,
+                },
+                {
+                  src: path.join(inputDir, '_assets', 'images', '*'),
+                  dest: path.join(outputDir, '_assets', 'images')
+                },
+                {
+                  src: path.join(inputDir, '_assets', 'fonts', '*'),
+                  dest: path.join(outputDir, '_assets', 'fonts')
+                }
+              ]
+            })
+          ]
+        },
+        sourcemap: true
+      },
+      /**
+       * Set to false to prevent Vite from clearing the terminal screen
+       * and have Vite logging messages rendered alongside Eleventy output.
+       */
+      clearScreen: false,
+      /**
+       * @see https://vitejs.dev/config/#server-host
+       */
+      server: {
+        hmr: {
+          overlay: false
+        },
+        middlewareMode: true,
+        mode: 'development'
+      }
+    }
+  })
+}


### PR DESCRIPTION
Changes:
- Encapsulate `EleventyPluginVite` config in `~plugins/vite`
- Return global data from `globalData` plugin. To do this, the plugin has to be immediately invoked, which requires that `dataExtensions` must be called before `globalData`.
- Add some (minor) validation to `publication.yaml` that ensures the `url` is valid and adds a `pathname` property.
- Run Figures plugin with the rest of the plugins instead of during `eleventy.before` hook so that it has access to vite config