### PR TITLE
Set image alt text for TOC item figures

### DIFF
--- a/packages/11ty/_includes/components/table-of-contents/item/grid.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/grid.js
@@ -60,39 +60,31 @@ module.exports = function (eleventyConfig) {
     const imageAttribute = image || pageFigure || pageObject ? 'image' : 'no-image'
     const slugPageAttribute = children ? 'slug-page' : ''
 
-    let imageElement
+    let tocFigure
+
     switch (true) {
       case !!image:
-        imageElement = html`
-          <div class="card-image">
-            <figure class="image">
-              <img src="${path.join(imageDir, image)}" alt="" />
-            </figure>
-          </div>
-        `
+        tocFigure = { alt: '', src: image }
         break
       case !!pageFigure: {
-        const firstFigure = pageFigure[0] ? getFigure(pageFigure[0]) : null
-        imageElement = firstFigure
-          ? tableOfContentsImage({ src: firstFigure.src })
-          : ''
+        tocFigure = pageFigure[0] ? getFigure(pageFigure[0]) : null
         break
       }
       case !!pageObject: {
         const firstObjectId = pageObject[0].id
         const object = firstObjectId ? getObject(firstObjectId) : pageObject[0]
-        const firstObjectFigure = object && object.figure
+        tocFigure = object && object.figure
           ? getFigure(object.figure[0].id)
           : null
-        imageElement = firstObjectFigure
-          ? tableOfContentsImage({ src: firstObjectFigure.src })
-          : ''
         break
       }
       default:
-        imageElement = ''
         break
     }
+
+    const imageElement = tocFigure
+      ? tableOfContentsImage({ alt: tocFigure.alt, src: tocFigure.src })
+      : ''
 
     if (!children) {
       mainElement = html`


### PR DESCRIPTION
### Fixed

- Pass figure `alt` text property to TOC image function; see also #874
