### PR TITLE
Render static figures inline; hide annotations inline

### DIFF
--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -28,9 +28,17 @@ module.exports = function (eleventyConfig) {
           return await imageSequence(figure, options)
         }
       case isCanvas:
-        return canvasPanel(figure)
+        if (!interactive && staticInlineFigureImage) {
+          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive })
+        } else {
+          return canvasPanel(figure)
+        }
       case isImageService:
-        return imageService(figure)
+        if (!interactive && staticInlineFigureImage) {
+          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive })
+        } else {
+          return imageService(figure)
+        }
       default:
         return imageTag(figure)
     }

--- a/packages/11ty/_includes/components/figure/image/html.js
+++ b/packages/11ty/_includes/components/figure/image/html.js
@@ -10,7 +10,6 @@ const path = require('path')
  * @return     {String}  HTML containing  a `figureImageElement`, a caption and annotations UI
  */
 module.exports = function(eleventyConfig) {
-  const annotationsUI = eleventyConfig.getFilter('annotationsUI')
   const figureCaption = eleventyConfig.getFilter('figureCaption')
   const figureImageElement = eleventyConfig.getFilter('figureImageElement')
   const figureLabel = eleventyConfig.getFilter('figureLabel')
@@ -28,9 +27,6 @@ module.exports = function(eleventyConfig) {
       label
     } = figure
 
-    const annotationsElement = !isSequence
-      ? annotationsUI({ figure })
-      : ''
     const labelElement = figureLabel({ id, label, isSequence })
 
     /**
@@ -43,7 +39,6 @@ module.exports = function(eleventyConfig) {
 
     return html`
       ${imageElement}
-      ${annotationsElement}
       ${captionElement}
     `
   }


### PR DESCRIPTION
**Work-in-progress**

- Render `staticInlineFigure` images inline, only show tiled IIIF images in lightbox / modal. Because the inline figures are just `<img>` tags, the annotation UI should also be shown only in lightbox / modal

This branching logic in `figure/image/element.js` could probably be made a lot more concise, but this works at the moment and yields some pretty immediate performance gains.
