### PR TITLE
Adding item `properties: ['svg']` to EPUB manifest to all pages that contain SVG content

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -168,6 +168,11 @@ module.exports = function(eleventyConfig, collections, content) {
     url: outputFilename
   }
 
+  const pageHasSvgContent = !!body.querySelector('svg')
+  if (pageHasSvgContent) {
+    item.properties = ['svg']
+  }
+
   switch (page.data.layout) {
     case 'table-of-contents':
       item.rel = 'contents'

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -93,11 +93,6 @@ module.exports = function(eleventyConfig, collections, content) {
       encodingFormat: 'application/xhtml+xml'
     }
 
-    const pageHasSvgContent = !!body.querySelector('svg')
-    if (pageHasSvgContent) {
-      item.properties = ['svg']
-    }
-
     switch (page.data.layout) {
       case 'table-of-contents':
         item.rel = 'contents'

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -93,6 +93,11 @@ module.exports = function(eleventyConfig, collections, content) {
       encodingFormat: 'application/xhtml+xml'
     }
 
+    const pageHasSvgContent = !!body.querySelector('svg')
+    if (pageHasSvgContent) {
+      item.properties = ['svg']
+    }
+
     switch (page.data.layout) {
       case 'table-of-contents':
         item.rel = 'contents'


### PR DESCRIPTION
This update uses `Element.querySelector` to check for SVG elements on any EPUB page, and adds `"properties": ["svg"]` to those pages in EPUB manifest.json `readingOrder`
