### PR TITLE
Remove duplicate print stylesheet compilation from `transforms/outputs/pdf/write.js`

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -74,7 +74,6 @@ module.exports = (eleventyConfig) => {
     try {
       const stylesDir = path.join(inputDir, '_assets', 'styles')
       const application = sass.compile(path.resolve(stylesDir, 'application.scss'), sassOptions)
-      const print = sass.compile(path.resolve(stylesDir, 'print.scss'), sassOptions)
       const custom = sass.compile(path.resolve(stylesDir, 'custom.css'), sassOptions)
       fs.writeFileSync(path.join(outputDir, 'pdf.css'), application.css + print.css + custom.css)
     } catch (error) {

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -75,7 +75,7 @@ module.exports = (eleventyConfig) => {
       const stylesDir = path.join(inputDir, '_assets', 'styles')
       const application = sass.compile(path.resolve(stylesDir, 'application.scss'), sassOptions)
       const custom = sass.compile(path.resolve(stylesDir, 'custom.css'), sassOptions)
-      fs.writeFileSync(path.join(outputDir, 'pdf.css'), application.css + print.css + custom.css)
+      fs.writeFileSync(path.join(outputDir, 'pdf.css'), application.css + custom.css)
     } catch (error) {
       logger.error(`Eleventy transform for PDF error compiling SASS. Error message: ${error}`)
     }


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

DEV-13808

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Remove duplicate print styles from print output.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

The `print.scss` stylesheet was being compiled in the PDF transform, but since it was already imported by `application.scss` they were being duplicated

### Does this pull request necessitate changes to Quire's documentation?

No

### Include screenshots of before/after if applicable.



### Additional Comments