### PR TITLE
Update print image transformation width

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -18,6 +18,12 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
+## [unreleased]
+
+### Changed
+
+- Incrase `print-image` transformation width to `2025px`
+
 ## [1.0.0-rc.14]
 
 ### Fixed

--- a/packages/11ty/_plugins/figures/test/__fixtures__/iiif-config.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/iiif-config.json
@@ -39,7 +39,8 @@
     {
       "name": "print-image",
       "resize": {
-        "width": 800
+        "width": 2025,
+        "withoutEnlargement": true
       }
     }
   ]


### PR DESCRIPTION
Updates the `print-image` transformation width to 2025px and sets option to not enlarge images < 2025px.