### PR TITLE
Sequence UI Interactions

### DIFF
--- a/packages/11ty/_includes/components/figure/image/html.js
+++ b/packages/11ty/_includes/components/figure/image/html.js
@@ -6,7 +6,7 @@ const path = require('path')
  *
  * @param      {Object} eleventyConfig  eleventy configuration
  * @param      {Object} figure          The figure object
- * 
+ *
  * @return     {String}  HTML containing  a `figureImageElement`, a caption and annotations UI
  */
 module.exports = function(eleventyConfig) {
@@ -20,10 +20,11 @@ module.exports = function(eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
 
   return function(figure) {
-    const { 
+    const {
       caption,
       credit,
       id,
+      isSequence,
       label
     } = figure
 
@@ -33,7 +34,9 @@ module.exports = function(eleventyConfig) {
     /**
      * Wrap image in modal link
      */
-    const imageElement = figureModalLink({ content: figureImageElement(figure), id })
+    const imageElement = isSequence
+      ? figureImageElement(figure)
+      : figureModalLink({ content: figureImageElement(figure), id, isSequence })
 
     const captionElement = figureCaption({ caption, content: labelElement, credit })
 

--- a/packages/11ty/_includes/components/figure/image/sequence-panel.js
+++ b/packages/11ty/_includes/components/figure/image/sequence-panel.js
@@ -16,7 +16,6 @@ module.exports = function(eleventyConfig) {
    * @property  {String} manifestId The id of the manifest to render
    * @property  {String} preset <sequence-panel> preset {@link https://iiif-canvas-panel.netlify.app/docs/examples/responsive-image#presets}
    * @property  {String} startCanvas The id of the canvas to display first in the sequence
-
    *
    * @return {String}        <sequence-panel> markup
    */
@@ -28,8 +27,8 @@ module.exports = function(eleventyConfig) {
       margin='',
       preset='responsive',
       startCanvas,
-      textEnabled='true',
-      textSelectionEnabled='true',
+      textEnabled='false',
+      textSelectionEnabled='false',
     } = data
 
     if (!manifestId) {

--- a/packages/11ty/_includes/components/figure/image/sequence-panel.js
+++ b/packages/11ty/_includes/components/figure/image/sequence-panel.js
@@ -25,7 +25,7 @@ module.exports = function(eleventyConfig) {
       id,
       manifestId,
       margin='',
-      preset='responsive',
+      preset='static',
       startCanvas,
       textEnabled='false',
       textSelectionEnabled='false',

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -1,3 +1,4 @@
+const path = require('path')
 /**
  * Head Tag
  *
@@ -11,7 +12,7 @@ module.exports = function(eleventyConfig) {
   const twitterCard = eleventyConfig.getFilter('twitterCard')
   const webComponents = eleventyConfig.getFilter('webComponents')
 
-  const { application, publication } = eleventyConfig.globalData
+  const { application, figures, publication } = eleventyConfig.globalData
 
   /**
    * @param  {Object} params The Whole Dang Data Object, from base.11ty.js
@@ -23,6 +24,21 @@ module.exports = function(eleventyConfig) {
       : publication.title
 
     const description = publication.description.full || publication.description.one_line
+
+    const figureTilePreloadLinks = figures.figure_list
+      .filter(({ isSequence }) => isSequence)
+      .map(({ sequences }) => {
+        return sequences[0].items.map(({ uri }) => {
+          const { ext } = path.parse(uri)
+          console.warn('EXT', ext)
+          if (ext === '.json') {
+            // TODO lookup the tile defaults - need paths from sharp output
+            return ''
+          } else {
+            return `<link rel="preload" as="image" href="${uri}">`
+          }
+        }).join('\n')
+      }).join('\n')
 
     const publisherLinks = publication.publisher
       .filter(({ url }) => url)
@@ -58,6 +74,8 @@ module.exports = function(eleventyConfig) {
 
         <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56" type="module"></script>
         <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
+
+        ${figureTilePreloadLinks}
 
         ${publisherLinks}
 

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -190,6 +190,7 @@ module.exports = class Figure {
       mediaType: this.mediaType,
       printImage: this.printImage,
       region: this.region,
+      sequences: this.sequences,
       startCanvas,
       src: this.src
     }


### PR DESCRIPTION
- Don't display sequence panels inside a `figureModalLink`
- Pre-load non-zoom sequence images
- Pass `sequences` through figure `adapter()`
- Set sequence panel to `preset="static"` by default
