### PR TITLE
Fix/GH-787: Copy downloads directory into _site on build

### DIFF
--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -62,6 +62,10 @@ module.exports = function (eleventyConfig, { directoryConfig, publication }) {
                   dest: path.join(outputDir, '_assets', 'images')
                 },
                 {
+                  src: path.join(inputDir, '_assets', 'downloads', '*'),
+                  dest: path.join(outputDir, '_assets', 'downloads')
+                },
+                {
                   src: path.join(inputDir, '_assets', 'fonts', '*'),
                   dest: path.join(outputDir, '_assets', 'fonts')
                 }


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [exisiting issue](https://github.com/thegetty/quire/issues).*

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

Issue #787 

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

After outputting PDF and EPUB files, Quire users most often make those available for download from the deployed project site. Our practice for this is to add them to an `_assets/downloads/` directory. This PR ensures that directory is copied over to the `_site` directory when running `quire build`.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Updates Vite configuration to copy the `downloads` directory, along with the `images` and `fonts` directories we were already copying over.

### Does this pull request necessitate changes to Quire's documentation?

The PDF and EPUB instructions could be clarified a little. I'll submit that as a PR to the `quire-docs` site shortly.

### Include screenshots of before/after if applicable.



### Additional Comments

