### PR TITLE
DEV-16535: Add `is-land` to quire figures, `quire-figure.webc` regression fixes

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -208,6 +208,11 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript' })
 
   /**
+   * Manually copy `is-land` modules into client package
+   */
+  eleventyConfig.addPassthroughCopy({ 'node_modules/@11ty/is-land/is-land.js': '_assets/javascript' })
+
+  /**
    * Watch the following additional files for changes and rerun server
    * @see https://www.11ty.dev/docs/config/#add-your-own-watch-targets
    * @see https://www.11ty.dev/docs/watch-serve/#ignore-watching-files

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -208,11 +208,6 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript/' })
 
   /**
-   * Manually copy `is-land` modules into client package
-   */
-  eleventyConfig.addPassthroughCopy({ 'node_modules/@11ty/is-land/is-land.js': '_assets/javascript/is-land.js' })
-
-  /**
    * Watch the following additional files for changes and rerun server
    * @see https://www.11ty.dev/docs/config/#add-your-own-watch-targets
    * @see https://www.11ty.dev/docs/watch-serve/#ignore-watching-files

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -208,6 +208,11 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript/' })
 
   /**
+   * Manually copy `is-land` module into client package
+   */
+  eleventyConfig.addPassthroughCopy({ 'node_modules/@11ty/is-land/is-land.js': '_assets/javascript/is-land.js' })
+
+  /**
    * Watch the following additional files for changes and rerun server
    * @see https://www.11ty.dev/docs/config/#add-your-own-watch-targets
    * @see https://www.11ty.dev/docs/watch-serve/#ignore-watching-files

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -205,12 +205,12 @@ module.exports = function(eleventyConfig) {
    */
   if (process.env.ELEVENTY_ENV === 'production') eleventyConfig.addPassthroughCopy(publicDir)
   eleventyConfig.addPassthroughCopy(`${inputDir}/_assets`)
-  eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript' })
+  eleventyConfig.addPassthroughCopy({ '_includes/web-components': '_assets/javascript/' })
 
   /**
    * Manually copy `is-land` modules into client package
    */
