### PR TITLE
Add project quire-cli version to `info` output

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -18,6 +18,13 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.9]
+
+### Added
+- Update old `.quire` files  when running `info` command on versions prior to `1.0.0-rc.8`
+- Include `quire-cli` version used to generate project in `info` output
+- Adds headings to `info` output
+
 ## [1.0.0-rc.8]
 
 ### Added

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-rc.8",
+      "version": "1.0.0-rc.9",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "boxen": "^7.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -47,7 +47,8 @@ export default class InfoCommand extends Command {
       console.warn(
         `This project was generated with the quire-cli prior to version 1.0.0.rc-8. Updating the version file to the new format, though this project's version file will not contain specific starter version information.`
       )
-      fs.writeFileSync(VERSION_FILE, JSON.stringify({ cli: '<=1.0.0.rc-7' }))
+      versionFile = { cli: '<=1.0.0.rc-7' }
+      fs.writeFileSync(VERSION_FILE, JSON.stringify(versionFile))
     }
 
     const { name: projectDirectory } = path.parse(process.cwd())

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -55,10 +55,7 @@ export default class InfoCommand extends Command {
         items: [
           {
             name: 'quire-cli',
-            get: () => {
-              const { cli } = versionFile
-              return cli && `${cli}`
-            },
+            get: () => versionFile.cli,
           },
           {
             name: 'quire-11ty',
@@ -69,10 +66,7 @@ export default class InfoCommand extends Command {
           },
           {
             name: 'starter',
-            get: () => {
-              const { starter } = versionFile
-              return starter && (starter.path || starter.version) && `${starter.path} ${starter.version}`
-            },
+            get: () =>  versionFile.starter,
           },
         ],
       },

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -21,7 +21,9 @@ export default class InfoCommand extends Command {
     summary: 'list info',
     version: '1.0.0',
     args: [],
-    options: [['--debug', 'include os versions in output']],
+    options: [
+      ['--debug', 'include os versions in output']
+    ],
   }
 
   constructor() {
@@ -66,7 +68,7 @@ export default class InfoCommand extends Command {
           },
           {
             name: 'starter',
-            get: () =>  versionFile.starter,
+            get: () => versionFile.starter,
           },
         ],
       },

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -39,13 +39,14 @@ export default class InfoCommand extends Command {
       console.debug('[CLI] Command \'%s\' called', this.name())
     }
 
