### PR TITLE
DEV-15453/15454: Refactor `slugifyIds`

### DIFF
--- a/packages/11ty/_plugins/filters/slugifyIds.js
+++ b/packages/11ty/_plugins/filters/slugifyIds.js
@@ -1,23 +1,15 @@
-const jsdom = require('jsdom')
-
-const { JSDOM } = jsdom
-
 /**
  * Slugify all ids in a DOM
  *
- * @param   {Object}   element HTML element
+ * @param   {Object}   HTML Document element
  * @param   {Function} slugifyFn Function to slugify ids strings
  */
-module.exports = (content, eleventyConfig) => {
-  const dom = new JSDOM(content)
-  const { document } = dom.window
+module.exports = (documentElement, eleventyConfig) => {
   const slugify = eleventyConfig.getFilter('slugify')
 
   Array
-    .from(document.querySelectorAll('[id]'))
+    .from(documentElement.querySelectorAll('[id]'))
     .forEach((element) => {
       element.id = slugify(element.id)
     })
-
-  return dom.serialize()
 }

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -56,7 +56,7 @@ module.exports = function(eleventyConfig, collections, content) {
     const title = pageTitle(page.data)
     const body = document.createElement('body')
     body.innerHTML = mainElement.innerHTML
-    body.setAttribute('id', mainElement.getAttribute('id'))
+    body.setAttribute('id', mainElement.dataset.pageId)
 
     /**
      * Remove elements excluded from this output type

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -81,7 +81,8 @@ module.exports = function(eleventyConfig, collections, content) {
     const sequence = index.toString().padStart(targetLength, 0)
 
     const serializer = new window.XMLSerializer()
-    const xml = slugifyIds(serializer.serializeToString(body))
+    slugifyIds(document)
+    const xml = serializer.serializeToString(body)
 
     epubContent = layout({ body: xml, language, title })
 

--- a/packages/11ty/_plugins/transforms/outputs/html/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/html/transform.js
@@ -27,7 +27,8 @@ module.exports = function(eleventyConfig, collections, content) {
      * Add web component script tags to <head>
      */
     registerWebComponents(dom)
-    content = slugifyIds(dom.serialize())
+    slugifyIds(dom.window.document)
+    content = dom.serialize()
   }
 
   return content

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -64,7 +64,8 @@ module.exports = (eleventyConfig) => {
       element.style.backgroundImage = `url('${trimLeadingSlash(backgroundImageUrl)}')`
     })
 
-    const content = slugifyIds(dom.serialize())
+    slugifyIds(document)
+    const content = dom.serialize()
 
     try {
       fs.writeFileSync(outputPath, content)


### PR DESCRIPTION
This should fix both of the following issues
- missing `/` in `<img>` tags
- extra `<html>`, `<head>` tags in epub output

The `slugifyIds` filter was instantiating a new `JSDom`, which was stripping out the closing slashes in images, and adding the extra `<htm>`/`<head>` tags. I think `slugifyIds` being a filter is now kind of weird, as it does not return anything and expects an `HTMLElement` as an argument rather than a string of markup

- Refactor `slugifyIds` filter to NOT instantiate a new `JSDom`
- correctly set body `id` from `mainElement` dataset
- Ensure all uses of `slugifyIds` are updated to pass a DOM `document` element
