### PR TITLE
Fix handling of content in outputs transforms

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog entries are classified using the following labels:
 ### Fixed
 
 - Allow input images that are static or tiled to have `.jpeg`, `.tif`, `.tiff`, `.png`, and `.svg` extensions.
+- Return unmodified content from pdf/epub transforms, fixing site-only pages markup
 
 ## [1.0.0-rc.13]
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -49,7 +49,8 @@ module.exports = function(eleventyConfig, collections, content) {
   const index = epubPages.findIndex((path) => path == this.outputPath)
   let epubContent =  index !== -1 ? content : undefined
 
-  if (!epubContent || ext !== '.html') return
+  // Returning content allows subsequent transforms to process it unmodified
+  if (!epubContent || ext !== '.html') return content
 
   /**
    * Get sequence number, name, and create filename

--- a/packages/11ty/_plugins/transforms/outputs/html/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/html/transform.js
@@ -17,7 +17,7 @@ module.exports = function(eleventyConfig, collections, content) {
   const { ext } = path.parse(this.outputPath)
   content = pages.includes(this.outputPath) ? content : undefined
 
-  if (ext === '.html') {
+  if (content && ext === '.html') {
     const dom = new JSDOM(content)
     /**
      * Remove elements excluded from this output type

--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -89,14 +89,16 @@ module.exports = function(eleventyConfig, collections, content) {
 
   const pdfPages = collections.pdf.map(({ outputPath }) => outputPath)
 
-  if (!pdfPages.includes(this.outputPath)) return
+  // Returning content allows subsequent transforms to process it unmodified
+  if (!pdfPages.includes(this.outputPath)) return content
 
   const { document } = new JSDOM(content).window
   const mainElement = document.querySelector('main[data-output-path]')
   const svgSymbolElements = document.querySelectorAll('body > svg')
   const pageIndex = pdfPages.findIndex((path) => path === this.outputPath)
 
-  if (!mainElement || pageIndex === -1) return
+  // Returning content allows subsequent transforms to process it unmodified
+  if (!mainElement || pageIndex === -1) return content
 
   const currentPage = collections.pdf[pageIndex]
   const sectionElement = document.createElement('section')


### PR DESCRIPTION
Summary:
Quire transforms for outputs (pdf/epub/html) happen sequentially on the same set of files. The html is extracted, modified, and written out for pdf and epub, and then the unmodified content is returned for the next set of transforms. 

Two fixes:
- Content for pages that were only included in html output were not being returned by the epub and pdf transforms
- Skip html transforms on pages that are excluded from the site output (`pdf-epub-title`, etc)