### PR TITLE
Ensure SVG symbol definitions are included in PDF output

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -65,6 +65,7 @@ module.exports = function(eleventyConfig, collections, content) {
   if (pdfPages.includes(this.outputPath)) {
     const { document } = new JSDOM(content).window
     const mainElement = document.querySelector('main[data-output-path]')
+    const svgSymbolElements = document.querySelectorAll('body > svg')
     const pageIndex = pdfPages.findIndex((path) => path === this.outputPath)
 
     if (mainElement) {
@@ -88,6 +89,7 @@ module.exports = function(eleventyConfig, collections, content) {
 
         // remove non-pdf content
         filterOutputs(sectionElement, 'pdf')
+        collections.pdf[pageIndex].svgSymbolElements = Array.from(svgSymbolElements)
         collections.pdf[pageIndex].sectionElement = sectionElement
       }
 

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -34,8 +34,11 @@ module.exports = (eleventyConfig) => {
     const dom = await JSDOM.fromFile(layoutPath)
     const { document } = dom.window
 
-    collection.forEach(({ outputPath, sectionElement }) => {
+    collection.forEach(({ outputPath, sectionElement, svgSymbolElements }) => {
       try {
+        svgSymbolElements.forEach((svgSymbolElement) => {
+          document.body.appendChild(svgSymbolElement)
+        })
         document.body.appendChild(sectionElement)
       } catch (error) {
         logger.error(`Eleventy transform for PDF error appending content for ${outputPath} to combined output. ${error}`)


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

DEV-13813

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Ensure Creative Commons license icons, and other icons display in PDF output

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Adds all SVG `<symbol>` definitions to `pdf.html`. In web output, these are always the first immediate child of `<body>`

### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

