### PR TITLE
DEV-16531: Implement `addWebcShortcode` in `shortcodeFactory`

### DIFF
--- a/packages/11ty/_includes/components/object-filters/objects-catalog.webc
+++ b/packages/11ty/_includes/components/object-filters/objects-catalog.webc
@@ -25,6 +25,7 @@ const currentDir = filePathStem
   .filter((item) => item)
   .slice(0, -1)
   .join('/');
+if (!this.collections) return;
 const collection = this.collections.tableOfContentsHtml;
 const getCurrentDirIndexPage = (navigation) => {
   return navigation.reduce((indexPage, item) => {

--- a/packages/11ty/_plugins/components/shortcodeFactory.js
+++ b/packages/11ty/_plugins/components/shortcodeFactory.js
@@ -30,11 +30,11 @@ module.exports = function(eleventyConfig, collections) {
      * @param  {String}  tagName          A template tag name for the component
      * @param  {String}  webcElementName  A webc component tag name
      */
-    addWebcShortcode: function(tagName, webcElementName, attributeNames) {
+    addWebcShortcode: function(tagName, componentName, attributeNames) {
       eleventyConfig.addShortcode(tagName, async function(...args) {
         const renderTemplate = eleventyConfig.getFilter('renderTemplate')
         const renderedAttributes = attributeNames.map((name, index) => `${name}="${args[index]}"`).join(' ')
-        const template = `<${webcElementName} ${renderedAttributes}></${webcElementName}>`
+        const template = `<${componentName} ${renderedAttributes}></${componentName}>`
         let renderedHTML
         try {
           renderedHTML = await renderTemplate.call(this, template, 'webc')

--- a/packages/11ty/_plugins/components/shortcodeFactory.js
+++ b/packages/11ty/_plugins/components/shortcodeFactory.js
@@ -22,6 +22,27 @@ module.exports = function(eleventyConfig, collections) {
         const page = collections.all.find(({ inputPath }) => inputPath === this.page.inputPath)
         return component(eleventyConfig, { collections, page })(content, ...args)
       })
+    },
+    /**
+     * Adds a custom tag for a webc component.
+     *
+     * @param  {Array}  attributeNames    An array of attribute names to map to shortcode argument values
+     * @param  {String}  tagName          A template tag name for the component
+     * @param  {String}  webcElementName  A webc component tag name
+     */
+    addWebcShortcode: function(tagName, webcElementName, attributeNames) {
+      eleventyConfig.addShortcode(tagName, async function(...args) {
+        const renderTemplate = eleventyConfig.getFilter('renderTemplate')
+        const renderedAttributes = attributeNames.map((name, index) => `${name}="${args[index]}"`).join(' ')
+        const template = `<${webcElementName} ${renderedAttributes}></${webcElementName}>`
+        let renderedHTML
+        try {
+          renderedHTML = await renderTemplate.call(this, template, 'webc')
+        } catch (error) {
+          console.warn('ERROR', error)
+        }
+        return renderedHTML
+      });
     }
   }
 }

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -22,7 +22,7 @@
         "@11ty/eleventy-plugin-directory-output": "^1.0.1",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
         "@11ty/eleventy-plugin-vite": "^4.0.0",
-        "@11ty/eleventy-plugin-webc": "^0.11.0",
+        "@11ty/eleventy-plugin-webc": "^0.11.1",
         "@11ty/is-land": "^3.0.1",
         "@iiif/parser": "^1.1.2",
         "@iiif/vault": "^0.9.22",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -58,7 +58,7 @@
     "@11ty/eleventy-plugin-directory-output": "^1.0.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
     "@11ty/eleventy-plugin-vite": "^4.0.0",
-    "@11ty/eleventy-plugin-webc": "^0.11.0",
+    "@11ty/eleventy-plugin-webc": "^0.11.1",
     "@11ty/is-land": "^3.0.1",
     "@iiif/parser": "^1.1.2",
     "@iiif/vault": "^0.9.22",


### PR DESCRIPTION
- Update `@11ty/eleventy-plugin-webc` to version 0.11.1
- Implement `addWebcShortcode` in `shortcodeFactory`

I'm definitely open to different ways of serializing attributes for webc components. Since we don't have keyword args in liquid, I was thinking we would have to specify the argument names when registering shortcodes:

**component registration:**
```javascript
addWebcShortcode('gradoo, 'gradoo-component', ['foo', 'bar'])
```

**liquid template**
```html
{% gradoo 'hello' 'goodbye' %}
```

**webc template**
```html
<gradoo-component foo="hello" bar="goodbye"></gradoo-component>
```
