### PR TITLE
Update `quire-11ty` package version to `1.0.0-rc.16`

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -18,11 +18,13 @@ Changelog entries are classified using the following labels:
 
 - `Removed`: for deprecated features removed in this release
 
-## [unreleased]
+## [1.0.0-rc.15]
 
 ### Added
 
 - Validation method to check if an image can be tiled, and log error if invalid.
+- `objects-page` layout. This contains the 'Object Filters' feature, which renders a filterable list of all publication objects.
+- `object-filters` WebC components
 
 ### Changed
 
@@ -35,6 +37,8 @@ Changelog entries are classified using the following labels:
 - Resolved issue with logic rendering external manifests
 - Prefix epub filename with `page-` to ensure validity if filename begins with a number
 - Include `svg` definitions in body of epub pages using `svg`
+- Ensure relative links with hashes are properly transformed for EPUB output
+- Include title in epub manifest if no subtitle
 
 ### Removed
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -154,7 +154,7 @@ module.exports = function(eleventyConfig, collections, content) {
         return url
       }
     }
-    const { hash, href, pathname } = relativeUrl(href)
+    const { hash, pathname } = relativeUrl(href)
 
     const index = collections.epub
       .findIndex(({ url }) => url === pathname)

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0-rc.14",
+      "version": "1.0.0-rc.15",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "bulma": "^0.9.3",

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0-rc.15",
+      "version": "1.0.0-rc.16",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "bulma": "^0.9.3",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",


### PR DESCRIPTION
I've already published a new `rc`-tagged version

- Update `quire-11ty` package version to `1.0.0-rc.15`
- Update `CHANGELOG`
- Update `quire-11ty` package version to `1.0.0-rc.16`

* Had to update again due to a syntax error in the epub transform
**To test**: `quire new starter-default --quire-version 1.0.0-rc.16`