### PR TITLE
Fix undefined link attributes

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog entries are classified using the following labels:
 ### Fixed
 
 - Removed empty `<title>` tags from epub output
+- Updated `link` shortcode to only apply anchor tag attributes if they are defined
 
 ## [1.0.0-rc.12]
 

--- a/packages/11ty/_includes/components/link.js
+++ b/packages/11ty/_includes/components/link.js
@@ -12,12 +12,12 @@ const { oneLine } = require('~lib/common-tags')
  * @return {String}                anchor tag
  */
 module.exports = function(eleventyConfig) {
-  const link = eleventyConfig.getFilter('link')
-
   return function (params) {
     const { classes = [], link_relation, media_type, name, url } = params
+    const rel = link_relation ? `rel="${link_relation}"` : ''
+    const type = media_type ? `type="${media_type}"` : ''
     return oneLine`
-      <a href="${url}" class="${classes.join(' ')}" target="_blank" rel="${link_relation}" type="${media_type}">
+      <a href="${url}" class="${classes.join(' ')}" target="_blank" ${rel} ${type}>
         ${name}
       </a>
     `


### PR DESCRIPTION
Changes:
- Updated the `link` shortcode to only apply attributes if they are defined