### PR TITLE
Fix image support for png, tif, and svg images

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -18,6 +18,12 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
+## [unreleased]
+
+### Fixed
+
+- Allow input images that are static or tiled to have `.jpeg`, `.tif`, `.tiff`, `.png`, and `.svg` extensions.
+
 ## [1.0.0-rc.13]
 
 ### Added

--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -26,10 +26,10 @@ const logger = chalkFactory('Figures:Annotation')
  */
 module.exports = class Annotation {
   constructor(figure, data) {
-    const { iiifConfig, outputDir, zoom } = figure
+    const { iiifConfig, outputDir, outputFormat, zoom } = figure
     const { baseURI, tilesDirName } = iiifConfig
     const { label, region, selected, src, text } = data
-    const { base, ext, name } = src ? path.parse(src) : {}
+    const { base, name } = src ? path.parse(src) : {}
 
     /**
      * If an id is not provided, compute id from the `label` or `src` properties
@@ -56,7 +56,7 @@ module.exports = class Annotation {
      * Note: Currently only JPG image services are supported by
      * canvas-panel/image-service tags
      */
-    const isImageService = !!zoom && ext === '.jpg'
+    const isImageService = !!zoom && outputFormat === '.jpg'
     const info = () => {
       if (!isImageService) return
       const tilesPath = path.join(outputDir, name, tilesDirName)

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -186,8 +186,9 @@ module.exports = class Figure {
     }
 
     if (!this.isExternalResource && filename) {
-      const { name } = path.parse(filename)
-      return path.join('/', this.outputDir, name, `static-inline-figure-image.jpg`)
+      const { ext, name } = path.parse(filename)
+      const format = this.iiifConfig.formats.find(({ input }) => input.includes(ext))
+      return path.join('/', this.outputDir, name, `static-inline-figure-image${format.output}`)
     }
     return this.data.staticInlineFigure
   }

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -6,7 +6,6 @@ const path = require('path')
 const SequenceFactory = require('../sequence/factory')
 const sharp = require('sharp')
 const {
-  getSequenceFiles,
   isCanvas,
   isImageService,
   isSequence
@@ -60,6 +59,9 @@ module.exports = class Figure {
       zoom
     } = data
 
+    const ext = src ? path.parse(src).ext : null
+    const format = iiifConfig.formats.find(({ input }) => input.includes(ext))
+
     this.annotationFactory = new AnnotationFactory(this)
     this.canvasId = canvasId
     this.data = data
@@ -73,6 +75,7 @@ module.exports = class Figure {
     this.mediaType = mediaType || defaults.mediaType
     this.mediaId = mediaId
     this.outputDir = outputDir
+    this.outputFormat = format && format.output
     this.processImage = imageProcessor
     this.sequenceFactory = new SequenceFactory(this)
     this.src = src
@@ -155,7 +158,7 @@ module.exports = class Figure {
   get printImage() {
     if (!this.isExternalResource && this.src && !this.data.printImage) {
       const { ext, name } = path.parse(this.src)
-      return path.join('/', this.outputDir, name, `print-image${ext}`)
+      return path.join('/', this.outputDir, name, `print-image${this.outputFormat}`)
     }
     return this.data.printImage
   }


### PR DESCRIPTION
Fixes tile and print-image extensions for input image extensions other than `jpg` that are supported (`jpeg`, `tif`, `png`, `svg`) and transformed into `.jpg`. Does not address the `.jp2` issue or tiled images output to `.png` (these are separate issues to follow).