### PR TITLE
Relative paths in epub output

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelog entries are classified using the following labels:
 ### Changed
 
 - Increase `print-image` transformation width to `2025px`
+- Remove preceding slash from relative paths in epub output
 
 ## [1.0.0-rc.14]
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/layout.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/layout.js
@@ -10,7 +10,7 @@ module.exports = ({ body, language, title }) => {
     <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="${language}">
       <head>
         <meta charset="utf-8" />
-        <link rel="stylesheet" type="text/css" href="/_assets/epub.css" />
+        <link rel="stylesheet" type="text/css" href="_assets/epub.css" />
         ${titleElement}
         ${stylesheets}
       </head>

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -42,6 +42,29 @@ module.exports = function(eleventyConfig, collections, content) {
   }
 
   /**
+   * Removes preceding slashes from asset paths
+   * @param {HTMLElement} element 
+   */
+  const transformPaths = (element) => {
+    const images = element.querySelectorAll('img')
+    const links = element.querySelectorAll('a')
+    const heros = element.querySelectorAll('.quire-page__header.hero, .quire-cover__overlay')
+    heros.forEach((item) => {
+      item.style.backgroundImage = item.style.backgroundImage.replace(/(?<=url\()\//, '')
+    })
+    images.forEach((item) => {
+      const src = item.getAttribute('src')
+      if (!src) return
+      item.setAttribute('src', src.replace(/^\//, ''))
+    })
+    links.forEach((item) => {
+      const href = item.getAttribute('href')
+      if (!href) return
+      item.setAttribute('href', href.replace(/^\//, ''))
+    })
+  }
+
+  /**
    * Remove pages excluded from this output type
    */
   const epubPages = collections.epub.map(({ outputPath }) => outputPath)
@@ -77,7 +100,10 @@ module.exports = function(eleventyConfig, collections, content) {
    * Remove elements excluded from this output type
    */
   filterOutputs(body, 'epub')
+
   getAssets(body)
+
+  transformPaths(body)
 
   /**
    * Add epub-specific attributes to TOC element

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -103,8 +103,6 @@ module.exports = function(eleventyConfig, collections, content) {
 
   getAssets(body)
 
-  transformPaths(body)
-
   /**
    * Add epub-specific attributes to TOC element
    */
@@ -140,6 +138,8 @@ module.exports = function(eleventyConfig, collections, content) {
 
     linkElement.setAttribute('href', filename(index, collections.epub[index]))
   })
+
+  transformPaths(body)
 
   /**
    * Sequence and write files


### PR DESCRIPTION
Changes:
- Remove preceding slash from relative paths in epub output, which cause validation errors