### PR TITLE
DEV-16148: Add support for `object_filters: false` to disable filtering and hide UI

### DIFF
--- a/packages/11ty/_includes/components/object-filters/object-filters.webc
+++ b/packages/11ty/_includes/components/object-filters/object-filters.webc
@@ -1,5 +1,5 @@
 <div class="object-filters__list">
-  <div webc:for="filter of getFilters(this.$data, objects)" class="object-filters__item">
+  <div webc:for="filter of getFilters(getFilterOrder($data), objects)" class="object-filters__item">
     <label :for="filter.id" @html="filter.fieldLabel"></label>
     <div class="object-filters__select">
       <select :id="filter.id" data-control-filter :data-control-name="filter.fieldName">
@@ -34,8 +34,9 @@ const humanize = (string) => {
 const isAtomicValue = (value) => typeof value === 'string' ||
   typeof value === 'number'
 
-const getFilterNamesFromObjectData = (objects) =>
-  objects.reduce((filterNames, { objectData }) => {
+const getFilterNamesFromObjectData = (objects) => {
+  const ignoredAttributes = ['name', 'thumbnail', 'title'];
+  return objects.reduce((filterNames, { objectData }) => {
     Object.entries(objectData).forEach(([key, value]) => {
       /**
        * Only render filters for keys:
@@ -56,6 +57,7 @@ const getFilterNamesFromObjectData = (objects) =>
     });
     return filterNames;
   }, []);
+}
 
 const sortByValueWithLocaleCompare = (a, b) => {
   return a.value.localeCompare(b.value)
@@ -79,9 +81,26 @@ const getUniqueOptionsFromObjectData = (objects, fieldName) =>
     }, [])
     .sort(sortByValueWithLocaleCompare);
 
-const getFilters = ($data, objects) => {
-  const ignoredAttributes = ['name', 'thumbnail', 'title'];
-  const filterOrder = $data.object_filters || $data.objects.object_filters;
+const getFilterOrder = ($data) => {
+  switch (true) {
+    case $data.object_filters:
+      return $data.object_filters;
+      /*
+       * When $data.object_filters is explicitly set to `false`, use it instead of
+       * global $data.objects.object_filters
+       */
+    case $data.object_filters === false:
+      return false;
+    default:
+      return $data.objects.object_filters;
+  }
+};
+
+const getFilters = (filterOrder, objects) => {
+  if (filterOrder === false) {
+    return [];
+  }
+
   const filterNames = filterOrder
     ? filterOrder
     : getFilterNamesFromObjectData(objects);

--- a/packages/11ty/_includes/components/object-filters/object-filters.webc
+++ b/packages/11ty/_includes/components/object-filters/object-filters.webc
@@ -81,18 +81,13 @@ const getUniqueOptionsFromObjectData = (objects, fieldName) =>
     }, [])
     .sort(sortByValueWithLocaleCompare);
 
+/**
+ * When object_filters is set to `false` filters are not rendered
+ */
 const getFilterOrder = ($data) => {
-  switch (true) {
-    case $data.object_filters:
-      return $data.object_filters;
-      /*
-       * When $data.object_filters is explicitly set to `false`, use it instead of
-       * global $data.objects.object_filters
-       */
-    case $data.object_filters === false:
-      return false;
-    default:
-      return $data.objects.object_filters;
+  return $data.object_filters !== false
+    ? $data.object_filters || $data.objects.object_filters
+    : false;
   }
 };
 

--- a/packages/11ty/_includes/components/object-filters/object-filters.webc
+++ b/packages/11ty/_includes/components/object-filters/object-filters.webc
@@ -88,7 +88,6 @@ const getFilterOrder = ($data) => {
   return $data.object_filters !== false
     ? $data.object_filters || $data.objects.object_filters
     : false;
-  }
 };
 
 const getFilters = (filterOrder, objects) => {

--- a/packages/11ty/_includes/components/object-filters/objects-catalog.webc
+++ b/packages/11ty/_includes/components/object-filters/objects-catalog.webc
@@ -7,7 +7,7 @@
       <object-filters :@objects="objects"></object-filters>
     </div>
     <div class="collapsible__controls">
-      <div class="object-filters__controls">
+      <div webc:if="!areFiltersDisabled($data)" class="object-filters__controls">
         <button class="object-filters__button object-filters__button--primary" data-control-apply>Apply Filters</button>
         <button class
 ="object-filters__button" data-control-reset>Reset</button>
@@ -80,6 +80,10 @@ const sortByOrderKey = (a, b) => {
   return a.order > b.order ? 1 : -1;
 };
 objects = objects.sort(sortByOrderKey);
+
+const areFiltersDisabled = ($data) => {
+  return $data.object_filters === false || $data.objects.object_filters === false;
+}
 </script>
 <script webc:keep type="text/javascript">
 window.customElements.define('objects-catalog', class extends HTMLElement {

--- a/packages/11ty/_includes/components/object-filters/objects-catalog.webc
+++ b/packages/11ty/_includes/components/object-filters/objects-catalog.webc
@@ -7,7 +7,7 @@
       <object-filters :@objects="objects"></object-filters>
     </div>
     <div class="collapsible__controls">
-      <div webc:if="displayFilters($data)" class="object-filters__controls">
+      <div webc:if="hasFilters($data)" class="object-filters__controls">
         <button class="object-filters__button object-filters__button--primary" data-control-apply>Apply Filters</button>
         <button class
 ="object-filters__button" data-control-reset>Reset</button>

--- a/packages/11ty/_includes/components/object-filters/objects-catalog.webc
+++ b/packages/11ty/_includes/components/object-filters/objects-catalog.webc
@@ -81,8 +81,8 @@ const sortByOrderKey = (a, b) => {
 };
 objects = objects.sort(sortByOrderKey);
 
-const areFiltersDisabled = ($data) => {
-  return $data.object_filters === false || $data.objects.object_filters === false;
+const hasFilters = ($data) => {
+  return $data.object_filters !== false || $data.objects.object_filters !== false;
 }
 </script>
 <script webc:keep type="text/javascript">

--- a/packages/11ty/_includes/components/object-filters/objects-catalog.webc
+++ b/packages/11ty/_includes/components/object-filters/objects-catalog.webc
@@ -82,7 +82,7 @@ const sortByOrderKey = (a, b) => {
 objects = objects.sort(sortByOrderKey);
 
 const hasFilters = ($data) => {
-  return $data.object_filters !== false || $data.objects.object_filters !== false;
+  return $data.object_filters !== false && $data.objects.object_filters !== false;
 }
 </script>
 <script webc:keep type="text/javascript">

--- a/packages/11ty/_includes/components/object-filters/objects-catalog.webc
+++ b/packages/11ty/_includes/components/object-filters/objects-catalog.webc
@@ -7,7 +7,7 @@
       <object-filters :@objects="objects"></object-filters>
     </div>
     <div class="collapsible__controls">
-      <div webc:if="!areFiltersDisabled($data)" class="object-filters__controls">
+      <div webc:if="displayFilters($data)" class="object-filters__controls">
         <button class="object-filters__button object-filters__button--primary" data-control-apply>Apply Filters</button>
         <button class
 ="object-filters__button" data-control-reset>Reset</button>


### PR DESCRIPTION
set `object_filters: false` either in `things/index.md` front matter or `objects.yaml` to disable filter UI. When `object_filters` is not specified in either place, filters for _all_ object properties will still render as before.