### PR TITLE
Feature: starter-11ty compatibility

### DIFF
--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -23,7 +23,7 @@ export default class CreateCommand extends Command {
     ],
     options: [
       [ '--quire-path <path>', 'local path to quire-11ty package' ],
-      [ '--quire-version <version>', 'quire-11ty version to install', 'latest' ],
+      [ '--quire-version <version>', 'quire-11ty version to install' ],
       // [ '--eject', 'install quire-11ty into the project directory', true ],
       [ '--debug', 'debug the `quire new` command', false ],
     ],

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -60,12 +60,12 @@ export default class CreateCommand extends Command {
        *   - interactive mode prompt to continue
        *   - non-interactive mode throw an error and exit the process
        */
-      await quire.initStarter(starter, projectPath, options)
+      const quireVersion = await quire.initStarter(starter, projectPath, options)
 
       options.eject = true
 
       if (options.eject) {
-        await quire.installInProject(projectPath, options)
+        await quire.installInProject(projectPath, quireVersion, options)
       } else {
         await quire.install(options)
       }

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -1,4 +1,5 @@
 import Command from '#src/Command.js'
+import fs from 'fs-extra'
 import { quire } from '#src/lib/quire/index.js'
 
 /**
@@ -60,7 +61,14 @@ export default class CreateCommand extends Command {
        *   - interactive mode prompt to continue
        *   - non-interactive mode throw an error and exit the process
        */
-      const quireVersion = await quire.initStarter(starter, projectPath, options)
+      let quireVersion
+      try {
+        quireVersion = await quire.initStarter(starter, projectPath, options)
+      } catch (error) {
+        console.error(error.message)
+        fs.removeSync(projectPath)
+        return
+      }
 
       options.eject = true
 

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -119,7 +119,6 @@ async function initStarter (starter, projectPath, options) {
    */
   const { quire11tyVersion, starterVersion } = await getVersionsFromStarter(projectPath)
   const quireVersion = options.quireVersion || quire11tyVersion
-
   setVersion(projectPath, quireVersion)
 
   /**
@@ -150,7 +149,7 @@ async function initStarter (starter, projectPath, options) {
    */
   const projectFiles = fs.readdirSync(projectPath)
   await git.init().add(projectFiles).commit('Initial Commit')
-
+  console.debug('quireVersion', quireVersion)
   return quireVersion
 }
 
@@ -211,8 +210,8 @@ async function install(options = {}) {
  * @param  {Object}  options  options passed from `quire new` command
  * @return  {Promise}
  */
-async function installInProject(projectPath, options = {}) {
-  const { quirePath, quireVersion } = options
+async function installInProject(projectPath, quireVersion, options = {}) {
+  const { quirePath } = options
   const quire11tyPackage = fs.existsSync(quirePath) ? quirePath : `${PACKAGE_NAME}@${quireVersion}`
   console.debug(`[CLI:quire] installing ${quire11tyPackage} into ${projectPath}`)
 

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -149,7 +149,6 @@ async function initStarter (starter, projectPath, options) {
    */
   const projectFiles = fs.readdirSync(projectPath)
   await git.init().add(projectFiles).commit('Initial Commit')
-  console.debug('quireVersion', quireVersion)
   return quireVersion
 }
 


### PR DESCRIPTION
Changes:
- Refactor `latest` to accept a semantic version range, such as `^1.0.0-rc`
- Log error message and clean up project if init starter fails
- Remove `latest` as default quire version option value. quire-11ty version will be determined by the option if provided or default to the version required by the starter.