-  eleventyConfig.addPassthroughCopy({ 'node_modules/@11ty/is-land/is-land.js': '_assets/javascript' })
+  eleventyConfig.addPassthroughCopy({ 'node_modules/@11ty/is-land/is-land.js': '_assets/javascript/is-land.js' })
 
   /**
    * Watch the following additional files for changes and rerun server

--- a/packages/11ty/_components/figure-image.webc
+++ b/packages/11ty/_components/figure-image.webc
@@ -6,7 +6,7 @@
   <canvas-panel webc:if="isCanvas(id, is_static)" @attributes="attributes(id, image_dir, is_static, preset).canvasPanel"></canvas-panel>
   <image-service webc:elseif="isImageService(id, is_static)" @attributes="attributes(id, image_dir, is_static, preset).imageService"></image-service>
   <image-sequence webc:elseif="isSequence(id, is_static)" @attributes="attributes(id, image_dir, is_static, preset).imageSequence"></image-sequence>
-  <image-tag webc:else @attributes="attributes(image_dir, is_static, preset).imageTag"></image-tag>
+  <image-tag webc:else @attributes="attributes(id, image_dir, is_static, preset).imageTag"></image-tag>
 </template>
 <script webc:setup>
 const attributes = (id, image_dir, is_static, preset_override) => {

--- a/packages/11ty/_components/figure-image.webc
+++ b/packages/11ty/_components/figure-image.webc
@@ -3,7 +3,8 @@
     Nota bene: `webc:is` does not support dynamic values (see 11ty/webc#143);
     use webc conditional statements and call the `attributes` function multiple times rather than using a fancier pattern of implementation.
   --->
-  <canvas-panel webc:if="isCanvas(id)" @attributes="attributes(id, image_dir).canvasPanel"></canvas-panel>
+  <image-tag webc:if="isStatic(id, is_static)" @attributes="attributes(id, image_dir).staticInlineFigureImage"></image-tag>
+  <canvas-panel webc:elseif="isCanvas(id)" @attributes="attributes(id, image_dir).canvasPanel"></canvas-panel>
   <image-service webc:elseif="isImageService(id)" @attributes="attributes(id, image_dir).imageService"></image-service>
   <image-sequence webc:elseif="isSequence(id)" @attributes="attributes(id, image_dir).imageSequence"></image-sequence>
   <image-tag webc:else @attributes="attributes(id, image_dir).imageTag"></image-tag>
@@ -22,6 +23,7 @@ const attributes = (id, image_dir) => {
     region,
     src,
     startCanvas,
+    staticInlineFigureImage,
     textEnabled,
     textSelectionEnabled,
     virtualSizes,
@@ -55,6 +57,10 @@ const attributes = (id, image_dir) => {
       alt,
       image_dir,
       src
+    },
+    staticInlineFigureImage: {
+      alt,
+      src: staticInlineFigureImage
     }
   }
 }
@@ -62,4 +68,5 @@ const attributes = (id, image_dir) => {
 const isCanvas = (id) => this.getFigure(id).isCanvas
 const isImageService = (id) => this.getFigure(id).isImageService
 const isSequence = (id) => this.getFigure(id).isSequence
+const isStatic = (id, is_static) => is_static && !this.getFigure(id).annotations
 </script>

--- a/packages/11ty/_components/figure-image.webc
+++ b/packages/11ty/_components/figure-image.webc
@@ -3,13 +3,13 @@
     Nota bene: `webc:is` does not support dynamic values (see 11ty/webc#143);
     use webc conditional statements and call the `attributes` function multiple times rather than using a fancier pattern of implementation.
   --->
-  <canvas-panel webc:if="isCanvas(id, is_static)" @attributes="attributes(id, image_dir, preset).canvasPanel"></canvas-panel>
-  <image-service webc:elseif="isImageService(id, is_static)" @attributes="attributes(id, image_dir, preset).imageService"></image-service>
-  <image-sequence webc:elseif="isSequence(id, is_static)" @attributes="attributes(id, image_dir, preset).imageSequence"></image-sequence>
-  <image-tag webc:else @attributes="attributes(id, image_dir, preset).imageTag"></image-tag>
+  <canvas-panel webc:if="isCanvas(id, is_static)" @attributes="attributes(id, image_dir, is_static, preset).canvasPanel"></canvas-panel>
+  <image-service webc:elseif="isImageService(id, is_static)" @attributes="attributes(id, image_dir, is_static, preset).imageService"></image-service>
+  <image-sequence webc:elseif="isSequence(id, is_static)" @attributes="attributes(id, image_dir, is_static, preset).imageSequence"></image-sequence>
+  <image-tag webc:else @attributes="attributes(image_dir, is_static, preset).imageTag"></image-tag>
 </template>
 <script webc:setup>
-const attributes = (id, image_dir, preset_override) => {
+const attributes = (id, image_dir, is_static, preset_override) => {
   const {
     alt,
     canvasId,
@@ -55,11 +55,7 @@ const attributes = (id, image_dir, preset_override) => {
     imageTag: {
       alt,
       image_dir,
-      src
-    },
-    staticInlineFigureImage: {
-      alt,
-      src: staticInlineFigureImage
+      src: is_static && !src ? staticInlineFigureImage : src
     }
   }
 }

--- a/packages/11ty/_components/figure-image.webc
+++ b/packages/11ty/_components/figure-image.webc
@@ -3,14 +3,13 @@
     Nota bene: `webc:is` does not support dynamic values (see 11ty/webc#143);
     use webc conditional statements and call the `attributes` function multiple times rather than using a fancier pattern of implementation.
   --->
-  <image-tag webc:if="isStatic(id, is_static)" @attributes="attributes(id, image_dir).staticInlineFigureImage"></image-tag>
-  <canvas-panel webc:elseif="isCanvas(id)" @attributes="attributes(id, image_dir).canvasPanel"></canvas-panel>
-  <image-service webc:elseif="isImageService(id)" @attributes="attributes(id, image_dir).imageService"></image-service>
-  <image-sequence webc:elseif="isSequence(id)" @attributes="attributes(id, image_dir).imageSequence"></image-sequence>
-  <image-tag webc:else @attributes="attributes(id, image_dir).imageTag"></image-tag>
+  <canvas-panel webc:if="isCanvas(id, is_static)" @attributes="attributes(id, image_dir, preset).canvasPanel"></canvas-panel>
+  <image-service webc:elseif="isImageService(id, is_static)" @attributes="attributes(id, image_dir, preset).imageService"></image-service>
+  <image-sequence webc:elseif="isSequence(id, is_static)" @attributes="attributes(id, image_dir, preset).imageSequence"></image-sequence>
+  <image-tag webc:else @attributes="attributes(id, image_dir, preset).imageTag"></image-tag>
 </template>
 <script webc:setup>
-const attributes = (id, image_dir) => {
+const attributes = (id, image_dir, preset_override) => {
   const {
     alt,
     canvasId,
@@ -36,7 +35,7 @@ const attributes = (id, image_dir) => {
       height,
       'iiif-content': iiifContent,
       'manifest-id': manifestId,
-      preset,
+      preset: preset_override || preset,
       region,
       'virtual-sizes': virtualSizes,
       width
@@ -45,7 +44,7 @@ const attributes = (id, image_dir) => {
       id,
       'manifest-id': manifestId,
       margin,
-      preset,
+      preset: preset_override || preset,
       'start-canvas': startCanvas,
       'text-enabled': textEnabled,
       'text-selection-enabled': textSelectionEnabled
@@ -65,8 +64,8 @@ const attributes = (id, image_dir) => {
   }
 }
 
-const isCanvas = (id) => this.getFigure(id).isCanvas
-const isImageService = (id) => this.getFigure(id).isImageService
-const isSequence = (id) => this.getFigure(id).isSequence
-const isStatic = (id, is_static) => is_static && !this.getFigure(id).annotations
+const shouldRenderCanvas = (id, is_static) => this.getFigure(id).annotations || !is_static
+const isCanvas = (id, is_static) => shouldRenderCanvas(id, is_static) && this.getFigure(id).isCanvas
+const isImageService = (id, is_static) => shouldRenderCanvas(id, is_static) && this.getFigure(id).isImageService
+const isSequence = (id, is_static) => shouldRenderCanvas(id, is_static) && this.getFigure(id).isSequence
 </script>

--- a/packages/11ty/_components/image-tag.webc
+++ b/packages/11ty/_components/image-tag.webc
@@ -1,6 +1,6 @@
 <img :alt="alt" class="q-figure__image" :src="getSrc(src, image_dir)" />
 <script webc:setup>
 const getSrc = async (src, imageDir) => {
-  return src.startsWith('http') ? src : [imageDir, src].join('/')
+  return src.startsWith('http') || src.startsWith('/') ? src : [imageDir, src].join('/')
 }
 </script>

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,7 +1,9 @@
-<figure :id="slugify(id)" :class="getClasses(classes, id)">
-  <template webc:nokeep @html="component(id, image_dir)"></template>
-  <template webc:nokeep @html="getCaption(id)"></template>
-</figure>
+<is-land on:visible>
+  <figure :id="slugify(id)" :class="getClasses(classes, id)">
+    <template webc:nokeep @html="component(id, image_dir)"></template>
+    <template webc:nokeep @html="getCaption(id)"></template>
+  </figure>
+</is-land>
 <script webc:setup>
 const component = async (id, imageDir) => {
   const figure = this.getFigure(id)

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -9,9 +9,10 @@
 const component = async (id, imageDir, isStatic, preset) => {
   const figure = this.getFigure(id)
   const { mediaType } = figure
-  const { figureAudio, figureImageWebc, figureTable, figureVideo } = this
+  const { figureAudio, figureImageWebc, figureModalLink, figureTable, figureVideo } = this
   if (mediaType === 'image') {
-    return await figureImageWebc.call(this, id, imageDir, isStatic, preset)
+    const imageElement = await figureImageWebc.call(this, id, imageDir, isStatic, preset)
+    return figureModalLink({ content: imageElement, id })
   }
   const mediaTypeToComponentMap = {
     soundcloud: figureAudio,
@@ -20,7 +21,8 @@ const component = async (id, imageDir, isStatic, preset) => {
     vimeo: figureVideo,
     youtube: figureVideo
   }
-  return await mediaTypeToComponentMap[mediaType](figure)
+  const mediaElement = mediaTypeToComponentMap[mediaType](figure)
+  return await figureModalLink({ content: mediaElement, id })
 }
 const getAnnotations = (id) => {
   const figure = this.getFigure(id)

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,9 +1,7 @@
 <is-land on:visible>
   <figure :id="slugify(id)" :class="getClasses(classes, id)">
     <template webc:nokeep @html="component(id, image_dir, is_static, preset)"></template>
-    <template webc:nokeep @html="getAnnotations(id)"></template><!--
-    --><template webc:nokeep @html="getCaption(id)"></template><!--
-  --></figure>
+    <template webc:nokeep @html="getAnnotations(id)"></template><template webc:nokeep @html="getCaption(id)"></template></figure>
 </is-land>
 <script webc:setup>
 const component = async (id, imageDir, isStatic, preset) => {

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,9 +1,9 @@
 <is-land on:visible>
   <figure :id="slugify(id)" :class="getClasses(classes, id)">
     <template webc:nokeep @html="component(id, image_dir, is_static, preset)"></template>
-    <template webc:nokeep @html="getAnnotations(id)"></template>
-    <template webc:nokeep @html="getCaption(id)"></template>
-  </figure>
+    <template webc:nokeep @html="getAnnotations(id)"></template><!--
+    --><template webc:nokeep @html="getCaption(id)"></template><!--
+  --></figure>
 </is-land>
 <script webc:setup>
 const component = async (id, imageDir, isStatic, preset) => {

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,16 +1,16 @@
 <is-land on:visible>
   <figure :id="slugify(id)" :class="getClasses(classes, id)">
-    <template webc:nokeep @html="component(id, image_dir, is_static)"></template>
+    <template webc:nokeep @html="component(id, image_dir, is_static, preset)"></template>
     <template webc:nokeep @html="getCaption(id)"></template>
   </figure>
 </is-land>
 <script webc:setup>
-const component = async (id, imageDir) => {
+const component = async (id, imageDir, isStatic, preset) => {
   const figure = this.getFigure(id)
   const { mediaType } = figure
   const { figureAudio, figureImageWebc, figureTable, figureVideo } = this
   if (mediaType === 'image') {
-    return await figureImageWebc.call(this, id, imageDir)
+    return await figureImageWebc.call(this, id, imageDir, isStatic, preset)
   }
   const mediaTypeToComponentMap = {
     soundcloud: figureAudio,

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,6 +1,6 @@
 <is-land on:visible>
   <figure :id="slugify(id)" :class="getClasses(classes, id)">
-    <template webc:nokeep @html="component(id, image_dir)"></template>
+    <template webc:nokeep @html="component(id, image_dir, is_static)"></template>
     <template webc:nokeep @html="getCaption(id)"></template>
   </figure>
 </is-land>

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -21,8 +21,8 @@ const component = async (id, imageDir, isStatic, preset) => {
     vimeo: figureVideo,
     youtube: figureVideo
   }
-  const mediaElement = mediaTypeToComponentMap[mediaType](figure)
-  return await figureModalLink({ content: mediaElement, id })
+  const mediaElement = await mediaTypeToComponentMap[mediaType](figure)
+  return figureModalLink({ content: mediaElement, id })
 }
 const getAnnotations = (id) => {
   const figure = this.getFigure(id)

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,6 +1,7 @@
 <is-land on:visible>
   <figure :id="slugify(id)" :class="getClasses(classes, id)">
     <template webc:nokeep @html="component(id, image_dir, is_static, preset)"></template>
+    <template webc:nokeep @html="getAnnotations(id)"></template>
     <template webc:nokeep @html="getCaption(id)"></template>
   </figure>
 </is-land>
@@ -20,6 +21,10 @@ const component = async (id, imageDir, isStatic, preset) => {
     youtube: figureVideo
   }
   return await mediaTypeToComponentMap[mediaType](figure)
+}
+const getAnnotations = (id) => {
+  const figure = this.getFigure(id)
+  return this.annotationsUI({ figure })
 }
 
 const getCaption = (id) => {

--- a/packages/11ty/_components/quire-figure.webc
+++ b/packages/11ty/_components/quire-figure.webc
@@ -1,7 +1,8 @@
 <is-land on:visible>
   <figure :id="slugify(id)" :class="getClasses(classes, id)">
     <template webc:nokeep @html="component(id, image_dir, is_static, preset)"></template>
-    <template webc:nokeep @html="getAnnotations(id)"></template><template webc:nokeep @html="getCaption(id)"></template></figure>
+    <template webc:nokeep @html="getAnnotations(id)"></template><template webc:nokeep @html="getCaption(id)"></template>
+  </figure>
 </is-land>
 <script webc:setup>
 const component = async (id, imageDir, isStatic, preset) => {

--- a/packages/11ty/_includes/components/figure/caption.js
+++ b/packages/11ty/_includes/components/figure/caption.js
@@ -12,14 +12,9 @@ const { oneLine } = require('~lib/common-tags')
 module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
-  return function({ caption='', credit='', content='', mediaId, mediaType}) {
-    const { sourceUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
-    const mediaSourceLink = sourceUrl
-      ? `<span class="q-figure__caption-embed-link"><a href="${sourceUrl}"><em>${sourceUrl}</em></a></span>`
-      : ''
+  return function({ caption='', credit='', content='' }) {
     return oneLine`
       <figcaption class="q-figure__caption">
-        ${mediaSourceLink}
         ${markdownify(content)}
         <span class="q-figure__caption-content">${markdownify(caption)}</span>
         <span class="q-figure__credit">${markdownify(credit)}</span>

--- a/packages/11ty/_includes/components/figure/caption.js
+++ b/packages/11ty/_includes/components/figure/caption.js
@@ -12,7 +12,7 @@ const { oneLine } = require('~lib/common-tags')
 module.exports = function(eleventyConfig) {
   const markdownify = eleventyConfig.getFilter('markdownify')
   const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
-  return function({ caption, credit, content='', mediaId, mediaType}) {
+  return function({ caption='', credit='', content='', mediaId, mediaType}) {
     const { sourceUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
     const mediaSourceLink = sourceUrl
       ? `<span class="q-figure__caption-embed-link"><a href="${sourceUrl}"><em>${sourceUrl}</em></a></span>`
@@ -21,8 +21,8 @@ module.exports = function(eleventyConfig) {
       <figcaption class="q-figure__caption">
         ${mediaSourceLink}
         ${markdownify(content)}
-        <span class="q-figure__caption-content">${markdownify(caption || '')}</span>
-        <span class="q-figure__credit">${markdownify(credit || '')}</span>
+        <span class="q-figure__caption-content">${markdownify(caption)}</span>
+        <span class="q-figure__credit">${markdownify(credit)}</span>
       </figcaption>
     `
   }

--- a/packages/11ty/_includes/components/figure/table/html.js
+++ b/packages/11ty/_includes/components/figure/table/html.js
@@ -12,7 +12,7 @@ module.exports = function(eleventyConfig) {
   const tableElement = eleventyConfig.getFilter('figureTableElement')
   const markdownify = eleventyConfig.getFilter('markdownify')
 
-  return async function({ id, src }) {
+  return async function({ caption='', id, src }) {
     const table = await tableElement({ src })
     const title = markdownify(caption)
 
@@ -21,9 +21,7 @@ module.exports = function(eleventyConfig) {
         class="q-figure__modal-link"
         href="#${id}"
         title="${title}"
-      >
-        ${table}
-      </a>
+      >${table}</a>
     `
   }
 }

--- a/packages/11ty/_includes/components/figure/video/print.js
+++ b/packages/11ty/_includes/components/figure/video/print.js
@@ -14,11 +14,18 @@ const logger = chalkFactory('Figure Video')
  */
 module.exports = function(eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
+  const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
 
   return function({
     aspect_ratio: aspectRatio,
+    mediaId,
+    mediaType,
     poster=''
   }) {
+    const { sourceUrl } = figureMediaEmbedUrl({ mediaId, mediaType })
+    const mediaSourceLink = sourceUrl
+      ? `<span class="q-figure__caption-embed-link"><a href="${sourceUrl}"><em>${sourceUrl}</em></a></span>`
+      : ''
     if (!poster) {
       logger.warn(`Figure '${id}' does not have a 'poster' property. Print media will not render a fallback image for id: ${id}`)
     }
@@ -30,6 +37,7 @@ module.exports = function(eleventyConfig) {
     return html`
       <div class="q-figure__media-wrapper--${ aspectRatio || 'widescreen' }">
         <img src="${posterSrc}" />
+        ${mediaSourceLink}
       </div>
     `
   }

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -58,7 +58,7 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
-        <script type="module">import "/is-land.js";</script>
+        <script type="module" src="/_assets/javascript/is-land.js"></script>
 
         <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56" type="module"></script>
         <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -58,7 +58,7 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
-        <script type="module" src="./node_modules/@11ty/is-land/is-land.js"></script>
+        <script type="module" src="/_assets/javascript/is-land.js"></script>
 
         <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56" type="module"></script>
         <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -58,7 +58,7 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
-        <script type="module" src="/_assets/javascript/is-land.js"></script>
+        <script type="module">import "/is-land.js";</script>
 
         <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56" type="module"></script>
         <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -58,6 +58,8 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
+        <script type="module" src="/_assets/javascript/is-land.js"></script>
+
         <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56" type="module"></script>
         <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
 

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -58,7 +58,7 @@ module.exports = function(eleventyConfig) {
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">
 
-        <script type="module" src="/_assets/javascript/is-land.js"></script>
+        <script type="module" src="./node_modules/@11ty/is-land/is-land.js"></script>
 
         <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56" type="module"></script>
         <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>

--- a/packages/11ty/_layouts/base.11ty.js
+++ b/packages/11ty/_layouts/base.11ty.js
@@ -13,7 +13,14 @@ module.exports = async function(data) {
   const id = this.slugify(url) || path.parse(inputPath).name
   const pageId = `page-${id}`
   const figures = pageData.page.figures
-  const figuresJSON = figures ? JSON.stringify(figures) : '{}'
+  /**
+   * This is currently throwing an error about circular references in figure data
+   * Removing until we need quire-data written to page
+   *
+   * TODO: add `quire-data` when refactoring lightbox and modal to use webc + is-land
+   */
+  // const figuresJSON = figures ? JSON.stringify(figures) : '{}'
+  const figuresJSON = '{}';
 
   return html`
     <!doctype html>

--- a/packages/11ty/_plugins/components/index.js
+++ b/packages/11ty/_plugins/components/index.js
@@ -28,5 +28,5 @@ module.exports = function(eleventyConfig, collections, options) {
   /**
    * Note: WebC attribute names must be all lowercase or snake_case
    */
-  addWebcShortcode('figureImageWebc', 'figure-image', ['id', 'image_dir', 'is_static'])
+  addWebcShortcode('figureImageWebc', 'figure-image', ['id', 'image_dir', 'is_static', 'preset'])
 }

--- a/packages/11ty/_plugins/components/index.js
+++ b/packages/11ty/_plugins/components/index.js
@@ -28,5 +28,5 @@ module.exports = function(eleventyConfig, collections, options) {
   /**
    * Note: WebC attribute names must be all lowercase or snake_case
    */
-  addWebcShortcode('figureImageWebc', 'figure-image', ['id', 'image_dir'])
+  addWebcShortcode('figureImageWebc', 'figure-image', ['id', 'image_dir', 'is_static'])
 }

--- a/packages/11ty/_plugins/components/shortcodeFactory.js
+++ b/packages/11ty/_plugins/components/shortcodeFactory.js
@@ -30,7 +30,7 @@ module.exports = function(eleventyConfig, collections) {
      * @param  {String}  tagName          A template tag name for the component
      * @param  {String}  webcElementName  A webc component tag name
      */
-    addWebcShortcode: function(tagName, componentName, attributeNames) {
+    addWebcShortcode: function(tagName, componentName, attributeNames=[]) {
       eleventyConfig.addShortcode(tagName, async function(...args) {
         const renderTemplate = eleventyConfig.getFilter('renderTemplate')
         const renderedAttributes = attributeNames.map((name, index) => `${name}="${args[index]}"`).join(' ')

--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -36,7 +36,7 @@ module.exports = function (eleventyConfig) {
 
     const formats = ['bio', 'initials', 'name', 'name-title', 'name-title-block', 'string']
 
-    if (!formats.includes(format)) {
+    if (format && !formats.includes(format)) {
       logger.error(
         `Unrecognized contributors shortcode format "${format}". Supported format values are: ${formats.join(', ')}`
       )

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -43,7 +43,8 @@ module.exports = function (eleventyConfig) {
      * Render static versions of IIIF images inline
      */
     const isStatic = true
+    const preset = 'responsive'
 
-    return await quireFigure.call(this, classes, id, imageDir, isStatic)
+    return await quireFigure.call(this, classes, id, imageDir, isStatic, preset)
   }
 }

--- a/packages/11ty/_plugins/shortcodes/figure.js
+++ b/packages/11ty/_plugins/shortcodes/figure.js
@@ -39,6 +39,11 @@ module.exports = function (eleventyConfig) {
     this.page.figures ||= []
     this.page.figures.push(figure)
 
-    return await quireFigure.call(this, classes, id, imageDir)
+    /**
+     * Render static versions of IIIF images inline
+     */
+    const isStatic = true
+
+    return await quireFigure.call(this, classes, id, imageDir, isStatic)
   }
 }

--- a/packages/11ty/_plugins/shortcodes/figureGroup.js
+++ b/packages/11ty/_plugins/shortcodes/figureGroup.js
@@ -33,7 +33,7 @@ module.exports = function (eleventyConfig, { page }) {
     //   logger.warn(`NoMediaType: One of the figures passed to the q-figures shortcode is missing the 'media_type' attribute. Figures in 'figures.yaml' must be have a 'media_type' attribute with a value of either  "vimeo" or "youtube"`)
     // }
 
-    const classes = ['column', 'q-figure--group__item', `quire-grid--${columns}`]
+    const classes = ['column', 'q-figure--group__item']
     const rows = Math.ceil(ids.length / columns)
     let figureTags = []
     for (let i=0; i < rows; ++i) {
@@ -42,7 +42,7 @@ module.exports = function (eleventyConfig, { page }) {
       for (let id of ids.slice(startIndex, columns + startIndex)) {
         row += await figure(eleventyConfig, { page }).bind(this)(id, classes)
       }
-      figureTags.push(`<div class="q-figure--group__row columns">${row}</div>`)
+      figureTags.push(`<div class="q-figure--group__row columns quire-grid--${columns}">${row}</div>`)
     }
 
     return oneLine`

--- a/packages/11ty/_plugins/shortcodes/index.js
+++ b/packages/11ty/_plugins/shortcodes/index.js
@@ -27,5 +27,5 @@ module.exports = function(eleventyConfig, collections, options) {
   /**
    * Note: WebC attribute names must be all lowercase or snake_case
    */
-  addWebcShortcode('quireFigure', 'quire-figure', ['classes', 'id', 'image_dir', 'is_static'])
+  addWebcShortcode('quireFigure', 'quire-figure', ['classes', 'id', 'image_dir', 'is_static', 'preset'])
 }

--- a/packages/11ty/_plugins/shortcodes/index.js
+++ b/packages/11ty/_plugins/shortcodes/index.js
@@ -27,5 +27,5 @@ module.exports = function(eleventyConfig, collections, options) {
   /**
    * Note: WebC attribute names must be all lowercase or snake_case
    */
-  addWebcShortcode('quireFigure', 'quire-figure', ['classes', 'id', 'image_dir'])
+  addWebcShortcode('quireFigure', 'quire-figure', ['classes', 'id', 'image_dir', 'is_static'])
 }

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -35,6 +35,7 @@ module.exports = function (eleventyConfig, { directoryConfig, publication }) {
         mode: 'production',
         outDir: outputDir,
         rollupOptions: {
+          external: `${outputDir}/_assets/javascript/is-land.js`,
           output: {
             assetFileNames: ({ name }) => {
               const fullFilePathSegments = name.split('/').slice(0, -1)

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -35,7 +35,6 @@ module.exports = function (eleventyConfig, { directoryConfig, publication }) {
         mode: 'production',
         outDir: outputDir,
         rollupOptions: {
-          external: `${outputDir}/_assets/javascript/is-land.js`,
           output: {
             assetFileNames: ({ name }) => {
               const fullFilePathSegments = name.split('/').slice(0, -1)

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -23,7 +23,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
         "@11ty/eleventy-plugin-vite": "^4.0.0",
         "@11ty/eleventy-plugin-webc": "^0.11.1",
-        "@11ty/is-land": "^3.0.1",
+        "@11ty/is-land": "^3.0.2",
         "@iiif/parser": "^1.1.2",
         "@iiif/vault": "^0.9.22",
         "ajv": "^8.12.0",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -59,7 +59,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
     "@11ty/eleventy-plugin-vite": "^4.0.0",
     "@11ty/eleventy-plugin-webc": "^0.11.1",
-    "@11ty/is-land": "^3.0.1",
+    "@11ty/is-land": "^3.0.2",
     "@iiif/parser": "^1.1.2",
     "@iiif/vault": "^0.9.22",
     "ajv": "^8.12.0",


### PR DESCRIPTION
### Changed
- Give `addWebcShortcode` a default value for `attributeNames` argument
- Upgrade `is-land` to 3.0.2
- Add support for `formats: false`
- Wrap quire figure markup in `<is-land>`

### Fixed
- Figures styles broken with figures wrapped in <is-land> elements [DEV-16772](https://jira.getty.edu/browse/DEV-16772)
- Empty <p> elements are being adding before and after <figcaption> [DEV-16773](https://jira.getty.edu/browse/DEV-16773)
- Video and audio fallback links are displaying online [DEV-16774](https://jira.getty.edu/browse/DEV-16774)
- CLI errors with image sequences are breaking preview/build [DEV-16775](https://jira.getty.edu/browse/DEV-16775)
- Vite warning thrown in CLI on preview with new is-land work [DEV-16777](https://jira.getty.edu/browse/DEV-16777)
