### PR TITLE
Include cover asset from `manifest.resources` rather than `manifest.cover` in EPUB transform

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/index.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/index.js
@@ -54,7 +54,8 @@ module.exports = (eleventyConfig, collections) => {
      * Copy assets
      */
     const { assets } = eleventyConfig.globalData.epub
-    assets.push(manifest.cover)
+    const { url: coverUrl } = manifest.resources.find(({ rel }) => rel === 'cover-image')
+    assets.push(coverUrl)
     for (const asset of assets) {
       fs.copySync(
         path.join(eleventyConfig.dir.output, asset),


### PR DESCRIPTION
https://github.com/thegetty/quire/pull/792 added the correct cover image thumbnail to epubs, but removing the `manifest.cover` key broke something else in the EPUB transform module `index.js` -- this fixes the `undefined` cover asset error.
