### PR TITLE
Run figures plugin in 11ty before

### DIFF
--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -9,40 +9,42 @@ const logger = chalkFactory('Figures', 'DEBUG')
  * Uses the FigureFactory to create Figure instances
  * for all figures in `figures.yaml` and updates global data
  */
-module.exports = async function (eleventyConfig, options = {}) {
-  const config = iiifConfig(eleventyConfig)
-  const figureFactory = new FigureFactory(config)
+module.exports = function (eleventyConfig, options = {}) {
+  eleventyConfig.on('eleventy.before', async () => {
+    const config = iiifConfig(eleventyConfig)
+    const figureFactory = new FigureFactory(config)
 
-  const { figure_list: figureList } = eleventyConfig.globalData.figures
+    const { figure_list: figureList } = eleventyConfig.globalData.figures
 
-  const figures = await Promise.all(
-    figureList.map((data) => {
-      return figureFactory.create(data)
-    })
-  )
-  const errors = figureList.filter(({ errors }) => errors && !!errors.length)
-
-  if (errors.length) {
-    logger.error('There were errors processing the following images:')
-    console.table(
-      errors.map(({ errors, figure }) => {
-        return { id: figure.id, errors: errors.join(' ') }
-      }),
-      ['id', 'errors']
+    const figures = await Promise.all(
+      figureList.map((data) => {
+        return figureFactory.create(data)
+      })
     )
-  }
+    const errors = figureList.filter(({ errors }) => errors && !!errors.length)
 
-  /**
-   * Add IIIFConfig to global data
-   */
-  eleventyConfig.globalData.iiifConfig = config
+    if (errors.length) {
+      logger.error('There were errors processing the following images:')
+      console.table(
+        errors.map(({ errors, figure }) => {
+          return { id: figure.id, errors: errors.join(' ') }
+        }),
+        ['id', 'errors']
+      )
+    }
 
-  /**
-   * Update global figures data to only have properties for Quire shortcodes
-   */
-  Object.assign(
-    figureList,
-    figures.map(({ figure }) => figure.adapter()),
-  )
-  logger.info('Processing complete')
+    /**
+     * Add IIIFConfig to global data
+     */
+    eleventyConfig.globalData.iiifConfig = config
+
+    /**
+     * Update global figures data to only have properties for Quire shortcodes
+     */
+    Object.assign(
+      figureList,
+      figures.map(({ figure }) => figure.adapter()),
+    )
+    logger.info('Processing complete')
+  })
 }


### PR DESCRIPTION
Fixes:
- [DEV-14530](https://jira.getty.edu/browse/DEV-14530), [DEV-14531](https://jira.getty.edu/browse/DEV-14531)

While plugins run in the order they are listed, the only way to guarantee an async plugin has finished executing before other plugins is to run it in the `eleventy.before` hook. The errors in both of the above tickets were due to the figures plugin not having completed updating global data before other plugins ran.

Changes:
- Move figures plugin into `eleventy.before` hook