### PR TITLE
Fix duplicate footnote ids

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -27,6 +27,7 @@ Changelog entries are classified using the following labels:
 - Updated `link` shortcode to only apply anchor tag attributes if they are defined
 - Strip HTML from `<title>` tags in epub and site output
 - Replace unsupported `<em>` with `<span>` in `_includes/components/citation/page.js` `container-title` property
+- Fix setting footnote ids with two or more characters in `_plugins/markdown/footnotes.js`
 
 ## [1.0.0-rc.12]
 

--- a/packages/11ty/_plugins/markdown/footnotes.js
+++ b/packages/11ty/_plugins/markdown/footnotes.js
@@ -36,7 +36,7 @@ function footnoteRef(state, silent) {
   const id = parseInt(label) - 1
 
   if (!silent) {
-    token = state.push('footnote_ref', '', 0)
+    let token = state.push('footnote_ref', '', 0)
     token.meta = { id, label }
   }
 
@@ -72,8 +72,8 @@ function footnoteTail(state) {
   let tokens
   Object.keys(refTokens).forEach((key) => {
     const current = refTokens[key]
-    const id = parseInt(key[1]) - 1
-    const label = parseInt(key[1])
+    const label = key.replace(/:/, '')
+    const id = parseInt(label) - 1
     token = new state.Token('footnote_open', '', 1)
     token.meta = { id, label }
 


### PR DESCRIPTION
Fixes logic setting footnote ids in `_plugins/markdown/footnotes.js`