### PR TITLE
DEV-13813: Only write SVG symbol definitions to PDF output once

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -27,18 +27,22 @@ module.exports = (eleventyConfig) => {
   fs.ensureDirSync(path.parse(outputPath).dir)
 
   /**
-   * Write each page section in the PDF collection to a single HTML file
+   * Write each page section in the PDF collection to a single HTML file,
+   * as well as one instance of SVG symbol definitions
    * @param  {Object} collection collections.pdf with `sectionElement` property
    */
   return async (collection) => {
     const dom = await JSDOM.fromFile(layoutPath)
     const { document } = dom.window
 
-    collection.forEach(({ outputPath, sectionElement, svgSymbolElements }) => {
+    collection.forEach(({ outputPath, sectionElement, svgSymbolElements }, index) => {
       try {
-        svgSymbolElements.forEach((svgSymbolElement) => {
-          document.body.appendChild(svgSymbolElement)
-        })
+        // only write SVG symbol definitions one time
+        if (index === 0) {
+          svgSymbolElements.forEach((svgSymbolElement) => {
+            document.body.appendChild(svgSymbolElement)
+          })
+        }
         document.body.appendChild(sectionElement)
       } catch (error) {
         logger.error(`Eleventy transform for PDF error appending content for ${outputPath} to combined output. ${error}`)


### PR DESCRIPTION
@geealbers good catch, writing these SVGs for each section was an oversight, this should fix it

Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

DEV-13813

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

We were including SVG symbol definitions to display CC license icons in PDF output, but they were being included before each `<section>` element

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Only write SVG symbol definitions for the first collection index

### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

