### PR TITLE
Set EPUB cover image correctly

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -104,11 +104,12 @@ module.exports = (eleventyConfig) => {
   }
 
   const coverUrl = cover()
+  resources.push({
+    url: coverUrl,
+    rel: 'cover-image'
+  })
   for (const asset of assets) {
     let item = { url: asset }
-    if (asset === coverUrl) {
-      item.rel = 'cover-image'
-    }
     resources.push(item)
   }
 
@@ -124,7 +125,6 @@ module.exports = (eleventyConfig) => {
     ],
     conformsTo: 'https://www.w3.org/TR/pub-manifest/',
     contributors: contributors('secondary'),
-    cover: coverUrl,
     creators: contributors('primary'),
     dateModifed: pubDate,
     description: publicationDescription,


### PR DESCRIPTION
This update replaces the `cover` key at the top level of the EPUB manifest with an object under `resources` with `rel: 'cover-image'` to display cover image thumbnail in EPUB readers