-    let versionFile = {}
+    let versionFile = fs.readFileSync(VERSION_FILE, { encoding: 'utf8' })
     try {
-      versionFile = JSON.parse(fs.readFileSync(VERSION_FILE))
+      versionFile = JSON.parse(versionFile)
     } catch (error) {
       console.warn(
-        `This project was generated with quire-cli version < 1.0.0.rc-8 so we cannot determine which cli or starter version was used to create it.`
+        `This project was generated with quire-cli prior to version 1.0.0.rc-8, the quire version file does not contain specific version information.`
       )
+      fs.writeFileSync(VERSION_FILE, JSON.stringify({}))
     }
 
     const versions = [
@@ -56,7 +57,7 @@ export default class InfoCommand extends Command {
             name: 'quire-cli',
             get: () => {
               const { cli } = versionFile
-              return cli ? `${cli}` : 'unknown'
+              return cli && `${cli}`
             },
           },
           {
@@ -70,7 +71,7 @@ export default class InfoCommand extends Command {
             name: 'starter',
             get: () => {
               const { starter } = versionFile
-              return starter ? `${starter.path} ${starter.version}` : 'unknown'
+              return starter && (starter.path || starter.version) && `${starter.path} ${starter.version}`
             },
           },
         ],

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -21,9 +21,7 @@ export default class InfoCommand extends Command {
     summary: 'list info',
     version: '1.0.0',
     args: [],
-    options: [
-      [ '--debug', 'include os versions in output' ],
-    ],
+    options: [['--debug', 'include os versions in output']],
   }
 
   constructor() {
@@ -32,7 +30,11 @@ export default class InfoCommand extends Command {
 
   async action(options, command) {
     if (options.debug) {
-      console.debug('[CLI] Command \'%s\' called with options %o', this.name(), options)
+      console.debug(
+        '[CLI] Command \'%s\' called with options %o',
+        this.name(),
+        options
+      )
     } else {
       console.debug('[CLI] Command \'%s\' called', this.name())
     }
@@ -55,23 +57,23 @@ export default class InfoCommand extends Command {
             get: () => {
               const { cli } = versionFile
               return cli ? `${cli}` : 'unknown'
-            }
+            },
           },
           {
             name: 'quire-11ty',
             get: () => {
               const { version } = JSON.parse(fs.readFileSync('./package.json'))
               return version
-            }
+            },
           },
           {
             name: 'starter',
             get: () => {
               const { starter } = versionFile
               return starter ? `${starter.path} ${starter.version}` : 'unknown'
-            }
+            },
           },
-        ]
+        ],
       },
       {
         title: '[Operating System]',
@@ -80,8 +82,8 @@ export default class InfoCommand extends Command {
           {
             name: os.type(),
             get: () => os.release(),
-          }
-        ]
+          },
+        ],
       },
       {
         title: '[Node]',
@@ -89,16 +91,16 @@ export default class InfoCommand extends Command {
         items: [
           {
             name: 'node',
-            get: () => process.version
+            get: () => process.version,
           },
           {
             name: 'npm',
             get: async () => {
               const { stdout } = await execaCommand('npm --version')
               return stdout
-            }
-          }
-        ]
+            },
+          },
+        ],
       },
       {
         title: '[Local Quire Version]',
@@ -108,28 +110,22 @@ export default class InfoCommand extends Command {
             get: async () => {
               const { stdout } = await execaCommand('quire --version')
               return stdout
-            }
-          }
-        ]
-      }
+            },
+          },
+        ],
+      },
     ]
 
     /**
      * Filter the command output based on `debug` settings
      */
     versions
