### PR TITLE
Fix page-level bibliography entries

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -25,6 +25,10 @@ Changelog entries are classified using the following labels:
 - Adds print `table` component without a modal link
 - Import `screen.scss` into `javascript/application/index.js`
 
+### Changed
+
+- Renames frontmatter property for page-level bibliography entries from `pageReferences` to `citations`
+
 ### Fixed
 
 - Sort epub reading order by `url`

--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -48,7 +48,7 @@ layout: base.11ty.js
     <div class="container is-fluid">
       <div class="content">
         {{ content }}
-        {% bibliography pageReferences %}
+        {% bibliography citations %}
       </div>
     </div>
   </section>

--- a/packages/11ty/_layouts/entry.liquid
+++ b/packages/11ty/_layouts/entry.liquid
@@ -66,7 +66,7 @@ Entry content, including entry image and tombstone data
       <div class="container">
         <div class="content">
           {{ content }}
-          {% bibliography pageReferences %}
+          {% bibliography citations %}
         </div>
       </div>
     </section>

--- a/packages/11ty/_layouts/essay.liquid
+++ b/packages/11ty/_layouts/essay.liquid
@@ -20,7 +20,7 @@ description: Essay layout. This layout describes a single-page template that has
   <div class="container">
     <div class="content">
       {{ content }}
-      {% bibliography pageReferences %}
+      {% bibliography citations %}
     </div>
     {% pageButtons pagination=pagination %}
   </div>

--- a/packages/11ty/_layouts/page.liquid
+++ b/packages/11ty/_layouts/page.liquid
@@ -17,7 +17,7 @@ description: Single page default template
   <div class="container">
     <div class="content">
       {{ content }}
-      {% bibliography pageReferences %}
+      {% bibliography citations %}
     </div>
   </div>
 </section>

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -30,7 +30,7 @@ description: splash page layout
     <div class="container">
       <div class="content{% if image %}{% else %} no-image-above{% endif %}">
         {{ content }}
-        {% bibliography pageReferences %}
+        {% bibliography citations %}
       </div>
       {% pageButtons pagination=pagination %}
     </div>

--- a/packages/11ty/_layouts/table-of-contents.11ty.js
+++ b/packages/11ty/_layouts/table-of-contents.11ty.js
@@ -51,7 +51,7 @@ module.exports = class TableOfContents {
           <div class="quire-contents-list ${presentation}">
             ${await this.tableOfContents({ collections, currentPageUrl: page.url, key, presentation })}
             <div class="content">
-              {% bibliography pageReferences %}
+              {% bibliography citations %}
             </div>
           </div>
           ${this.pageButtons({ pagination })}

--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -20,10 +20,11 @@ module.exports = function (eleventyConfig, { page }) {
   const { displayOnPage, displayShort, heading } = page.data.config.bibliography
   /**
    * bibliography shortcode
-   * @example {% bibliography pageReferences %}
+   * @example {% bibliography citations %}
    *
    * Nota bene: the front matter property for additional page level references
-   * is `pageReferences` to avoid conflicts with the global data `references.yaml`
+   * is `citations` to avoid conflicts with the global data `references.yaml`
+   * and for consistency with the {% cite %} shortcode
    *
    * @param  {Array}  referenceIds  An array of `references.yaml` entry ids
    *                                to include in the rendered bibliography
@@ -45,7 +46,7 @@ module.exports = function (eleventyConfig, { page }) {
     page.citations ??= {}
 
     /**
-     * Add `pageReferences` from template front-matter to the array of citations
+     * Add `citations` from template front-matter to the array of citations
      * for inclusion in the rendered page bibliography
      */
     referenceIds.forEach((id) => {


### PR DESCRIPTION
The references frontmatter property had been named `pageReferences` during the refactor though this was not communicated out, and it appeared to be broken. This PR renames `pageReferences` to the preferred name `citations` for consistency with the `{% cite %}` shortcode.