### PR TITLE
DEV-14840: Add support for IIIF `viewingDirection` property to image sequences

### DIFF
--- a/packages/11ty/_includes/components/figure/image/image-sequence.webc
+++ b/packages/11ty/_includes/components/figure/image/image-sequence.webc
@@ -56,8 +56,9 @@ if (!window.customElements.get('image-sequence')) {
       this.items = this.getAttribute('items').split(',');
       this.oldX = null;
       this.imagesLoaded = 0;
-      this.isInteractive = this.getAttribute('interactive') === 'true';
       this.isContinuous = this.getAttribute('continuous') === 'true';
+      this.isInteractive = this.getAttribute('interactive') === 'true';
+      this.isReversed = this.getAttribute('reverse') === 'true';
       this.sequenceId = this.getAttribute('sequence-id');
       this.totalCanvases = this.items.length;
 
@@ -296,25 +297,19 @@ img.${placeholder} {
       };
     }
 
-    handleSequenceNavigation({ clientX, target }) {
-      const draggingLeft = clientX < this.oldX;
-      const draggingRight = clientX > this.oldX;
-      if (draggingLeft) {
-        this.previousCanvas();
-      } else if (draggingRight) {
-        this.nextCanvas();
-      }
-    }
-
     handleMouseMove({ buttons, clientX }) {
       if (buttons) {
         this.hideOverlays();
         if (this.oldX) {
           const deltaX = clientX - this.oldX;
           if (deltaX > 0) {
-            this.nextCanvas(deltaX);
+            this.isReversed
+              ? this.previousCanvas(deltaX)
+              : this.nextCanvas(deltaX);
           } else if (deltaX < 0) {
-            this.previousCanvas(deltaX);
+            this.isReversed
+              ? this.nextCanvas(deltaX)
+              : this.previousCanvas(deltaX);
           }
         }
         this.oldX = clientX;

--- a/packages/11ty/_includes/components/figure/image/sequence.js
+++ b/packages/11ty/_includes/components/figure/image/sequence.js
@@ -10,13 +10,15 @@ module.exports = function(eleventyConfig) {
     const includesDir = path.join(eleventyConfig.dir.input, eleventyConfig.dir.includes)
     const componentPathname = __dirname.split(includesDir)[1]
     const filePath = path.join(includesDir, componentPathname, fileName)
+    const reverse = sequences[0].viewingDirection === 'right-to-left'
     // const filePath = path.join('_includes', 'components', 'figure', 'image', 'image-sequence.webc')
     return await renderWebcComponent(filePath, {
       'continuous': continuous,
       'index': startCanvasIndex,
       'items': itemUris,
       'interactive': interactive,
-      'sequence-id': id
+      'sequence-id': id,
+      'reverse': reverse
     })
   }
 }

--- a/packages/11ty/_plugins/figures/iiif/manifest/sequence-builder.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/sequence-builder.js
@@ -25,7 +25,7 @@ module.exports = class SequenceBuilder {
   }
 
   createSequence(sequence, index) {
-    const { figure, label } = sequence
+    const { figure, label, viewingDirection='left-to-right' } = sequence
     const { iiifConfig, outputDir } = figure
     const { baseURI } = iiifConfig
     const items = this.items.slice(sequence.startIndex)
@@ -33,7 +33,8 @@ module.exports = class SequenceBuilder {
     const structure = {
       id,
       items,
-      type: 'Range'
+      type: 'Range',
+      viewingDirection
     }
     if (label) {
       structure.label = { en: [ label ] }

--- a/packages/11ty/_plugins/figures/sequence/index.js
+++ b/packages/11ty/_plugins/figures/sequence/index.js
@@ -20,6 +20,7 @@ module.exports = class Sequence {
     this.files = getSequenceFiles(sequence, iiifConfig)
     this.regex = sequence.regex
     this.start = sequence.start
+    this.viewingDirection = sequence.viewingDirection
   }
 
   get items() {

--- a/packages/11ty/_plugins/figures/sequence/index.js
+++ b/packages/11ty/_plugins/figures/sequence/index.js
@@ -20,7 +20,7 @@ module.exports = class Sequence {
     this.files = getSequenceFiles(sequence, iiifConfig)
     this.regex = sequence.regex
     this.start = sequence.start
-    this.viewingDirection = sequence.viewingDirection
+    this.viewingDirection = sequence.viewing_direction
   }
 
   get items() {


### PR DESCRIPTION
- Update `Sequence` class to support IIIF `viewingDirection` property, and `image-sequence.webc` to support `reverse` attribute
- Write `viewingDirection` property to manifest `range`

This update allows the `viewingDirection` property to be set in `figures.yaml` (see https://iiif.io/api/presentation/3.0/#viewingdirection). By default, this is set to `left-to-right`. To reverse the order, set `viewingDirection: "right-to-left"`:

```yaml
  - id: "rotating"
    zoom: true
    label: "Figure 4"
    caption: "Head of a Woman, 350–300 B.C., Unknown (Greek (Sicilian)). Terracotta with white slip and polychromy (pink, red, dark pink, white, purple), 28.8 × 19.1 × 15.1 cm (11 5/16 × 7 1/2 × 5 15/16 in.)."
    credit: "The J. Paul Getty Museum, Villa Collection, Malibu, California, Gift of Dr. Max Gerchik, 76.AD.34"
    sequences:
      - id: "figures/terracotta/"
        behavior:
          - continuous
          - sequence
        start: 171.jpg
        viewingDirection: "right-to-left"
```

see https://github.com/thegetty/quire-starter-iiif/pull/4