### PR TITLE
Fix page citation italics

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -26,6 +26,7 @@ Changelog entries are classified using the following labels:
 - Removed empty `<title>` tags from epub output
 - Updated `link` shortcode to only apply anchor tag attributes if they are defined
 - Strip HTML from `<title>` tags in epub and site output
+- Replace unsupported `<em>` with `<span>` in `_includes/components/citation/page.js` `container-title` property
 
 ## [1.0.0-rc.12]
 

--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -30,7 +30,9 @@ module.exports = function (eleventyConfig) {
       'container-author': publicationContributors
         .filter(({ type }) => type === 'primary')
         .map(citeName),
-      'container-title': `<em>${siteTitle()}</em>`,
+      // CSL-JSON support for html tags is spotty, use a span here
+      // since an <em> tag would be treated as a word and title-cased
+      'container-title': `<span style="font-style: italic;">${siteTitle()}</span>`,
       editor: pageContributors
         .filter(({ role }) => role === 'editor')
         .map(citeName),

--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -15,11 +15,10 @@ module.exports = function (eleventyConfig) {
     contributor: publicationContributors,
     pub_date: pubDate,
     publisher: publishers,
-    url
   } = eleventyConfig.globalData.publication
 
   return function (params) {
-    let { context, page, type } = params
+    let { context, page } = params
     
     const pageContributors = page.data.contributor
       ? page.data.contributor.map((item) => getContributor(item))


### PR DESCRIPTION
CSL-JSON support for styling elements is spotty and not well documented ([docs](https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html?highlight=font-style#html-like-formatting-tags) - for the record I did also try `<i>` but these tags are actually removed from the text). Using the `<em>` kind of worked, but this field is title-cased by the citation processor which was title-casing the tag to `</Em>` and then the browser would attempt to close the tag at the next forward slash in the URL (fun) causing weirdness. This change replaces the unsupported `<em>` with a styled `<span>` (which is allowed) in the `_includes/components/citation/page.js` `container-title` property