### PR TITLE
DEV-16151: Add prev/next navigation buttons to `_layouts/objects-page.webc`

### DIFF
--- a/packages/11ty/_includes/components/page-header.webc
+++ b/packages/11ty/_includes/components/page-header.webc
@@ -1,3 +1,0 @@
-<script webc:type="js">
-this.$data ? this.pageHeader(this.$data) : '';
-</script>

--- a/packages/11ty/_layouts/objects-page.webc
+++ b/packages/11ty/_layouts/objects-page.webc
@@ -2,7 +2,7 @@
 layout: base.11ty.js
 ---
 <template webc:nokeep>
-  <page-header></page-header>
+  <template @html="pageHeader(this.$data)" webc:nokeep></template>
   <style @raw="getBundle('css')" webc:keep></style>
   <section class="objects-catalog-content" @html="content"></section>
   <objects-catalog></objects-catalog>

--- a/packages/11ty/_layouts/objects-page.webc
+++ b/packages/11ty/_layouts/objects-page.webc
@@ -6,6 +6,7 @@ layout: base.11ty.js
   <style @raw="getBundle('css')" webc:keep></style>
   <section class="objects-catalog-content" @html="content"></section>
   <objects-catalog></objects-catalog>
+  <template @html="pageButtons(this)" webc:nokeep></template>
 </template>
 <style>
 .objects-catalog-content {


### PR DESCRIPTION
This update renders publication navigation buttons below the objects catalog in `objects-page` layout.
Following this same pattern, we are now calling the `pageHeader` shortcode from the markup `@html` attribute, which allows us to remove the `page-header.webc` wrapper component