### PR TITLE
Remove `urlFilter` from TOC list/grid item

### DIFF
--- a/packages/11ty/_includes/components/table-of-contents/item/grid.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/grid.js
@@ -19,7 +19,6 @@ module.exports = function (eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const tableOfContentsImage = eleventyConfig.getFilter('tableOfContentsImage')
-  const urlFilter = eleventyConfig.getFilter('url')
   const { contributorDivider } = eleventyConfig.globalData.config.tableOfContents
   const { imageDir } = eleventyConfig.globalData.config.figures
 
@@ -108,7 +107,7 @@ module.exports = function (eleventyConfig) {
 
     if (isPage) {
       mainElement = html`
-        <a href="${urlFilter(page.url)}">
+        <a href="${page.url}">
           ${mainElement}
         </a>
       `

--- a/packages/11ty/_includes/components/table-of-contents/item/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/list.js
@@ -17,7 +17,6 @@ module.exports = function (eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const removeHTML = eleventyConfig.getFilter('removeHTML')
-  const urlFilter = eleventyConfig.getFilter('url')
   const { contributorDivider } = eleventyConfig.globalData.config.tableOfContents
 
   return function (params) {
@@ -66,7 +65,7 @@ module.exports = function (eleventyConfig) {
     let mainElement = `${markdownify(pageTitleElement)}${isPage && !children ? arrowIcon : ''}`
 
     if (isPage) {
-      mainElement = `<a href="${urlFilter(page.url)}">${mainElement}</a>`
+      mainElement = `<a href="${page.url}">${mainElement}</a>`
     } else {
       classes.push('no-landing')
     }


### PR DESCRIPTION
@geealbers I think you are right, it looks like `urlFilter` was doubling the subpaths. I'm assuming we were using that for validation/sanitation purposes?

Let me know if this works