### PR TITLE
Update `canvasImagePath` to check first sequence item dimensions

### DIFF
--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -121,7 +121,13 @@ module.exports = class Figure {
       if (!firstChoice) return
       return firstChoice.src
     }
-    const imagePath = this.src || firstChoiceSrc()
+    const firstSequenceItemSrc = () => {
+      if (!this.sequences) return
+      const firstSequenceItemDirname = this.sequences[0].dir
+      const firstSequenceItemFilename = this.sequences[0].files[0]
+      return path.join(firstSequenceItemDirname, firstSequenceItemFilename)
+    }
+    const imagePath = this.src || firstChoiceSrc() || firstSequenceItemSrc()
     if (!imagePath) {
       this.errors.push(`Invalid figure ID "${this.id}". Figures with annotations must have "choice" annotations or a "src" property.`)
       return


### PR DESCRIPTION
Sequence figures were not calculating their canvas dimensions, preventing an image from displaying in a `<sequence-panel>` (due to having height, width = 0). This returns the first sequence item image file path if it is a sequence.