### PR TITLE
Fix issue where not assigning `classes` in front matter of a layout was breaking the build

### DIFF
--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -63,7 +63,7 @@ module.exports = {
       computedClasses.push('frontmatter')
     }
     // filter null values, handles 11ty's first pass at build
-    const filteredClasses = classes.filter((x) => x)
+    const filteredClasses = Array.from(classes).filter((x) => x)
 
     // add custom classes from page frontmatter
     return computedClasses.concat(filteredClasses)


### PR DESCRIPTION
When creating a new publication with https://github.com/thegetty/quire-starter-objects-test/ **things** index front matter `things/index.md` using `objects-page` layout needs to set `classes`: 
```yaml
classes:
  - something
```

If you remove `classes` from `things/index.md`, the build fails because `_layouts/objects-page.webc` does not set `classes` in the layout front matter which all other layouts do. 

This is the error when `classes` is not defined (when I remove it from the **things** index front matter `things/index.md`):
`[11ty] classes.filter is not a function (via TypeError)`

This is odd because `classes=[]` is given a default value in the `eleventyComputed` `classes` function signature, so it should still filter over an empty array. But when logging `classes` I see this:
```
...
[ <1 empty item> ]
[ <1 empty item> ]
[ <2 empty items> ]
[ <1 empty item> ]
...
```
It's unclear where these empty items are coming from, but when I log `Array.from(classes)`, I see:
```
...
[]
[ 'quire-contents' ]
[ 'half-title-page' ]
[ 'title-page' ]
[ 'quire-splash', 'page-one' ]
[ 'quire-cover' ]
[ 'quire-page', 'copyright-page' ]
[ 'quire-page' ]
...
```