### PR TITLE
DEV-14564: Fix issue where URL `pathname` for sub-directory deploys is dropped

### DIFF
--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -60,14 +60,14 @@ module.exports = class Annotation {
       if (!isImageService) return
       const tilesPath = path.join(outputDir, name, iiifConfig.tilesDirName)
       const infoPath = path.join(tilesPath, 'info.json')
-      return new URL(infoPath, iiifConfig.baseURI).toString()
+      return new URL(path.join(iiifConfig.baseURI, infoPath)).toString()
     }
 
     const uri = () => {
       const filepath = isImageService
         ? info()
         : path.join(outputDir, base)
-      return new URL(filepath, iiifConfig.baseURI).toString()
+      return new URL(path.join(iiifConfig.baseURI, filepath)).toString()
     }
 
     this.format = text && !src ? 'text/plain' : mime.lookup(src)

--- a/packages/11ty/_plugins/figures/iiif/manifest/writer.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/writer.js
@@ -14,8 +14,8 @@ module.exports = class ManifestWriter {
    */
   write(manifest) {
     if (!manifest) return { errors: ['Error writing manifest. Manifest is undefined.'] }
-    const uri = new URL(manifest.id)
-    const outputPath = path.join(this.outputRoot, uri.pathname)
+    const uriPathname = manifest.id.replace(this.baseURI, '')
+    const outputPath = path.join(this.outputRoot, uriPathname)
     try {
       fs.ensureDirSync(path.parse(outputPath).dir)
       fs.writeJsonSync(outputPath, manifest)


### PR DESCRIPTION
With a sub-directory deploy path set in `publication.yaml`,
```yaml
url: 'https://quire.reclaim.hosting/test-rc5'
```
URIs for annotations were getting created incorrectly. One would assume that creating a `new URL(pathname, basename)` would add `pathname` after `basename` even when `basename` has a subpath (e.g. `test-rc5`), but that is not the case:
```javascript
filePath = '/iiif/mother-annotations/scratches.png'
iiifConfig.baseURI = 'https://quire.reclaim.hosting/test-rc5'

new URL(filepath, iiifConfig.baseURI)
URL {
  href: 'https://quire.reclaim.hosting/iiif/mother-annotations/scratches.png',
  origin: 'https://quire.reclaim.hosting',
  protocol: 'https:',
  username: '',
  password: '',
  host: 'quire.reclaim.hosting',
  hostname: 'quire.reclaim.hosting',
  port: '',
  pathname: '/iiif/mother-annotations/scratches.png',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
} 

new URL(iiifConfig.baseURI)
URL {
  href: 'https://quire.reclaim.hosting/test-rc5',
  origin: 'https://quire.reclaim.hosting',
  protocol: 'https:',
  username: '',
  password: '',
  host: 'quire.reclaim.hosting',
  hostname: 'quire.reclaim.hosting',
  port: '',
  pathname: '/test-rc5',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```

I was not seeing the exact issue outlined in the ticket where there was a double slash in manifest urls, but I'm hoping this will fix both issues, as this
```
https://quire.reclaim.hosting/test-rc5//iiif/mother-variants/manifest.json 
```
now shows up as:
```
https://quire.reclaim.hosting/test-rc5/iiif/mother-variants/manifest.json
```

Additionally, the `Manifest` `Writer` was using the entire URL `pathname` to extract an output directory for manifests to write to, so `test-rc5` was being inserted into manifest output URLs