### PR TITLE
Add a version option for the quire-cli new command

### DIFF
--- a/packages/cli/src/commands/README.md
+++ b/packages/cli/src/commands/README.md
@@ -82,22 +82,22 @@ quire new <path> <starter>
 
 #### Specifying the `quire-11ty` version
 
-When the `--version` flag is used the new project will be started using the specified version of `quire-11ty`
+When the `--quire` flag is used the new project will be started using the specified version of `quire-11ty`
 
 ```sh
-quire new <path> --version <version> <starter>
+quire new <path> <starter> --quire <version>
 ```
 
 ##### Version identifiers
 
-The `--version` flag must be either a semantic version identifier or a npm distribution tag. For example:
+The `--quire` flag must be either a semantic version identifier or a npm distribution tag. For example:
 
 ```sh
-quire new ./blargh --version 1.0.0-rc.5
+quire new ./blargh --quire 1.0.0-rc.5
 ```
 
 ```sh
-quire new ./blargh --version latest
+quire new ./blargh --quire latest
 ```
 
 ### `preview`

--- a/packages/cli/src/commands/README.md
+++ b/packages/cli/src/commands/README.md
@@ -80,6 +80,26 @@ To create a new project from a starter template
 quire new <path> <starter>
 ```
 
+#### Specifying the `quire-11ty` version
+
+When the `--version` flag is used the new project will be started using the specified version of `quire-11ty`
+
+```sh
+quire new <path> --version <version> <starter>
+```
+
+##### Version identifiers
+
+The `--version` flag must be either a semantic version identifier or a npm distribution tag. For example:
+
+```sh
+quire new ./blargh --version 1.0.0-rc.5
+```
+
+```sh
+quire new ./blargh --version latest
+```
+
 ### `preview`
 
 Build and server the Quire site in development mode.

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -62,6 +62,10 @@ export default class CreateCommand extends Command {
       const requiredVersion = await quire.initStarter(starter, projectPath)
       if (!requiredVersion) return
 
+      const version = options.quire || requiredVersion
+
+      quire.setVersion(projectPath, version)
+
       options.eject = true
 
       if (options.eject) {

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -22,8 +22,9 @@ export default class CreateCommand extends Command {
       [ '[starter]', 'repository url or local path for a starter project' ],
     ],
     options: [
-      [ '--debug', 'debug the `quire new` command' ],
+      [ '--version', 'the quire-11ty version for the project', 'latest' ],
       [ '--eject', 'install quire-11ty into the project directory', 'true' ],
+      [ '--debug', 'debug the `quire new` command' ],
     ],
   }
 
@@ -52,14 +53,19 @@ export default class CreateCommand extends Command {
       // const starter = starters['default']
       // `git clone starter path`
     } else {
-      const version = await quire.initStarter(starter, projectPath)
-      // @TODO we will want to abstract the test for emptiness to prevent further install steps on error
-      if (!version) return
+      /**
+       * @TODO test that `version` is compatible with the `requiredVersion`
+       * if version is incompatible or unknown
+       *   - interactive mode prompt to continue
+       *   - non-interactive mode throw an error and exit the process
+       */
+      const requiredVersion = await quire.initStarter(starter, projectPath)
+      if (!requiredVersion) return
 
       if (options.eject) {
-        await quire.installInProject(projectPath, version, options)
+        await quire.installInProject(projectPath, options)
       } else {
-        await quire.install(version, options)
+        await quire.install(options)
       }
     }
   }

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -22,9 +22,9 @@ export default class CreateCommand extends Command {
       [ '[starter]', 'repository url or local path for a starter project' ],
     ],
     options: [
-      [ '--version', 'the quire-11ty version for the project', 'latest' ],
-      [ '--eject', 'install quire-11ty into the project directory', 'true' ],
-      [ '--debug', 'debug the `quire new` command' ],
+      [ '--quire <version>', 'quire-11ty version to install', 'latest' ],
+      // [ '--eject', 'install quire-11ty into the project directory', true ],
+      [ '--debug', 'debug the `quire new` command', false ],
     ],
   }
 
@@ -61,6 +61,8 @@ export default class CreateCommand extends Command {
        */
       const requiredVersion = await quire.initStarter(starter, projectPath)
       if (!requiredVersion) return
+
+      options.eject = true
 
       if (options.eject) {
         await quire.installInProject(projectPath, options)

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -148,7 +148,7 @@ async function initStarter (starter, projectPath) {
  * @return  {Promise}
  */
 async function install(options = {}) {
-  const version = options.version || 'latest'
+  const version = options.quire || 'latest'
   console.debug(`[CLI:quire] installing quire-11ty@${version}`)
   const absoluteInstallPath = path.join(__dirname, 'versions')
   fs.ensureDirSync(absoluteInstallPath)
@@ -197,7 +197,7 @@ async function install(options = {}) {
  * @return  {Promise}
  */
 async function installInProject(projectPath, options = {}) {
-  const version = options.version || 'latest'
+  const version = options.quire || 'latest'
   console.debug(`[CLI:quire] installing quire-11ty@${version} into ${projectPath}`)
 
   /**

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -140,13 +140,15 @@ async function initStarter (starter, projectPath) {
 }
 
 /**
- * Install a specific version of `quire-11ty`
+ * Install `quire-11ty`, default to 'latest' version
  *
- * @param  {String}  version  Quire-11ty semantic version
+ * @TODO refactor this to be callable by the installInProject method
+ *
  * @param  {Object}  options  options passed from `quire new` command
  * @return  {Promise}
  */
-async function install(version, options={}) {
+async function install(options = {}) {
+  const version = options.version || 'latest'
   console.debug(`[CLI:quire] installing quire-11ty@${version}`)
   const absoluteInstallPath = path.join(__dirname, 'versions')
   fs.ensureDirSync(absoluteInstallPath)
@@ -185,19 +187,22 @@ async function install(version, options={}) {
 }
 
 /**
- * Install a specific version of `quire-11ty` directly into a quire project
+ * Install `quire-11ty` directly into a quire project
+ *
+ * @TODO refactor this to use the install method with pre and post-install hooks
+ * or steps to prepare the working directory and cleanup on error and completion
  *
  * @param  {String}  projectPath  Absolute system path to the project root
- * @param  {String}  version  Quire-11ty semantic version
  * @param  {Object}  options  options passed from `quire new` command
  * @return  {Promise}
  */
-async function installInProject(projectPath, version, options={}) {
+async function installInProject(projectPath, options = {}) {
+  const version = options.version || 'latest'
   console.debug(`[CLI:quire] installing quire-11ty@${version} into ${projectPath}`)
 
   /**
-   * delete `package.json` from starter project, as it will be replaced with
-   * `package.json` from `@thegetty/quire-11ty`
+   * Delete the starter project package configuration so that it can be replaced
+   * with the `@thegetty/quire-11ty` configuration
    * @TODO If a user runs quire eject at a later date we may want to merge their
    * package.json with the `quire-11ty` dev dependencies, scripts, etc
    */

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -111,10 +111,8 @@ async function initStarter (starter, projectPath) {
 
   /**
    * Determine `quire-11ty` version required by the starter project
-   * and write a `.quire` file with the semantic version string.
    */
   const quireVersion = await getVersionFromStarter(projectPath)
-  setVersion(projectPath, quireVersion)
 
   // Re-initialize project directory as a new git repository
   await fs.remove(path.join(projectPath, '.git'))
@@ -319,16 +317,16 @@ async function remove(version) {
 /**
  * Sets the quire-11ty version for a project
  *
- * @param  {String}  version  Quire-11ty semantic version
+ * @param  {String}  version  a version identifier or distribution tag
  */
 function setVersion(projectPath, version) {
   if (!version) {
     console.error('[CLI] no version specified')
+    return
   }
+  fs.writeFileSync(path.join(projectPath, VERSION_FILE), version)
   const projectName = path.basename(projectPath)
   console.info(`${projectName} set to use quire-11ty@${version}`)
-  const versionFilePath = path.join(projectPath, VERSION_FILE)
-  fs.writeFileSync(versionFilePath, version)
 }
 
 /**


### PR DESCRIPTION
### Changes

Refactor the `quire new` command to have a `--quire <version>` option for the `quire-11ty` version that will be installed when creating a project; the default value is the npm distribution tag `latest`.

**Nota bene:** this is a _work-in-progess_ implementation that is currently intended for development only to test release candidate versions; this implementation does **not** check that the starter project is compatible with the `--quire <version>` option, see `@TODO` comments.
