### PR TITLE
DEV-13197: Fix missing fonts in PDF output

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -72,10 +72,13 @@ module.exports = (eleventyConfig) => {
     }
 
     try {
+      const fontsDir = path.join(inputDir, '_assets', 'fonts')
+      const fonts = sass.compile(path.resolve(fontsDir, 'index.scss'), sassOptions)
+      fonts.css = fonts.css.replaceAll('/_assets', '_assets')
       const stylesDir = path.join(inputDir, '_assets', 'styles')
       const application = sass.compile(path.resolve(stylesDir, 'application.scss'), sassOptions)
       const custom = sass.compile(path.resolve(stylesDir, 'custom.css'), sassOptions)
-      fs.writeFileSync(path.join(outputDir, 'pdf.css'), application.css + custom.css)
+      fs.writeFileSync(path.join(outputDir, 'pdf.css'), fonts.css + application.css + custom.css)
     } catch (error) {
       logger.error(`Eleventy transform for PDF error compiling SASS. Error message: ${error}`)
     }

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -8,6 +8,7 @@
  */
 
 // Stylesheets
+import "../../fonts/index.scss";
 import '../../styles/application.scss'
 import '../../styles/custom.css'
 


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?



### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Modifies @font-face declaration `src` paths to be relative in PDF output

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

- Import new `_assets/fonts/index.scss` into `_assets/javascript/application/index`
- Replace all instances of `/_assets` file path with `_assets` (no leading slash) in `@font-face` declarations in compiled `pdf.css` stylesheet

### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

Depends on changes to Quire starter templates
