### PR TITLE
Release quire-11ty 1.0.0-rc.14

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -18,7 +18,7 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
-## [unreleased]
+## [1.0.0-rc.14]
 
 ### Fixed
 

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0-rc.13",
+      "version": "1.0.0-rc.14",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "bulma": "^0.9.3",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",


### PR DESCRIPTION
Includes fixes for:
- site-only output files
- converting non-jpg images to jpg and tiling and rendering them statically