### PR TITLE
DEV-14988: Add extra height constraints to prevent image-sequences from rendering outside of catalog lightbox boundaries

### DIFF
--- a/packages/11ty/_includes/components/figure/image/image-sequence.webc
+++ b/packages/11ty/_includes/components/figure/image/image-sequence.webc
@@ -415,7 +415,13 @@ img.${placeholder} {
 }
 </script>
 <style>
+image-sequence {
+  display: block;
+  height: 100%;
+}
+
 .image-sequence.interactive {
+  height: 100%;
   cursor: grab;
 }
 </style>


### PR DESCRIPTION
See these companion PRs with lightbox style updates (all three are identical, we should really move these styles into quire core soon):
- https://github.com/thegetty/quire-starter-default/pull/30
- https://github.com/thegetty/quire-starter-iiif/pull/3
- https://github.com/thegetty/quire-starter-demo/pull/1