### PR TITLE
Rewrite relative web links to work properly in epub readers

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -75,6 +75,32 @@ module.exports = function(eleventyConfig, collections, content) {
     }
 
     /**
+     * Rewrite relative web links to work properly in epub readers
+     */
+    const pageLinks = body.querySelectorAll('a')
+    pageLinks.forEach((link) => {
+      const href = link.getAttribute('href')
+      if (!href) return
+
+      const isRelativeLink = (href) => {
+        return !href.startsWith('#') && !href.startsWith('http')
+      }
+      if (!isRelativeLink(href)) return
+
+      const epubFileInfo = collections.epub.flatMap(({ url }, index) => {
+        return url === href ? [{ index, url }] : []
+      })[0]
+      if (!epubFileInfo) return
+
+      const { index, url } = epubFileInfo
+      const name = slugify(url)
+      const targetLength = collections.epub.length.toString().length
+      const sequence = index.toString().padStart(targetLength, 0)
+      const filename = `${sequence}_${name}.xhtml`
+      link.setAttribute('href', filename)
+    })
+
+    /**
      * Sequence and write files
      */
     const name = slugify(this.url) || path.parse(this.inputPath).name

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -90,7 +90,7 @@ module.exports = function(eleventyConfig, collections, content) {
       const index = collections.epub
         .findIndex(({ url }) => url === href)
 
-      if (index < 0) return
+      if (index === -1) return
 
       const { url } = collections.epub[index]
       const name = slugify(url)

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -87,9 +87,9 @@ module.exports = function(eleventyConfig, collections, content) {
       }
       if (!isRelativeLink(href)) return
 
-    /**
-     * Get the URL and collection index of epub file that corresponds to the current `href`
-     */
+      /**
+       * Get the URL and collection index of epub file that corresponds to the current `href`
+       */
       const epubFileInfo = collections.epub.flatMap(({ url }, index) => {
         return url === href ? [{ index, url }] : []
       })[0]

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -79,15 +79,21 @@ module.exports = function(eleventyConfig, collections, content) {
     /**
      * Rewrite relative web links to work properly in epub readers
      */
-    const pageLinks = body.querySelectorAll('a')
-    pageLinks.forEach((link) => {
-      const href = link.getAttribute('href')
+    const linkElements = body.querySelectorAll('a')
+    linkElements.forEach((linkElement) => {
+      const href = linkElement.getAttribute('href')
       if (!href) return
 
-      const isRelativeLink = (href) => {
+      /**
+       * Determine if a URL points to an internal page
+       *
+       * @param      {String}  href
+       * @return     {Boolean}
+       */
+      const isPageLink = (href) => {
         return !href.startsWith('#') && !href.startsWith('http')
       }
-      if (!isRelativeLink(href)) return
+      if (!isPageLink(href)) return
 
       const index = collections.epub
         .findIndex(({ url }) => url === href)
@@ -98,7 +104,7 @@ module.exports = function(eleventyConfig, collections, content) {
       const name = slugify(url)
       const sequence = index.toString().padStart(targetLength, 0)
       const filename = `${sequence}_${name}.xhtml`
-      link.setAttribute('href', filename)
+      linkElement.setAttribute('href', filename)
     })
 
     /**

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -87,6 +87,9 @@ module.exports = function(eleventyConfig, collections, content) {
       }
       if (!isRelativeLink(href)) return
 
+    /**
+     * Get the URL and collection index of epub file that corresponds to the current `href`
+     */
       const epubFileInfo = collections.epub.flatMap(({ url }, index) => {
         return url === href ? [{ index, url }] : []
       })[0]

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -87,13 +87,10 @@ module.exports = function(eleventyConfig, collections, content) {
       }
       if (!isRelativeLink(href)) return
 
-      /**
-       * Get the URL and collection index of epub file that corresponds to the current `href`
-       */
       const index = collections.epub
         .findIndex(({ url }) => url === href)
-        
-      if (!index) return
+
+      if (index < 0) return
 
       const { url } = collections.epub[index]
       const name = slugify(url)

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -74,6 +74,8 @@ module.exports = function(eleventyConfig, collections, content) {
       tableOfContents.setAttribute('epub:type', 'toc')
     }
 
+    const targetLength = collections.epub.length.toString().length
+
     /**
      * Rewrite relative web links to work properly in epub readers
      */
@@ -94,7 +96,6 @@ module.exports = function(eleventyConfig, collections, content) {
 
       const { url } = collections.epub[index]
       const name = slugify(url)
-      const targetLength = collections.epub.length.toString().length
       const sequence = index.toString().padStart(targetLength, 0)
       const filename = `${sequence}_${name}.xhtml`
       link.setAttribute('href', filename)
@@ -104,7 +105,6 @@ module.exports = function(eleventyConfig, collections, content) {
      * Sequence and write files
      */
     const name = slugify(this.url) || path.parse(this.inputPath).name
-    const targetLength = collections.epub.length.toString().length
     const sequence = index.toString().padStart(targetLength, 0)
 
     const serializer = new window.XMLSerializer()

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -101,9 +101,8 @@ module.exports = function(eleventyConfig, collections, content) {
       if (index === -1) return
 
       const { url } = collections.epub[index]
-      const name = slugify(url)
-      const sequence = index.toString().padStart(targetLength, 0)
-      const filename = `${sequence}_${name}.xhtml`
+      const sequenceNumber = index.toString().padStart(targetLength, 0)
+      const filename = `${sequenceNumber}_${slugify(url)}.xhtml`
       linkElement.setAttribute('href', filename)
     })
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -90,12 +90,12 @@ module.exports = function(eleventyConfig, collections, content) {
       /**
        * Get the URL and collection index of epub file that corresponds to the current `href`
        */
-      const epubFileInfo = collections.epub.flatMap(({ url }, index) => {
-        return url === href ? [{ index, url }] : []
-      })[0]
-      if (!epubFileInfo) return
+      const index = collections.epub
+        .findIndex(({ url }) => url === href)
+        
+      if (!index) return
 
-      const { index, url } = epubFileInfo
+      const { url } = collections.epub[index]
       const name = slugify(url)
       const targetLength = collections.epub.length.toString().length
       const sequence = index.toString().padStart(targetLength, 0)


### PR DESCRIPTION
This update fixes internal links in EPUB output. Relative links, such as those in the table of contents were previously pointing to paths like `/catalogue/1/`. These now instead correspond to paths in the EPUB zip archive, like `08_catalogue-1.xhtml`.
