### PR TITLE
Replace `\u0020` unicode space with ` ` literal space character in cover as unicode text is present in EPUB output

### DIFF
--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -24,7 +24,7 @@ layout: base.11ty.js
       </h1>
       <p class="reading-line">{{ publication.reading_line | markdownify }}</p>
       <div class="contributor">
-        <span class="visually-hidden">Contributors:\u0020</span>
+        <span class="visually-hidden">Contributors: </span>
         {% if publication.contributor_as_it_appears %}
           <em>{{ publication.contributor_as_it_appears }}</em>
         {% else %}


### PR DESCRIPTION
We had originally replaced all instances of `&nbsp;` with unicode ASCII spaces `\u0020` to ensure spaces were retained in screen reader output. However, this instance was visible on the cover page of the EPUB output when viewing in a reader application. This update replaces that single instance of `\u0020` with a literal ` ` to prevent EPUB readers from seeing literal `\u0020` on the book cover.

This is the only instance of visible unicode I could find in the starter test publication, as the other replaced instances were in page navigation button and title shortcodes (visible only in web version). This is probably worth testing with a screen reader to make sure this one space is not removed from the publication title