### PR TITLE
DEV-15887: Include title in epub manifest if no subtitle

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -85,10 +85,16 @@ module.exports = (eleventyConfig) => {
    * Publication title, subtitle, and reading line
    */
   const pubTitle = () => {
-    if (subtitle && readingLine) {
-      return `${title}: ${subtitle} ${readingLine}`
-    } else if (subtitle) {
-      return `${title}: ${subtitle}`
+    const joiner = title.endsWith('?') || title.endsWith('!') ? '' : ':';
+    switch (true) {
+    case subtitle && readingLine:
+      return `${title}${joiner} ${subtitle} ${readingLine}`
+    case readingLine:
+      return `${title} (${readingLine})`
+    case subtitle:
+      return `${title}${joiner} ${subtitle}`
+    default:
+      return title
     }
   }
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -85,7 +85,7 @@ module.exports = (eleventyConfig) => {
    * Publication title, subtitle, and reading line
    */
   const pubTitle = () => {
-    const joiner = title.endsWith('?') || title.endsWith('!') ? '' : ':';
+    const separator = title.match(/[.,:!?]$/) ? '' : ':';
     switch (true) {
       case subtitle && readingLine:
         return `${title}${separator} ${subtitle} ${readingLine}`

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -5,7 +5,7 @@ const logger = chalkFactory('_plugins:epub:manifest')
 
 /**
  * Returns publication.yaml data as JSON for the EPUB generation library
- * 
+ *
  * @param  {Object} publication
  * @return {Object}
  */
@@ -87,14 +87,14 @@ module.exports = (eleventyConfig) => {
   const pubTitle = () => {
     const separator = title.match(/[.,:!?]$/) ? '' : ':';
     switch (true) {
-      case subtitle && readingLine:
-        return `${title}${separator} ${subtitle} ${readingLine}`
-      case readingLine:
-        return `${title} (${readingLine})`
-      case subtitle:
-        return `${title}${separator} ${subtitle}`
+      case !!subtitle && !!readingLine:
+        return `${title}${separator} ${subtitle} ${readingLine}`;
+      case !!readingLine:
+        return `${title} (${readingLine})`;
+      case !!subtitle:
+        return `${title}${separator} ${subtitle}`;
       default:
-        return title
+        return title;
     }
   }
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -87,14 +87,14 @@ module.exports = (eleventyConfig) => {
   const pubTitle = () => {
     const joiner = title.endsWith('?') || title.endsWith('!') ? '' : ':';
     switch (true) {
-    case subtitle && readingLine:
-      return `${title}${joiner} ${subtitle} ${readingLine}`
-    case readingLine:
-      return `${title} (${readingLine})`
-    case subtitle:
-      return `${title}${joiner} ${subtitle}`
-    default:
-      return title
+      case subtitle && readingLine:
+        return `${title}${separator} ${subtitle} ${readingLine}`
+      case readingLine:
+        return `${title} (${readingLine})`
+      case subtitle:
+        return `${title}${separator} ${subtitle}`
+      default:
+        return title
     }
   }
 


### PR DESCRIPTION
This `epubTitle` function should now work in all permutations of `readingLine` and `subtitle` being defined (assuming title is defined, which if it isn't causes problems elsewhere)