### PR TITLE
DEV-15269: Render static image tag for sequence figures inline

### DIFF
--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -14,15 +14,19 @@ module.exports = function (eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
 
   return async function (figure, options) {
-    const { isCanvas, isImageService, isSequence } = figure
-    const { preset } = options
+    const { alt, isCanvas, isImageService, isSequence, staticInlineFigureImage } = figure
+    const { interactive, preset } = options
     if (preset) {
       figure.preset = preset
     }
 
     switch (true) {
       case isSequence:
-        return await imageSequence(figure, options)
+        if (!interactive && staticInlineFigureImage) {
+          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive })
+        } else {
+          return await imageSequence(figure, options)
+        }
       case isCanvas:
         return canvasPanel(figure)
       case isImageService:

--- a/packages/11ty/_includes/components/figure/image/image-tag.js
+++ b/packages/11ty/_includes/components/figure/image/image-tag.js
@@ -13,8 +13,8 @@ const path = require('path')
 module.exports = function(eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
 
-  return function ({ alt='', src='' }) {
-    const imageSrc = src.startsWith('http') ? src : path.join(imageDir, src)
+  return function ({ alt='', src='', isStatic=false }) {
+    const imageSrc = src.startsWith('http') || isStatic ? src : path.join(imageDir, src)
 
     return html`
       <img alt="${alt}" class="q-figure__image" src="${imageSrc}" />

--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -46,7 +46,7 @@ module.exports = function(eleventyConfig) {
             return figureVideoElement(figure)
           case mediaType === 'image':
           default:
-            return figureImageElement(figure, { preset: 'zoom' })
+            return figureImageElement(figure, { preset: 'zoom', interactive: true })
         }
       }
 

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -290,7 +290,10 @@ module.exports = class Figure {
     // TODO Consider refactor - any time `this.sequences` is referenced, it creates a new instance of SequenceFactory
     if (!this.sequences) return
     const { transformations } = this.iiifConfig
-    const [ sequenceStartFilename ] = this.sequences.flatMap(({ start }) => start)
+    const [ sequenceStartFilename ] = this.sequences.flatMap(({ files, start }) => {
+      const { name: firstFileName } = path.parse(files[0])
+      return start || firstFileName
+    })
     const { name: startId } = sequenceStartFilename ? path.parse(sequenceStartFilename) : {}
     const sequenceItems = this.sequences.flatMap(({ items }) => items)
     const results = await Promise.all(sequenceItems.map((item) => {

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -183,8 +183,8 @@ module.exports = class Figure {
     }
 
     if (!this.isExternalResource && filename) {
-      const { ext, name } = path.parse(filename)
-      return path.join('/', this.outputDir, name, `static-inline-figure-image${ext}`)
+      const { name } = path.parse(filename)
+      return path.join('/', this.outputDir, name, `static-inline-figure-image.jpg`)
     }
     return this.data.staticInlineFigure
   }

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -170,6 +170,26 @@ module.exports = class Figure {
   }
 
   /**
+   * Path to a static representation of the figure for inline display
+   * @type {String}
+   */
+  get staticInlineFigureImage() {
+    let filename
+    if (this.src) {
+      filename = this.src
+    } else if (this.sequences) {
+      const sequenceStart = this.sequences[0].start
+      filename = sequenceStart ? sequenceStart : this.sequences[0].files[0]
+    }
+
+    if (!this.isExternalResource && filename) {
+      const { ext, name } = path.parse(filename)
+      return path.join('/', this.outputDir, name, `static-inline-figure-image${ext}`)
+    }
+    return this.data.staticInlineFigure
+  }
+
+  /**
    * Return only the data properties consumed by quire shortcodes
    * @return {Object} figure
    */
@@ -196,7 +216,8 @@ module.exports = class Figure {
       region: this.region,
       sequences: this.sequences,
       startCanvasIndex,
-      src: this.src
+      src: this.src,
+      staticInlineFigureImage: this.staticInlineFigureImage,
     }
   }
 

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -114,7 +114,7 @@ module.exports = (eleventyConfig) => {
        * Transformation applied to IIIF resources for use in inline figures
        */
       {
-        name: 'static-inline-figure',
+        name: 'static-inline-figure-image',
         resize: {
           width: 626
         }

--- a/packages/11ty/_plugins/figures/schema.json
+++ b/packages/11ty/_plugins/figures/schema.json
@@ -149,6 +149,11 @@
           "type": "string",
           "pattern": "^(/[^/]+)+$"
         },
+        "staticInlineFigureImage": {
+          "description": "A relative path to an image project assets directory for static inline display",
+          "type": "string",
+          "pattern": "^(/[^/]+)+$"
+        },
         "zoom": {
           "description": "Enable image tiling for IIIF zoom interaction",
           "type": "boolean",


### PR DESCRIPTION
This update renders image sequence figures as a static `<img>` tag inline, retaining interactive click + drag functionality when opened in a modal.

@geealbers I hope this solves a good chunk of french-silver performance problems, let me know if this change is working