### PR TITLE
Correct epub lib switch statment condition

### DIFF
--- a/packages/cli/src/lib/epub/index.js
+++ b/packages/cli/src/lib/epub/index.js
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename)
 export default async (name = 'epubjs', options = {}) => {
   const lib = { name, options, path }
 
-  switch (lib.toLowerCase()) {
+  switch (name.toLowerCase()) {
     case 'epubjs': {
       lib.name = 'Epub.js'
       lib.options = {}

--- a/packages/cli/src/lib/epub/index.js
+++ b/packages/cli/src/lib/epub/index.js
@@ -11,7 +11,9 @@ const __dirname = path.dirname(__filename)
 export default async (name = 'epubjs', options = {}) => {
   const lib = { name, options, path }
 
-  switch (name.toLowerCase()) {
+  const normalizedName = name.replace(/[-_.\s]/g, '').toLowerCase()
+
+  switch (normalizedName) {
     case 'epubjs': {
       lib.name = 'Epub.js'
       lib.options = {}

--- a/packages/cli/src/lib/pdf/index.js
+++ b/packages/cli/src/lib/pdf/index.js
@@ -11,7 +11,9 @@ const __dirname = path.dirname(__filename)
 export default async (name = 'pagedjs', options = {}) => {
   const lib = { name, options, path }
 
-  switch (name.toLowerCase()) {
+  const normalizedName = name.replace(/[-_.\s]/g, '').toLowerCase()
+
+  switch (normalizedName) {
     case 'paged':
     case 'pagedjs': {
       lib.name = 'Paged.js'


### PR DESCRIPTION
### Fixed

- Correct switch statement for Epub lib #671
- Normalize the lib name before conditionally loading an `epub` or `pdf` library.
 