### PR TITLE
Include svgs in epub body tag

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -34,6 +34,7 @@ Changelog entries are classified using the following labels:
 
 - Resolved issue with logic rendering external manifests
 - Prefix epub filename with `page-` to ensure validity if filename begins with a number
+- Include `svg` definitions in body of epub pages using `svg`
 
 ### Removed
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -93,6 +93,18 @@ module.exports = function(eleventyConfig, collections, content) {
 
   const title = removeHTML(pageTitle(page.data))
   const body = document.createElement('body')
+
+  /**
+   * Add SVGs to body
+  */
+  const svgSymbolElements = document.querySelectorAll('body > svg')
+  const svgsOnPage = mainElement.querySelectorAll('svg')
+  if (Array.from(svgsOnPage).length) {
+    Array.from(svgSymbolElements).forEach((svgSymbolElement) => {
+      body.appendChild(svgSymbolElement)
+    })
+  }
+
   body.innerHTML = mainElement.innerHTML
   body.setAttribute('id', mainElement.dataset.pageId)
 


### PR DESCRIPTION
Changes:
- Includes svg definitions in the body tag of epub pages containing svgs