### PR TITLE
Ensure print output renders static start frame of image sequences

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -35,6 +35,7 @@ Changelog entries are classified using the following labels:
 - Fix setting footnote ids with two or more characters in `_plugins/markdown/footnotes.js`
 - Fixed epub video component poster path by allowing path to be handled by the output transforms rather than the component
 - Fixed duplicate footnote ids in PDF output by prefixing hrefs and ids with the page id
+- Static images are now rendered for image sequences in PDF and EPUB output
 
 ## [1.0.0-rc.12]
 

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -16,15 +16,18 @@ module.exports = function(eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
 
   return function(figure) {
-    const { alt, caption, credit, id, label, src } = figure
+    const { alt, caption, credit, id, label, src, staticInlineFigureImage } = figure
 
-    if (!src) return ''
+    if (!src && !staticInlineFigureImage) return ''
 
     const labelElement = figureLabel({ caption, id, label })
 
     let imageSrc
 
     switch (true) {
+      case figure.isSequence:
+        imageSrc = figure.staticInlineFigureImage
+        break
       case figure.isCanvas || figure.isImageService:
         imageSrc = figure.printImage
         break


### PR DESCRIPTION
In PDF and EPUB outputs, the `figure.staticInlineFigureImage` is now rendered for image sequences
