### PR TITLE
DEV-14549: Markdownify `credit` and `label` in lightbox `slides.js`

### DIFF
--- a/packages/11ty/_includes/components/lightbox/slides.js
+++ b/packages/11ty/_includes/components/lightbox/slides.js
@@ -51,10 +51,10 @@ module.exports = function(eleventyConfig) {
       }
 
       const labelSpan = label
-        ? html`<span class="q-lightbox-slides__caption-label">${label}</span>`
+        ? html`<span class="q-lightbox-slides__caption-label">${markdownify(label)}</span>`
         : ''
       const captionAndCreditSpan = caption || credit
-        ? html`<span class="q-lightbox-slides__caption-content">${caption ? markdownify(caption) : ''} ${credit ? credit : ''}</span>`
+        ? html`<span class="q-lightbox-slides__caption-content">${caption ? markdownify(caption) : ''} ${credit ? markdownify(credit) : ''}</span>`
         : ''
       const captionElement = labelSpan.length || captionAndCreditSpan.length
         ? html`


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

https://github.com/thegetty/quire/issues/687

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Ensure `credit` and `label` in modal lightboxes render markdown text

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Apply the `markdownify` filter to `credit` and `label` as well as `caption`

### Does this pull request necessitate changes to Quire's documentation?



### Include screenshots of before/after if applicable.



### Additional Comments

