### PR TITLE
Fix id generation and tiling of base image

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -24,7 +24,7 @@ Changelog entries are classified using the following labels:
 
 - Allow input images that are static or tiled to have `.jpeg`, `.tif`, `.tiff`, `.png`, and `.svg` extensions.
 - Return unmodified content from pdf/epub transforms, fixing site-only pages markup
-- Validate urls and error logging to id generation methods in figure and annotaiton models
+- Validate urls and error logging to id generation methods in figure and annotation models
 - Enables tiling of base image of annotated canvases
 
 ## [1.0.0-rc.13]

--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -24,6 +24,8 @@ Changelog entries are classified using the following labels:
 
 - Allow input images that are static or tiled to have `.jpeg`, `.tif`, `.tiff`, `.png`, and `.svg` extensions.
 - Return unmodified content from pdf/epub transforms, fixing site-only pages markup
+- Validate urls and error logging to id generation methods in figure and annotaiton models
+- Enables tiling of base image of annotated canvases
 
 ## [1.0.0-rc.13]
 

--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -53,12 +53,15 @@ module.exports = class Annotation {
      * Create image service for annotation image if it is a JPG and
      * the figure has zoom enabled
      * 
-     * Note: Currently tiling is only supported for figures with no annotations
+     * Note: Currently tiling is only supported for the figure.src, not annotations
      *
      * Note: Currently only JPG image services are supported by
      * canvas-panel/image-service tags
      */
-    const isImageService = !!zoom && outputFormat === '.jpg' && annotationCount === 0
+    const isImageService =
+      !!zoom
+      && outputFormat === '.jpg'
+      && (annotationCount === 0 || src === figure.src)
     const info = () => {
       if (!isImageService) return
       const tilesPath = path.join(outputDir, name, tilesDirName)

--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -61,14 +61,26 @@ module.exports = class Annotation {
       if (!isImageService) return
       const tilesPath = path.join(outputDir, name, tilesDirName)
       const infoPath = path.join(tilesPath, 'info.json')
-      return new URL(path.join(baseURI, infoPath)).toString()
+      try {
+        return new URL(path.join(baseURI, infoPath)).href
+      } catch (error) {
+        logger.error(`Error creating info.json. Either the tile path (${tilesPath}) or base URI (${baseURI}) are invalid to form a fully qualified URI.`)
+        return
+      }
     }
 
     const uri = () => {
-      const filepath = isImageService
-        ? info()
-        : path.join(outputDir, base)
-      return new URL(path.join(baseURI, filepath)).toString()
+      switch (true) {
+        case isImageService:
+          return info()
+        default:
+          try{
+            return new URL(path.join(baseURI, outputDir, base)).href
+          } catch (error) {
+            logger.error(`Error creating annotation URI. Either the output directory (${outputDir}), filename (${base}) or base URI (${baseURI}) are invalid to form a fully qualified URI.`)
+            return
+          }
+      }
     }
 
     this.format = text && !src ? 'text/plain' : mime.lookup(src)

--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -26,7 +26,7 @@ const logger = chalkFactory('Figures:Annotation')
  */
 module.exports = class Annotation {
   constructor(figure, data) {
-    const { iiifConfig, outputDir, outputFormat, zoom } = figure
+    const { annotationCount, iiifConfig, outputDir, outputFormat, zoom } = figure
     const { baseURI, tilesDirName } = iiifConfig
     const { label, region, selected, src, text } = data
     const { base, name } = src ? path.parse(src) : {}
@@ -52,11 +52,13 @@ module.exports = class Annotation {
     /**
      * Create image service for annotation image if it is a JPG and
      * the figure has zoom enabled
+     * 
+     * Note: Currently tiling is only supported for figures with no annotations
      *
      * Note: Currently only JPG image services are supported by
      * canvas-panel/image-service tags
      */
-    const isImageService = !!zoom && outputFormat === '.jpg'
+    const isImageService = !!zoom && outputFormat === '.jpg' && annotationCount === 0
     const info = () => {
       if (!isImageService) return
       const tilesPath = path.join(outputDir, name, tilesDirName)

--- a/packages/11ty/_plugins/figures/figure/index.js
+++ b/packages/11ty/_plugins/figures/figure/index.js
@@ -62,6 +62,7 @@ module.exports = class Figure {
     const ext = src ? path.parse(src).ext : null
     const format = iiifConfig.formats.find(({ input }) => input.includes(ext))
 
+    this.annotationCount = data.annotations ? data.annotations.length : 0
     this.annotationFactory = new AnnotationFactory(this)
     this.canvasId = canvasId
     this.data = data

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -118,8 +118,7 @@ module.exports = class Manifest {
    * @todo handle text annotations
    * @todo handle annotations with target region
    */
-  createAnnotationBody({ format, info, label, src, uri }) {
-    const { ext } = path.parse(src)
+  createAnnotationBody({ format, info, label, uri }) {
     return {
       format,
       height: this.figure.canvasHeight,


### PR DESCRIPTION
Changes:
- Adds url validation and error logging to id generation methods
- Enables tiling of base image of annotated canvases. Previous fix to enable tiling of non-jpgs excluded tiling the base image of an annotated canvas.