### PR TITLE
Return figure group HTML in oneLine to avoid markdown errors

### DIFF
--- a/packages/11ty/_plugins/shortcodes/figureGroup.js
+++ b/packages/11ty/_plugins/shortcodes/figureGroup.js
@@ -1,4 +1,4 @@
-const { html } = require('~lib/common-tags')
+const { oneLine } = require('~lib/common-tags')
 const chalkFactory = require('~lib/chalk')
 const figure = require('./figure')
 
@@ -45,7 +45,7 @@ module.exports = function (eleventyConfig, { page }) {
       figureTags.push(`<div class="q-figure--group__row columns">${row}</div>`)
     }
 
-    return html`
+    return oneLine`
       <figure class="q-figure q-figure--group">
         ${figureTags.join('\n')}
       </figure>


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

No.

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Given this Markdown:

```md
1.  Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquet aliquam nisl non consectetur. Sed ipsum tortor, rhoncus non erat eu, tincidunt accumsan lacus.

    { figuregroup '2' 'fig-01, fig-02' }

2. Nam vestibulum molestie bibendum. Sed in orci commodo, sodales dui nec, auctor neque.

3. Praesent lobortis fermentum mauris, a ullamcorper mauris porttitor in. Sed cursus sapien varius odio viverra facilisis. 
```

The following HTML should be generated, with the `<figure>` element as a child of the first `<li>` since it is indented twice in the Markdow to keep it with the list item:

```html
<ol>
  <li>
    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquet aliquam nisl non consectetur. Sed ipsum tortor, rhoncus non erat eu, tincidunt accumsan lacus.</p>
    <figure> ... </figure>
  </li>
  <li>
    <p>Nam vestibulum molestie bibendum. Sed in orci commodo, sodales dui nec, auctor neque.</p>
  </li>
  <li>
    <p>Praesent lobortis fermentum mauris, a ullamcorper mauris porttitor in. Sed cursus sapien varius odio viverra facilisis.<p>
  <li>
</ol>
```

However, `_plugins/shortcodes/figureGroup.js` is returning its HTML with some spacing preceding it, and this is leading to Markdown errors and the list HTML markup is broken.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

The solution in this PR is simply to return the HTML from `figureGroup.js` as `oneLine` rather than `html`. This is consistent with the regular `figure.js` shortcode as well.

### Does this pull request necessitate changes to Quire's documentation?

No.

### Include screenshots of before/after if applicable.



### Additional Comments

