### PR TITLE
CLI version 1.0.0-rc.10

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -18,6 +18,11 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.10]
+
+### Added
+- Support semantic version ranges for `quire-11ty` in quire starter projects and the `--quire-version` option of the `quire new` command, and use the latest compatible `quire-11ty` version when creating and installing a new project.
+
 ## [1.0.0-rc.9]
 
 ### Added

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-rc.9",
+      "version": "1.0.0-rc.10",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "boxen": "^7.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {


### PR DESCRIPTION
Includes change to install in new quire projects the latest compatible `quire-11ty` version specified in the starter or in the `quire new` option `--quire-version`.