### PR TITLE
Fix empty title tags in epub output

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -18,6 +18,12 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
+## [unreleased]
+
+### Fixed
+
+- Removed empty `<title>` tags from epub output
+
 ## [1.0.0-rc.12]
 
 ### Added

--- a/packages/11ty/_plugins/transforms/outputs/epub/layout.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/layout.js
@@ -1,6 +1,9 @@
 const { html } = require('~lib/common-tags')
 module.exports = ({ body, language, title }) => {
   const stylesheets = ''
+
+  const titleElement = title ? `<title>${title}</title>` : ''
+
   return html`
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE html>
@@ -8,7 +11,7 @@ module.exports = ({ body, language, title }) => {
       <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="/_assets/epub.css" />
-        <title>${title}</title>
+        ${titleElement}
         ${stylesheets}
       </head>
       ${body}


### PR DESCRIPTION
Empty title tags cause epub validation errors, this changes the layout to not render the tag if the `title` is undefined