### PR TITLE
Update to epubjs-cli@0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "root",
+  "name": "@thegetty/quire",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "root",
+      "name": "@thegetty/quire",
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE"
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "conf": "^11.0.1",
     "cross-env": "^7.0.3",
     "del": "^7.0.0",
-    "epubjs-cli": "^0.1.2",
+    "epubjs-cli": "^0.1.3",
     "execa": "^6.1.0",
     "fs-extra": "^11.1.0",
     "hosted-git-info": "^6.1.1",


### PR DESCRIPTION
Update to `epubjs-cli@0.1.3`

- Fixes extra itemref in epub manifest: https://github.com/thegetty/quire/issues/717
- Fixes epub cover and author meta: https://github.com/thegetty/quire/issues/715
- Generate epub item IDs from full url path: https://github.com/thegetty/quire/issues/718
- Allows using `date` in manifest: https://github.com/thegetty/quire/issues/716