### PR TITLE
Remove modal link from tables in print

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -20,6 +20,10 @@ Changelog entries are classified using the following labels:
 
 ## [unreleased]
 
+### Added
+
+- Adds print `table` component without a modal link
+
 ### Fixed
 
 - Sort epub reading order by `url`

--- a/packages/11ty/_includes/components/figure/table/html.js
+++ b/packages/11ty/_includes/components/figure/table/html.js
@@ -1,0 +1,35 @@
+const { html } = require('~lib/common-tags')
+
+/**
+ * Renders a table into the document with a captionn
+ *
+ * @param      {Object}  eleventyConfig  eleventy configuration
+ * @param      {Object}  figure          The figure object
+ *
+ * @return     {String}  Content of referenced table file and a caption
+ */
+module.exports = function(eleventyConfig) {
+  const figureCaption = eleventyConfig.getFilter('figureCaption')
+  const figureLabel = eleventyConfig.getFilter('figureLabel')
+  const tableElement = eleventyConfig.getFilter('figureTableElement')
+  const markdownify = eleventyConfig.getFilter('markdownify')
+
+  return async function({ caption, credit, id, label, src }) {
+    const table = await tableElement({ src })
+    const title = markdownify(caption)
+
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
+
+    return html`
+      <a
+        class="q-figure__modal-link"
+        href="#${id}"
+        title="${title}"
+      >
+        ${table}
+      </a>
+      ${captionElement}
+    `
+  }
+}

--- a/packages/11ty/_includes/components/figure/table/index.js
+++ b/packages/11ty/_includes/components/figure/table/index.js
@@ -1,36 +1,9 @@
-const { html } = require('~lib/common-tags')
-const path = require('path')
-
 /**
- * Renders a table into the document with a captionn
- *
- * @param      {Object}  eleventyConfig  eleventy configuration
- * @param      {Object}  figure          The figure object
- *
- * @return     {String}  Content of referenced table file and a caption
+ * Render all `table` outputs
  */
 module.exports = function(eleventyConfig) {
-  const figureCaption = eleventyConfig.getFilter('figureCaption')
-  const figureLabel = eleventyConfig.getFilter('figureLabel')
-  const tableElement = eleventyConfig.getFilter('figureTableElement')
-  const markdownify = eleventyConfig.getFilter('markdownify')
-
-  return async function({ caption, credit, id, label, src }) {
-    const table = await tableElement({ src })
-    const title = markdownify(caption)
-
-    const labelElement = figureLabel({ caption, id, label })
-    const captionElement = figureCaption({ caption, content: labelElement, credit })
-
-    return html`
-      <a
-        class="q-figure__modal-link"
-        href="#${id}"
-        title="${title}"
-      >
-        ${table}
-      </a>
-      ${captionElement}
-    `
+  const renderOutputs = eleventyConfig.getFilter('renderOutputs')
+  return function(params) {
+    return renderOutputs(__dirname, params)
   }
 }

--- a/packages/11ty/_includes/components/figure/table/print.js
+++ b/packages/11ty/_includes/components/figure/table/print.js
@@ -1,0 +1,27 @@
+const { html } = require('~lib/common-tags')
+
+/**
+ * Renders a table into the document with a captionn
+ *
+ * @param      {Object}  eleventyConfig  eleventy configuration
+ * @param      {Object}  figure          The figure object
+ *
+ * @return     {String}  Content of referenced table file and a caption
+ */
+module.exports = function(eleventyConfig) {
+  const figureCaption = eleventyConfig.getFilter('figureCaption')
+  const figureLabel = eleventyConfig.getFilter('figureLabel')
+  const tableElement = eleventyConfig.getFilter('figureTableElement')
+
+  return async function({ caption, credit, id, label, src }) {
+    const table = await tableElement({ src })
+
+    const labelElement = figureLabel({ caption, id, label })
+    const captionElement = figureCaption({ caption, content: labelElement, credit })
+
+    return html`
+      ${table}
+      ${captionElement}
+    `
+  }
+}


### PR DESCRIPTION
Adds a print component to tables to render them without a modal link