### PR TITLE
Fix issue where modals are not opening or rendering

### DIFF
--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -11,6 +11,7 @@ module.exports = async function(data) {
   const { pageClasses, collections, content, pageData, publication } = data
   const { inputPath, outputPath, url } = pageData || {}
   const pageId = this.slugify(url) || path.parse(inputPath).name
+  const figures = pageData.page.figures
 
   return html`
     <!doctype html>
@@ -37,7 +38,7 @@ module.exports = async function(data) {
           </div>
           ${this.search(data)}
         </div>
-        ${await this.modal()}
+        ${await this.modal(figures)}
         ${this.scripts()}
       </body>
     </html>

--- a/packages/11ty/_plugins/components/addShortcode.js
+++ b/packages/11ty/_plugins/components/addShortcode.js
@@ -13,7 +13,7 @@ module.exports = function(eleventyConfig, collections) {
   return function(tagName, component) {
     eleventyConfig.addShortcode(tagName, function(...args) {
       const page = collections.all.find(({ inputPath }) => inputPath === this.page.inputPath)
-      return component(eleventyConfig, { collections, page })(...args)
+      return component(eleventyConfig, { collections, page }).bind(this)(...args)
     })
   }
 }

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -41,8 +41,8 @@ module.exports = function (eleventyConfig, { page }) {
       return ''
     }
     figure = { ...figure, ...arguments }
-    if (!page.figures) page.figures = []
-    page.figures.push(figure)
+    if (!this.page.figures) this.page.figures = []
+    this.page.figures.push(figure)
 
     const { mediaType } = figure
 

--- a/packages/11ty/_plugins/shortcodes/figureGroup.js
+++ b/packages/11ty/_plugins/shortcodes/figureGroup.js
@@ -40,7 +40,7 @@ module.exports = function (eleventyConfig, { page }) {
       const startIndex = i * columns
       let row = ''
       for (let id of ids.slice(startIndex, columns + startIndex)) {
-        row += await figure(eleventyConfig, { page })(id, classes)
+        row += await figure(eleventyConfig, { page }).bind(this)(id, classes)
       }
       figureTags.push(`<div class="q-figure--group__row columns">${row}</div>`)
     }


### PR DESCRIPTION
This one's strange. I thought this was a bug related to 360 image sequence work, but found it happening with a current non-360 rc. 

The modal was not rendering, because `page.figures` was undefined, despite each figure shortcode appending its data to `page.figures`

It has been fixed by binding the `this` context to all components added with `addShortcode`, which allows figure shortcodes to cumulatively write to `this.page.figures` instead of `page.figures`