### PR TITLE
DEV-15479: Fix `dateModified` not formatting/validating correctly in EPUB manifest

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -118,6 +118,13 @@ module.exports = (eleventyConfig) => {
     ? removeHTML(full).replace(/\r?\n|\r/g, ' ')
     : oneLine
 
+  /**
+   * Strip milliseconds from ISO date string (`.sss`)
+   */
+  const pubDateWithoutMs = pubDate
+    .toISOString()
+    .replace(/\.\d{3}/, '')
+
   return {
     '@context': [
       'https://schema.org',
@@ -126,7 +133,7 @@ module.exports = (eleventyConfig) => {
     conformsTo: 'https://www.w3.org/TR/pub-manifest/',
     contributors: contributors('secondary'),
     creators: contributors('primary'),
-    dateModified: pubDate,
+    dateModified: pubDateWithoutMs,
     description: publicationDescription,
     id: isbn,
     languages: language,

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -126,7 +126,7 @@ module.exports = (eleventyConfig) => {
     conformsTo: 'https://www.w3.org/TR/pub-manifest/',
     contributors: contributors('secondary'),
     creators: contributors('primary'),
-    dateModifed: pubDate,
+    dateModified: pubDate,
     description: publicationDescription,
     id: isbn,
     languages: language,


### PR DESCRIPTION
- Replace misspelled `dateModifed` key with `dateModifed` in epub manifest
- Strip milliseconds (`.sss`) from ISO date string in EPUB manifest `dateModified` field
