### PR TITLE
Fix urls in test fixtures

### DIFF
--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/annotations-checkbox/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/annotations-checkbox/manifest.json
@@ -24,7 +24,7 @@
               "target": "http://localhost:8080/iiif/checkbox-annotations/canvas",
               "type": "Annotation",
               "body": {
-                "id": "http://localhost:8080/http:/localhost:8080/iiif/checkbox-annotations/base/tiles/info.json",
+                "id": "http://localhost:8080/iiif/checkbox-annotations/base/tiles/info.json",
                 "type": "Image",
                 "format": "image/jpeg",
                 "height": 1455,

--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/zoomable/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/zoomable/manifest.json
@@ -24,7 +24,7 @@
               "target": "http://localhost:8080/iiif/zoom/canvas",
               "type": "Annotation",
               "body": {
-                "id": "http://localhost:8080/http:/localhost:8080/iiif/zoom/irises/tiles/info.json",
+                "id": "http://localhost:8080/iiif/zoom/irises/tiles/info.json",
                 "type": "Image",
                 "format": "image/jpeg",
                 "height": 3221,


### PR DESCRIPTION
The previous changes to 1.0.0-rc.14 fixed manifest uri generation, now updating the test files.