### PR TITLE
Page class inheritance

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -25,6 +25,10 @@ Changelog entries are classified using the following labels:
 - Adds print `table` component without a modal link
 - Import `screen.scss` into `javascript/application/index.js`
 
+### Changed
+
+- Renames `eleventyComputed` property `pageClasses` and frontmatter property `class` to `classes` for consistency, avoiding using the reserved word `class`, and to handle merging template, layout, and computed classes.
+
 ### Fixed
 
 - Sort epub reading order by `url`

--- a/packages/11ty/_layouts/README.md
+++ b/packages/11ty/_layouts/README.md
@@ -66,17 +66,19 @@ A default class is set in the layout:
 **`_layouts/entry.liquid`**
 ```yaml
 ---
-class: quire-entry
+classes:
+  - quire-entry
 ---
 ```
 
-Additional style classes can also be added in a template. These will be appended to the class value set in the layout.
+Additional style classes can also be added in a template. These will be appended to the class value set in the layout. The `class` property must use array syntax.
 
 **`content/catalogue/1.md`**
 ```yaml
 ---
 layout: entry
-class: fancy-custom-class
+classes:
+  - fancy-custom-class
 ---
 ```
 

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -8,7 +8,7 @@ const { html } = require('~lib/common-tags')
  * @return     {Function}  Template render function
  */
 module.exports = async function(data) {
-  const { pageClasses, collections, content, pageData, publication } = data
+  const { classes, collections, content, pageData, publication } = data
   const { inputPath, outputPath, url } = pageData || {}
   const id = this.slugify(url) || path.parse(inputPath).name
   const pageId = `page-${id}`
@@ -33,7 +33,7 @@ module.exports = async function(data) {
           </div>
           <div class="quire__primary">
             ${this.navigation(data)}
-            <main class="quire-page ${pageClasses}" data-output-path="${outputPath}" data-page-id="${pageId}" >
+            <main class="quire-page ${classes}" data-output-path="${outputPath}" data-page-id="${pageId}" >
               ${content}
             </main>
           </div>

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -1,5 +1,6 @@
 ---
-class: quire-cover
+classes:
+ - quire-cover
 description: Quire publication cover page
 layout: base.11ty.js
 ---

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -1,5 +1,6 @@
 ---
-class: quire-entry
+classes:
+  - quire-entry
 layout: base.11ty.js
 description: Entry layout. This template is intended for use in catalogue-style pages where a single image or object needs to be featured prominently.
 ---

--- a/packages/11ty/_layouts/essay.liquid
+++ b/packages/11ty/_layouts/essay.liquid
@@ -1,5 +1,6 @@
 ---
-class: quire-essay
+classes:
+  - quire-essay
 layout: base.11ty.js
 description: Essay layout. This layout describes a single-page template that has been augmented with the ability to display a frontmatter-defined abstract (in markdown format) as well as bibliography references.
 ---

--- a/packages/11ty/_layouts/page.liquid
+++ b/packages/11ty/_layouts/page.liquid
@@ -1,5 +1,6 @@
 ---
-class: quire-page
+classes:
+  - quire-page
 layout: base.11ty.js
 description: Single page default template
 ---

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -1,5 +1,6 @@
 ---
-class: quire-splash
+classes:
+  - quire-splash
 layout: base
 description: splash page layout
 ---

--- a/packages/11ty/_layouts/table-of-contents.11ty.js
+++ b/packages/11ty/_layouts/table-of-contents.11ty.js
@@ -9,7 +9,7 @@
 module.exports = class TableOfContents {
   data() {
     return {
-      class: 'quire-contents',
+      classes: ['quire-contents'],
       layout: 'base'
     }
   }

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -19,6 +19,7 @@ module.exports = {
     data: (data) => {
       return {
         abstract: data.abstract,
+        classes: data.classes,
         contributor: data.contributor,
         figure: data.figure,
         image: data.image,
@@ -26,7 +27,6 @@ module.exports = {
         layout: data.layout,
         object: data.object,
         order: data.order,
-        classes: data.pageClasses,
         short_title: data.short_title,
         subtitle: data.subtitle,
         summary: data.summary,
@@ -52,16 +52,21 @@ module.exports = {
   /**
    * Classes applied to <main> page element
    */
-  pageClasses: ({ collections, class: classes, layout, page }) => {
-    const pageClasses = []
+  classes: ({ collections, classes=[], page }) => {
+    const computedClasses = []
     // Add computed frontmatter and page-one classes
     const pageIndex = collections.allSorted.findIndex(({ outputPath }) => outputPath === page.outputPath)
-    const pageOneIndex = collections.allSorted.findIndex(({ data }) => data.class && data.class.includes('page-one'))
+    const pageOneIndex = collections.allSorted.findIndex(
+      ({ data }) => Array.isArray(data.classes) && data.classes.includes('page-one')
+    )
     if (pageIndex < pageOneIndex) {
-      pageClasses.push('frontmatter')
+      computedClasses.push('frontmatter')
     }
+    // filter null values, handles 11ty's first pass at build
+    const filteredClasses = classes.filter((x) => x)
+
     // add custom classes from page frontmatter
-    return classes ? pageClasses.concat(classes) : pageClasses
+    return computedClasses.concat(filteredClasses)
   },
   pageContributors: ({ contributor, contributor_as_it_appears }) => {
     if (!contributor) return


### PR DESCRIPTION
Changes:
- Renames `eleventyComputed` property `pageClasses` and frontmatter property `class` to `classes` for consistency, avoiding using the reserved word `class`, and to handle merging template, layout, and computed classes.

Related to https://github.com/thegetty/quire-starter-default/pull/37