### PR TITLE
DEV-15455: Replace all `&nbsp;` and `&#32;` entities with unicode ASCII spaces `\u0020`

### DIFF
--- a/packages/11ty/_includes/components/page-buttons.js
+++ b/packages/11ty/_includes/components/page-buttons.js
@@ -25,7 +25,7 @@ module.exports = function(eleventyConfig) {
       if (!previousPage) return
       return html`
         <li class="quire-nav-button prev">
-          <a href="${previousPage.url}">${icon({ type: 'left-arrow', description: 'Go back a page'})}&nbsp;<span class="nav-title">${prevButtonText}</span></a>
+          <a href="${previousPage.url}">${icon({ type: 'left-arrow', description: 'Go back a page'})}\u0020<span class="nav-title">${prevButtonText}</span></a>
           <span class="visually-hidden">Previous Page (left keyboard arrow or swipe)</span>
         </li>
       `
@@ -35,7 +35,7 @@ module.exports = function(eleventyConfig) {
       if (!nextPage) return
       return html`
         <li class="quire-nav-button next">
-          <a href="${nextPage.url}"><span class="nav-title">${nextButtonText}</span>&nbsp;${icon({ type: 'right-arrow', description: 'Go back next page' })}</a>
+          <a href="${nextPage.url}"><span class="nav-title">${nextButtonText}</span>\u0020${icon({ type: 'right-arrow', description: 'Go back next page' })}</a>
             <span class="visually-hidden">Next Page (right keyboard arrow or swipe)</span>
         </li>
       `

--- a/packages/11ty/_includes/components/site-title.js
+++ b/packages/11ty/_includes/components/site-title.js
@@ -12,8 +12,8 @@ module.exports = function(eleventyConfig) {
   return function() {
     const separator = '!?'.includes(title.slice(-1)) ? '' : ':'
     let siteTitle = `${title}`
-    if (subtitle) siteTitle += `${separator}&#32;${subtitle}`
-    if (readingLine) siteTitle += `&#32;(${readingLine})`
+    if (subtitle) siteTitle += `${separator}\u0020${subtitle}`
+    if (readingLine) siteTitle += `\u0020(${readingLine})`
     return siteTitle
   }
 }

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -11,7 +11,8 @@ layout: base.11ty.js
   <div
     class="quire-cover__overlay"
     style="background-image: url('{{ imagePath }}');"
-  />
+  >
+  </div>
   <div class="quire-cover__hero-body hero-body">
     <div class="container is-fluid">
       <h1 class="title" id="page-header-{{ page.filePathStem }}">
@@ -23,7 +24,7 @@ layout: base.11ty.js
       </h1>
       <p class="reading-line">{{ publication.reading_line | markdownify }}</p>
       <div class="contributor">
-        <span class="visually-hidden">Contributors:&nbsp;</span>
+        <span class="visually-hidden">Contributors:\u0020</span>
         {% if publication.contributor_as_it_appears %}
           <em>{{ publication.contributor_as_it_appears }}</em>
         {% else %}

--- a/packages/11ty/_plugins/shortcodes/title.js
+++ b/packages/11ty/_plugins/shortcodes/title.js
@@ -19,6 +19,6 @@ module.exports = function(eleventyConfig) {
 
     const titleElement = `<span class="title">${markdownify(title)}</span>`
 
-    return oneLine`${titleElement}${separator}&#32;${subtitleElement}`
+    return oneLine`${titleElement}${separator}\u0020${subtitleElement}`
   }
 }


### PR DESCRIPTION
This update removes all HTML entities in layouts and shortcodes. All entities were originally meant to ensure intentional whitespace was preserved inside tags for screen readers, but since they are not allowed in EPUB, they have been replaced with unicode ASCII space characters (`\u0020`)
