### PR TITLE
Remove numbers from epub filenames

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -24,13 +24,17 @@ Changelog entries are classified using the following labels:
 
 - Validation method to check if an image can be tiled, and log error if invalid.
 
-### Removed
-
-- Remove `.jp2` from supported image extensions
-
 ### Changed
 
 - Increase `print-image` transformation width to `2025px`
+
+### Fixed
+
+- Sort epub pages for reading order by sort key rather than filename. Fixes epub validation error for filenames that begin with numbers.
+
+### Removed
+
+- Remove `.jp2` from supported image extensions
 
 ## [1.0.0-rc.14]
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -124,6 +124,12 @@ module.exports = (eleventyConfig) => {
   const pubDateWithoutMs = pubDate
     .toISOString()
     .replace(/\.\d{3}/, '')
+  
+  /**
+   * Sort reading order and remove sort key (index)
+   */
+  const sortedReadingOrder = readingOrder.sort(sortByKeys(['index']))
+  sortedReadingOrder.forEach((item) => delete item.index)
 
   return {
     '@context': [
@@ -138,7 +144,7 @@ module.exports = (eleventyConfig) => {
     id: isbn,
     languages: language,
     publisher: publisherNameAndLocations(),
-    readingOrder: readingOrder.sort(sortByKeys(['url'])),
+    readingOrder: sortedReadingOrder,
     resources: resources,
     rights: copyright,
     title: pubTitle(),

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -55,14 +55,12 @@ module.exports = function(eleventyConfig, collections, content) {
   /**
    * Get sequence number, name, and create filename
    */
-  const filename = (index, page) => {
-    const targetLength = collections.epub.length.toString().length
-    const sequenceNumber = index.toString().padStart(targetLength, 0)
-    const name = slugify(page.url) || path.parse(page.inputPath).name
-    return `${sequenceNumber}_${name}.xhtml`
+  const filename = ({ inputPath, url }) => {
+    const name = slugify(url) || path.parse(inputPath).name
+    return `${name}.xhtml`
   }
 
-  const outputFilename = filename(index, this)
+  const outputFilename = filename(this)
 
   const page = collections.epub[index]
   const { document, window } = new JSDOM(epubContent).window
@@ -112,7 +110,7 @@ module.exports = function(eleventyConfig, collections, content) {
 
     if (index === -1) return
 
-    linkElement.setAttribute('href', filename(index, collections.epub[index]))
+    linkElement.setAttribute('href', filename(collections.epub[index]))
   })
 
   /**
@@ -126,8 +124,9 @@ module.exports = function(eleventyConfig, collections, content) {
   epubContent = layout({ body: xml, language, title })
 
   const item = {
-    url: outputFilename,
-    encodingFormat: 'application/xhtml+xml'
+    index,
+    encodingFormat: 'application/xhtml+xml',
+    url: outputFilename
   }
 
   switch (page.data.layout) {


### PR DESCRIPTION
Changes:
- Refactors epub reading order to use a sort key rather than prepending the index and sorting by filename. Fixes validation errors for ids that begin with numbers.