### PR TITLE
Use configured publicDir in Vite configuration

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -128,7 +128,7 @@ module.exports = function(eleventyConfig) {
   dataExtensionsPlugin(eleventyConfig)
   const globalData = globalDataPlugin(eleventyConfig, { inputDir })
   const collections = collectionsPlugin(eleventyConfig)
-  vitePlugin(eleventyConfig, { inputDir, outputDir, globalData })
+  vitePlugin(eleventyConfig, { globalData, inputDir, outputDir, publicDir })
 
   eleventyConfig.addPlugin(i18nPlugin)
   eleventyConfig.addPlugin(figuresPlugin)

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -10,7 +10,7 @@ const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
  * Runs Vite build to postprocess the Eleventy build output
  */
 module.exports = function (eleventyConfig, pluginConfig) {
-  const { inputDir, outputDir, globalData } = pluginConfig
+  const { globalData, inputDir, outputDir, publicDir } = pluginConfig
   const { pathname } = globalData.publication 
 
   eleventyConfig.addPlugin(EleventyVitePlugin, {


### PR DESCRIPTION
### Fixes

- Pass `publicDir` from Eleventy config to Vite plugin
