### PR TITLE
Refine content area styles and add bibliography component

### DIFF
--- a/packages/11ty/_layouts/objects-page.webc
+++ b/packages/11ty/_layouts/objects-page.webc
@@ -4,21 +4,19 @@ layout: base.11ty.js
 <template webc:nokeep>
   <template @html="pageHeader(this.$data)" webc:nokeep></template>
   <style @raw="getBundle('css')" webc:keep></style>
-  <section webc:if="content" class="objects-catalog-content section quire-page__content">
+  <section webc:if="content" class="objects-page-content section quire-page__content">
     <div class="container">
-      <div class="content" @html="content"></div>
+      <div class="content">
+        <template @html="content" webc:nokeep></template>
+        <template @html="bibliography(this.$citations)" webc:nokeep></template>
+      </div>
     </div>
   </section>
   <objects-catalog></objects-catalog>
   <template @html="pageButtons(this)" webc:nokeep></template>
 </template>
 <style>
-.objects-catalog-content {
-  margin: 1em 1em 2em;
-  display: flex;
-  justify-content: center;
-}
-.objects-catalog-content > * {
-  max-width: 30em;
+.objects-page-content {
+  margin-bottom: 2em;
 }
 </style>


### PR DESCRIPTION
@anderspollack I felt badly for having missed these things when I was looking yesterday, so I thought I send them to you as a PR instead of another Jira ticket.

The `objects-catalog-content` class was conflicting with the default styles of the `div` wrappers you added (most notably making it a very narrow column), so I removed everything except the bottom margin, which was still needed. And I changed it to `objects-page-content` to keep consistent with the newer layout name.

I also realized that the page should include the bibliography should anyone choose to use it, and it had to be within the `.content` wrapper, but I think I figured out the webc stuff enough and it worked for me in testing

<img width="1588" alt="Screenshot 2023-10-10 at 8 47 50 AM" src="https://github.com/thegetty/quire/assets/7796401/07e8bab3-c8bb-412e-a5ed-9093d0608132">
