### PR TITLE
DEV-15458: Ensure background image assets are copied into EPUB package

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -34,6 +34,7 @@ Changelog entries are classified using the following labels:
 - Fix setting footnote ids with two or more characters in `_plugins/markdown/footnotes.js`
 - Fixed epub video component poster path by allowing path to be handled by the output transforms rather than the component
 - Fixed duplicate footnote ids in PDF output by prefixing hrefs and ids with the page id
+- Ensure image assets defined with `background-image: Url(...)` are copied into EPUB package
 
 ## [1.0.0-rc.12]
 

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -12,6 +12,8 @@ layout: base.11ty.js
     class="quire-cover__overlay"
     style="background-image: url('{{ imagePath }}');"
   >
+    <!-- This ensures background image asset gets copied into epub package -->
+    <img class="visually-hidden" src="{{ imagePath }}" />
   </div>
   <div class="quire-cover__hero-body hero-body">
     <div class="container is-fluid">

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -9,6 +9,10 @@ description: splash page layout
 {% assign labelDivider = config.pageTitle.labelDivider %}
 
 <section class="{% if title == "title page" or title == "half title page" %} is-screen-only {% endif %} quire-page__header hero {% if content %}{% else %}quire-page__header--full-height{% endif %} {% if image %}hero-image{% endif %}" {% if image %}style="background-image: url('{{ imagePath }}');"{% endif %}>
+  {% if image %}
+    <!-- This ensures background image asset gets copied into epub package -->
+    <img class="visually-hidden" src="{{ imagePath }}" />
+  {% endif %}
   <div class="hero-body">
     <h1 class="quire-page__header__title" id="page-header-{{ page.filePathStem }}">
       {% if label %}<span class="label">{{ label }}<span class="visually-hidden">{{ labelDivider }}</span></span>{% endif %}


### PR DESCRIPTION
This seemed like the most straightforward way to ensure that assets *only* referenced in inline style `background-image` declarations get copied into EPUBs. I can see some potential value in adding more programmatic logic to the EPUB transform to query select all things with `style*=background-image` and writing a hidden image tag inside that element, but that approach sounds pretty brittle and makes assumptions about how users write layout markup/styles. 

Not sure if this kind of thing also warrants extra documentation, and if so, where that documentation might go.
