### PR TITLE
Add directoryConfig to globalData

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -39,7 +39,7 @@ const { error } = chalkFactory('eleventy config')
 
 const inputDir = process.env.ELEVENTY_INPUT || 'content'
 const outputDir = process.env.ELEVENTY_OUTPUT || '_site'
-const publicDir = 'public'
+const publicDir = process.env.ELEVENTY_ENV === 'production' ? 'public' : false // yes, false
 
 /**
  * Eleventy configuration

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -126,9 +126,9 @@ module.exports = function(eleventyConfig) {
    * so that data can be provided to the config or another plugin.
    */
   dataExtensionsPlugin(eleventyConfig)
-  const globalData = globalDataPlugin(eleventyConfig, { inputDir })
+  const globalData = globalDataPlugin(eleventyConfig, { inputDir, outputDir, publicDir })
   const collections = collectionsPlugin(eleventyConfig)
-  vitePlugin(eleventyConfig, { globalData, inputDir, outputDir, publicDir })
+  vitePlugin(eleventyConfig, globalData)
 
   eleventyConfig.addPlugin(i18nPlugin)
   eleventyConfig.addPlugin(figuresPlugin)

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -39,7 +39,7 @@ const { error } = chalkFactory('eleventy config')
 
 const inputDir = process.env.ELEVENTY_INPUT || 'content'
 const outputDir = process.env.ELEVENTY_OUTPUT || '_site'
-const publicDir = process.env.ELEVENTY_ENV === 'production' ? 'public' : false // yes, false
+const publicDir = process.env.ELEVENTY_ENV === 'production' ? 'public' : false // publicDir should be set explicitly to false in development 
 
 /**
  * Eleventy configuration

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -6,15 +6,15 @@ const logger = chalkFactory('Figures:IIIF:Config', 'DEBUG')
 
 module.exports = (eleventyConfig) => {
   const { url } = eleventyConfig.globalData.publication
-  const { publicDir } = eleventyConfig.globalData.directoryConfig
+  const { inputDir, outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
   const { port=8080 } = eleventyConfig.serverOptions
 
-  const projectRoot = path.resolve(eleventyConfig.dir.input, '..')
+  const projectRoot = path.resolve(inputDir, '..')
 
   // logger.debug(`projectRoot: ${projectRoot}`)
 
   const resolveInputPath = () => {
-    const resolvedPath = path.resolve(eleventyConfig.dir.input)
+    const resolvedPath = path.resolve(inputDir)
     // logger.debug(`inputPath: ${resolvedPath}`)
     return resolvedPath
   }
@@ -23,7 +23,7 @@ module.exports = (eleventyConfig) => {
   const resolveOutputPath = () => {
     const resolvedPath = publicDir
       ? path.resolve(projectRoot, publicDir)
-      : path.resolve(projectRoot, eleventyConfig.dir.output)
+      : path.resolve(projectRoot, outputDir)
 
     // logger.debug(`ouputPath: ${resolvedPath}`)
     return resolvedPath

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -19,7 +19,6 @@ module.exports = (eleventyConfig) => {
     return resolvedPath
   }
 
-  // @todo abstract this concern to decouple this plugin from vite
   const resolveOutputPath = () => {
     const resolvedPath = publicDir
       ? path.resolve(projectRoot, publicDir)

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -6,6 +6,7 @@ const logger = chalkFactory('Figures:IIIF:Config', 'DEBUG')
 
 module.exports = (eleventyConfig) => {
   const { url } = eleventyConfig.globalData.publication
+  const { publicDir } = eleventyConfig.globalData.directoryConfig
   const { port=8080 } = eleventyConfig.serverOptions
 
   const projectRoot = path.resolve(eleventyConfig.dir.input, '..')
@@ -20,12 +21,8 @@ module.exports = (eleventyConfig) => {
 
   // @todo abstract this concern to decouple this plugin from vite
   const resolveOutputPath = () => {
-    const { viteOptions } = eleventyConfig.plugins.find(
-      ({ options }) => !!options && !!options.viteOptions
-    ).options
-
-    const resolvedPath = viteOptions && viteOptions.publicDir
-      ? path.resolve(projectRoot, viteOptions.publicDir)
+    const resolvedPath = publicDir
+      ? path.resolve(projectRoot, publicDir)
       : path.resolve(projectRoot, eleventyConfig.dir.output)
 
     // logger.debug(`ouputPath: ${resolvedPath}`)

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -57,9 +57,14 @@ const validatePublication = (publication) => {
  * so that it is available to shortcode components.
  * Nota bene: data is loaded from a sub directory of the `input` directory,
  * distinct from the `eleventyConfig.dir.data` directory.
+ *
+ * @param {Object} directoryConfig
+ * @property {String} inputDir
+ * @property {String} outputDir
+ * @property {String} publicDir
  */
-module.exports = function(eleventyConfig, { inputDir }) {
-  const dir = path.resolve(inputDir, '_data')
+module.exports = function(eleventyConfig, directoryConfig) {
+  const dir = path.resolve(directoryConfig.inputDir, '_data')
   // console.debug(`[plugins:globalData] ${dir}`)
   const files = fs.readdirSync(dir)
     .filter((file) => path.extname(file) !== '.md')
@@ -76,5 +81,9 @@ module.exports = function(eleventyConfig, { inputDir }) {
       eleventyConfig.addGlobalData(key, value)
     }
   }
+
+  // Add directory config to globalData so that it is available to other plugins
+  eleventyConfig.globalData.directoryConfig = directoryConfig
+
   return eleventyConfig.globalData
 }

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -54,10 +54,12 @@ const validatePublication = (publication) => {
 
 /**
  * Eleventy plugin to programmatically load global data from files
- * so that it is available to shortcode components.
+ * so that it is available to plugins and shortcode components.
+ *
  * Nota bene: data is loaded from a sub directory of the `input` directory,
  * distinct from the `eleventyConfig.dir.data` directory.
  *
+ * @param {Object} eleventyConfig
  * @param {Object} directoryConfig
  * @property {String} inputDir
  * @property {String} outputDir

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -8,15 +8,18 @@ const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite')
  *
  * Runs Vite as Middleware in the Eleventy Dev Server
  * Runs Vite build to postprocess the Eleventy build output
+ *
+ * @param {Object} eleventyConfig
+ * @param {Object} globalData
  */
-module.exports = function (eleventyConfig, pluginConfig) {
-  const { globalData, inputDir, outputDir, publicDir } = pluginConfig
-  const { pathname } = globalData.publication 
+module.exports = function (eleventyConfig, { directoryConfig, publication }) {
+  const { pathname } = publication
+  const { inputDir, outputDir, publicDir } = directoryConfig
 
   eleventyConfig.addPlugin(EleventyVitePlugin, {
     tempFolderName: '.11ty-vite',
     viteOptions: {
-      publicDir: process.env.ELEVENTY_ENV === 'production' ? publicDir : false,
+      publicDir,
       /**
        * @see https://vitejs.dev/config/#build-options
        */


### PR DESCRIPTION
The directory config is not available to immediately invoked plugins (like vite), so previously we were passing directories explicitly. Additionally, the `publicDir` was not available in the global data at all, so the `iiifConfig` was previously parsing the vite options to get it.

Changes:
- Provide `inputDir` `outputDir` and `publicDir` to globalData plugin and add them to globalData under `directoryConfig` key
- Decouple `iiifConfig` from vite plugin