-      .filter(({ debug }) => !debug || options.debug && debug)
-      .forEach(async (item) => {
+      .filter(({ debug }) => !debug || (options.debug && debug))
+      .forEach(async ({ items, title }) => {
         const versions = await Promise.all(
-          item.items.map(
-            async ({ name, get }) => {
-              const version = await get()
-              return `${name} ${version}`
-            }
-          )
+          items.map(async ({ name, get }) => `${name} ${await get()}`)
         )
-        console.info(item.title)
-        console.info(` ${versions.join('\n ')}`)
+        console.info(`${title}\n ${versions.join('\n ')}`)
       })
   }
 

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -4,6 +4,8 @@ import fs from 'node:fs'
 import os from 'node:os'
 import testcwd from '#helpers/test-cwd.js'
 
+const VERSION_FILE = '.quire'
+
 /**
  * Quire CLI `info` Command
  *
@@ -35,12 +37,21 @@ export default class InfoCommand extends Command {
       console.debug('[CLI] Command \'%s\' called', this.name())
     }
 
+    let versionFile = {}
+    try {
+      versionFile = JSON.parse(fs.readFileSync(VERSION_FILE))
+    } catch (error) {
+      console.warn(
+        `This project was generated with quire-cli version < 1.0.0.rc-8 so we cannot determine which cli or starter version was used to create it.`
+      )
+    }
+
     const versions = [
       {
         name: 'quire-cli',
         get: async () => {
-          const { stdout } = await execaCommand('quire --version')
-          return stdout
+          const { cli } = versionFile
+          return cli ? `${cli}` : 'unknown'
         }
       },
       {
@@ -53,8 +64,8 @@ export default class InfoCommand extends Command {
       {
         name: 'starter',
         get: () => {
-          const { starter } = JSON.parse(fs.readFileSync('.quire'))
-          return `${starter.path} ${starter.version}`
+          const { starter } = versionFile
+          return starter ? `${starter.path} ${starter.version}` : 'unknown'
         }
       },
       {

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -127,10 +127,7 @@ async function initStarter (starter, projectPath, options) {
    */
   const versionInfo = { 
     cli: packageConfig.version,
-    starter: { 
-      path: starter,
-      version: starterVersion
-    }
+    starter: `${starter}@${starterVersion}`,
   }
   fs.writeFileSync(path.join(projectPath, VERSION_FILE), JSON.stringify(versionInfo))
 

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -6,7 +6,7 @@ import { isEmpty } from '#helpers/is-empty.js'
 import fs from 'fs-extra'
 import git from '#src/lib/git/index.js'
 import inv from 'install-npm-version'
-import packageConfig from '../../../package.json' assert { type: 'json' }
+import packageConfig from '#root/package.json' assert { type: 'json' }
 import path from 'node:path'
 import semver from 'semver'
 

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -6,6 +6,7 @@ import { isEmpty } from '#helpers/is-empty.js'
 import fs from 'fs-extra'
 import git from '#src/lib/git/index.js'
 import inv from 'install-npm-version'
+import packageConfig from '../../../package.json' assert { type: 'json' }
 import path from 'node:path'
 import semver from 'semver'
 
@@ -61,8 +62,8 @@ function getVersion(projectPath) {
  * logic can be removed
  */
 async function getVersionsFromStarter(projectPath) {
-  const packageConfig = fs.readFileSync(path.join(projectPath, 'package.json'), { encoding:'utf8' })
-  const { peerDependencies, version: starterVersion } = JSON.parse(packageConfig)
+  const projectPackageConfig = fs.readFileSync(path.join(projectPath, 'package.json'), { encoding:'utf8' })
+  const { peerDependencies, version: starterVersion } = JSON.parse(projectPackageConfig)
   const quire11ty = peerDependencies[PACKAGE_NAME]
   const quire11tyVersion = quire11ty === 'latest'
     ? await latest()
@@ -122,9 +123,16 @@ async function initStarter (starter, projectPath, options) {
   setVersion(projectPath, quireVersion)
 
   /**
-   * Write starter name and version to VERSION_FILE
+   * Write quire-11ty, cli, starter name and version to VERSION_FILE
    */
-  const versionInfo = { 'quire-11ty': quireVersion, starter: { path: starter, version: starterVersion } }
+  const versionInfo = { 
+    cli: packageConfig.version,
+    'quire-11ty': quireVersion, 
+    starter: { 
+      path: starter,
+      version: starterVersion
+    }
+  }
   fs.writeFileSync(path.join(projectPath, VERSION_FILE), JSON.stringify(versionInfo))
 
   // Re-initialize project directory as a new git repository

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -127,7 +127,6 @@ async function initStarter (starter, projectPath, options) {
    */
   const versionInfo = { 
     cli: packageConfig.version,
-    'quire-11ty': quireVersion, 
     starter: { 
       path: starter,
       version: starterVersion


### PR DESCRIPTION
Changes:
- Adds the quire-cli version used to generate the project to the `.quire` and includes it in the `info` command to be listed in addition to the local quire-cli version being used.
- Adds section headings to the different version types in the info command
- Log warning if `.quire` was generated with an older version of the cli that did not include the cli or starter versions, and updates file to JSON format for future use.

Example output when running `quire info` on a project with an old `.quire`:
```
This project was generated with the quire-cli prior to version 1.0.0.rc-8. Updating the version file to the new format, though this project's version file will not contain specific starter version information.
[scroll-interactions]
 quire-cli <=1.0.0.rc-7
 quire-11ty 1.0.0-rc.10
 starter undefined
[System]
 quire-cli 1.0.0-rc.9
```

Same project with debug output:
```
[scroll-interactions]
 quire-cli <=1.0.0.rc-7
 quire-11ty 1.0.0-rc.10
 starter undefined
[System]
 quire-cli 1.0.0-rc.9
 node v18.16.0
 npm 9.5.1
 os Darwin 22.4.0
```

Output from `quire info` on a project generated with >= `1.0.0-rc8` (includes the starter version and specific cli version)
```
[test-info]
 quire-cli 1.0.0-rc.8
 quire-11ty 1.0.0-rc.10
 starter https://github.com/thegetty/quire-starter-default@2.4.0
[System]
 quire-cli 1.0.0-rc.9
```