### PR TITLE
Exclude tables from static image generation

### DIFF
--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -185,7 +185,7 @@ module.exports = class Figure {
       filename = sequenceStart ? sequenceStart : this.sequences[0].files[0]
     }
 
-    if (!this.isExternalResource && filename) {
+    if (!this.isExternalResource && filename && this.mediaType != 'table') {
       const { ext, name } = path.parse(filename)
       const format = this.iiifConfig.formats.find(({ input }) => input.includes(ext))
       return path.join('/', this.outputDir, name, `static-inline-figure-image${format.output}`)


### PR DESCRIPTION
Excludes tables from static image path generation, which would throw an error since it's an `.html` file