### PR TITLE
Add screen-only stylesheet

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog entries are classified using the following labels:
 ### Added
 
 - Adds print `table` component without a modal link
+- Import `screen.scss` into `javascript/application/index.js`
 
 ### Fixed
 

--- a/packages/11ty/content/_assets/javascript/application/index.js
+++ b/packages/11ty/content/_assets/javascript/application/index.js
@@ -10,6 +10,7 @@
 // Stylesheets
 import '../../fonts/index.scss';
 import '../../styles/application.scss'
+import '../../styles/screen.scss'
 import '../../styles/custom.css'
 
 // Modules (feel free to define your own and import here)


### PR DESCRIPTION
https://github.com/thegetty/quire-starter-default/pull/36 and https://github.com/thegetty/quire-starter-iiif/pull/9 should be merged first. 

Since pagedjs reads styles with the `@media screen` media query and does not allow overriding `position: fixed`, we need to include a separate stylesheet that is only included in the site output. 

See pagedjs issue https://gitlab.coko.foundation/pagedjs/pagedjs/-/issues/433