### PR TITLE
Allow sort_as to override both full and id values for bibliographies

### DIFF
--- a/packages/11ty/_plugins/filters/sortReferences.js
+++ b/packages/11ty/_plugins/filters/sortReferences.js
@@ -31,8 +31,8 @@ module.exports = function (eleventyConfig, items) {
 
   return items.sort((itemA, itemB) => {
     const sortById = eleventyConfig.globalData.config.bibliography.displayShort
-    let a = sortById ? itemA.id : itemA.sort_as || itemA.full
-    let b = sortById ? itemB.id : itemB.sort_as || itemB.full
+    let a = sortById ? itemA.sort_as || itemA.id : itemA.sort_as || itemA.full
+    let b = sortById ? itemB.sort_as || itemB.id : itemB.sort_as || itemB.full
     a = removeMarkdown(a)
     b = removeMarkdown(b)
     return a.localeCompare(b, locales, options)


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

Issue #739 

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

To allow `sort_as` values to work for overriding the default bibliography sorting regardless of whether the biblio is sorting by the `id` value (as is the case when `bibliography.displayShort` is set to true), or by the `full` value.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

I updated the sortReferences.js filter to choose `sort_as` before `id`, just like it was already set to choose `sort_as` before `full`.

### Does this pull request necessitate changes to Quire's documentation?

No.

### Include screenshots of before/after if applicable.



### Additional Comments

