### PR TITLE
DEV-16233: Ensure `:href` is a dynamic attribute in `object-card.webc`

### DIFF
--- a/packages/11ty/_includes/components/object-filters/object-card/object-card.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-card.webc
@@ -1,4 +1,4 @@
-<a class="object-card" href="this.webc.attributes.url">
+<a class="object-card" :href="this.webc.attributes.url">
   <div class="object-card__content">
     <template webc:for="attribute of getAttributes(this.webc.attributes, this.$data)" webc:nokeep>
 

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -1,5 +1,5 @@
 <figure class="object-card__image" :data-field-name="attribute.name">
-  <img :src="src(attributes)" alt="alt(attributes)">
+  <img :src="src(attributes)" :alt="alt(attributes)">
 </figure>
 
 <script webc:setup>

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -6,7 +6,7 @@
 /**
  * Get object image `alt` from `thumbnail` property
  */
-const alt = ({ thumbnail }) => typeof thumbnail === 'object' ? thumbnail.alt : '';
+const alt = ({ data }) => typeof data.thumbnail === 'object' ? data.thumbnail.alt : '';
 
 /**
  * Get object image `src` from `figures` or `thumbnail` properties


### PR DESCRIPTION
Not sure when this regressed but links should point to object pages now, not literally `"this.webc.attributes.url"`
