### PR TITLE
DEV-16533: Implement `quireData` component

### DIFF
--- a/packages/11ty/_includes/components/index.js
+++ b/packages/11ty/_includes/components/index.js
@@ -57,6 +57,7 @@ module.exports = {
   pageButtons: require('./page-buttons.js'),
   pageHeader: require('./page-header.js'),
   pageTitle: require('./page-title.js'),
+  quireData: require('./quire-data.js'),
   search: require('./search.js'),
   scripts: require('./scripts.js'),
   sequencePanel: require('./figure/image/sequence-panel'),
@@ -67,6 +68,5 @@ module.exports = {
   tableOfContentsItem: require('./table-of-contents/item/index.js'),
   tableOfContentsList: require('./table-of-contents/list/index.js'),
   tableOfContentsListItem: require('./table-of-contents/item/list.js'),
-  twitterCard: require('./head-tags/twitter-card.js'),
-  quireData: require('./quire-data.js')
+  twitterCard: require('./head-tags/twitter-card.js')
 }

--- a/packages/11ty/_includes/components/index.js
+++ b/packages/11ty/_includes/components/index.js
@@ -67,5 +67,6 @@ module.exports = {
   tableOfContentsItem: require('./table-of-contents/item/index.js'),
   tableOfContentsList: require('./table-of-contents/list/index.js'),
   tableOfContentsListItem: require('./table-of-contents/item/list.js'),
-  twitterCard: require('./head-tags/twitter-card.js')
+  twitterCard: require('./head-tags/twitter-card.js'),
+  quireData: require('./quire-data.js')
 }

--- a/packages/11ty/_includes/components/quire-data.js
+++ b/packages/11ty/_includes/components/quire-data.js
@@ -1,0 +1,6 @@
+module.exports = function(eleventyConfig) {
+  return function(...args) {
+    const [data, id='quire-data'] = args
+    return `<script type="application/json" id="${id}">${data}</script>`
+  }
+}

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -13,6 +13,7 @@ module.exports = async function(data) {
   const id = this.slugify(url) || path.parse(inputPath).name
   const pageId = `page-${id}`
   const figures = pageData.page.figures
+  const figuresJSON = figures ? JSON.stringify(figures) : '{}'
 
   return html`
     <!doctype html>
@@ -21,6 +22,7 @@ module.exports = async function(data) {
       <body>
         ${this.icons(data)}
         ${this.iconscc(data)}
+        ${await this.quireData(figuresJSON, 'page-figures')}
         <div class="quire no-js" id="container">
           <div
             aria-expanded="false"


### PR DESCRIPTION
I was having difficulty escaping the `"` in the stringified JSON to pass through to a webc version via `@raw`

```html
<script webc:keep type="application/json" @raw="data" :id="id"></script>
```

so I opted for a JS template string approach
