### PR TITLE
Fix duplicate footnote ids in PDF output

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -33,6 +33,7 @@ Changelog entries are classified using the following labels:
 - Replace unsupported `<em>` with `<span>` in `_includes/components/citation/page.js` `container-title` property
 - Fix setting footnote ids with two or more characters in `_plugins/markdown/footnotes.js`
 - Fixed epub video component poster path by allowing path to be handled by the output transforms rather than the component
+- Fixed duplicate footnote ids in PDF output by prefixing hrefs and ids with the page id
 
 ## [1.0.0-rc.12]
 

--- a/packages/11ty/_plugins/markdown/index.js
+++ b/packages/11ty/_plugins/markdown/index.js
@@ -88,11 +88,26 @@ module.exports = function(eleventyConfig, options) {
     return n
   }
 
+  /**
+   * Override default renderer to add class to footnote ref anchor
+   */
+  markdownLibrary.renderer.rules.footnote_ref = (tokens, idx, options, env, slf) => {
+    var id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf)
+    var caption = slf.rules.footnote_caption(tokens, idx, options, env, slf)
+    var refid = id
+  
+    if (tokens[idx].meta.subId > 0) {
+      refid += ':' + tokens[idx].meta.subId
+    }
+  
+    return '<sup class="footnote-ref"><a href="#fn' + id + '" id="fnref' + refid + '" class="footnote-ref-anchor">' + caption + '</a></sup>';
+  }
+
   /** 
    * Use custom footnote_ref and footnote_tail definitions
    */
-  markdownLibrary.inline.ruler.after('footnote_inline', 'footnote_ref', footnoteRef);
-  markdownLibrary.core.ruler.after('inline', 'footnote_tail', footnoteTail);
+  markdownLibrary.inline.ruler.after('footnote_inline', 'footnote_ref', footnoteRef)
+  markdownLibrary.core.ruler.after('inline', 'footnote_tail', footnoteTail)
 
   eleventyConfig.setLibrary('md', markdownLibrary)
 

--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -60,6 +60,12 @@ module.exports = function(eleventyConfig, collections, content) {
     return element
   }
 
+  /**
+   * Prefix footnote hrefs and ids to guarantee unique references in PDF output
+   * 
+   * @param {HTMLElement} element 
+   * @param {String} prefix 
+   */
   const prefixFootnotes = (element, prefix) => {
     const footnoteItems = element.querySelectorAll('.footnote-item')
     footnoteItems.forEach((item) => {


### PR DESCRIPTION
Fixes: Duplicate ids not allowed in PDF output

Changes:
- Excludes footnotes from the general `transformRelativeLinks`
- Overrides the default `markdown-it` footnote `footnote_ref` rule to include a class selector (`footnote-ref-anchor`) on the element
- Adds a method to add the page id as a prefix to footnote anchors and back references 