### PR TITLE
DEV-16150: Render `content` in container; apply classes to add missing global styles

### DIFF
--- a/packages/11ty/_layouts/objects-page.webc
+++ b/packages/11ty/_layouts/objects-page.webc
@@ -4,7 +4,11 @@ layout: base.11ty.js
 <template webc:nokeep>
   <template @html="pageHeader(this.$data)" webc:nokeep></template>
   <style @raw="getBundle('css')" webc:keep></style>
-  <section class="objects-catalog-content" @html="content"></section>
+  <section class="objects-catalog-content section quire-page__content">
+    <div class="container">
+      <div class="content" @html="content"></div>
+    </div>
+  </section>
   <objects-catalog></objects-catalog>
   <template @html="pageButtons(this)" webc:nokeep></template>
 </template>


### PR DESCRIPTION
Now content will render like this:
![localhost_8080_things_](https://github.com/thegetty/quire/assets/7109269/bd44cc2f-fdd9-411a-a345-4d7dd1831df9)
