### PR TITLE
Code formatting and linting

### DIFF
--- a/packages/11ty/_includes/components/download-link.js
+++ b/packages/11ty/_includes/components/download-link.js
@@ -1,11 +1,10 @@
-const path = require('path')
-
 const { oneLine } = require('~lib/common-tags')
 const chalkFactory = require('~lib/chalk')
-
 const checkFormat = require('../../_plugins/collections/filters/output.js')
+const path = require('path')
 
 const logger = chalkFactory('shortcode:footer-dl')
+
 /**
  * Handles logic about whether a footer d/l link appears at all and renders a link
  *
@@ -16,12 +15,11 @@ const logger = chalkFactory('shortcode:footer-dl')
  * @property  {String} name The link text
  * @property  {String} url
  * @param  {Array<String>} classes
- * @return {String}                anchor tag
+ *
+ * @return {String}  anchor tag
  */
 module.exports = function(eleventyConfig) {
-  
   const slugify = eleventyConfig.getFilter('slugify')
-
   const pdfConfig = eleventyConfig.globalData.config.pdf
 
   /**
@@ -32,38 +30,36 @@ module.exports = function(eleventyConfig) {
    * @param {bool} frontmatterSetting pdf page setting from page frontmatter
    * 
    * Returns true if a download link of this kind is configured
-   **/
-  const checkLinkPagePDF = (type,config,outputs,frontmatterSetting) => {
-
+   */
+  const checkLinkPagePDF = (type, config, outputs, frontmatterSetting) => {
     // Is the output being created?
-    if ( !checkFormat('pdf',{data:{outputs}}) ) { 
+    if ( !checkFormat('pdf', { data: { outputs } })) {
       return false 
     }
 
     // Are the links of this type set?
-    if ( config.pagePDF.accessLinks.find( (al) => al[type] === true ) === undefined )  {
+    if (config.pagePDF.accessLinks.find((al) => al[type] === true) === undefined)  {
       return false
     }
 
     // Return the core logic check
-    return ( config.pagePDF.output === true && frontmatterSetting !== false ) || frontmatterSetting === true
-
+    return (config.pagePDF.output === true && frontmatterSetting !== false) || frontmatterSetting === true
   }
 
   return function (params) {
     const { key, outputs, page_pdf_output: pagePDFOutput, type } = params
 
-    if (!checkLinkPagePDF(type,pdfConfig,outputs,pagePDFOutput)) { 
+    if (!checkLinkPagePDF(type, pdfConfig, outputs, pagePDFOutput)) {
       return ''
     }
 
-    const text = pdfConfig.pagePDF.accessLinks.find( al => al[type] === true ).label
+    const text = pdfConfig.pagePDF.accessLinks.find((al) => al[type] === true).label
     const href = path.join( pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(key)}.pdf` )
 
     return oneLine`
       <div class="quire-download ${ type==='footer' ? 'quire-download-footer-link' : '' }" data-outputs-exclude="epub,pdf">
-        <a class="quire-download__link" href="${ href }" download><span>${ text }</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
-      </div>`
+        <a class="quire-download__link" href="${href}" download><span>${text}</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
+      </div>
+    `
   }
-
 }

--- a/packages/11ty/_includes/components/page-header.js
+++ b/packages/11ty/_includes/components/page-header.js
@@ -26,22 +26,21 @@ module.exports = function(eleventyConfig) {
    * @param {bool} frontmatterSetting pdf page setting from page frontmatter
    * 
    * Check if the PDF link should be generated for this page
-   **/
+   */
   const checkPagePDF = (config,outputs,frontmatterSetting) => {
 
     // Is the output being created?
-    if ( !checkFormat('pdf',{data:{outputs}}) ) { 
+    if (!checkFormat('pdf', { data: { outputs } })) {
       return false 
     }
 
     // Are the footer links set?
-    if ( config.pagePDF.accessLinks.find( (al) => al.header === true ) === undefined )  {
+    if (config.pagePDF.accessLinks.find((al) => al.header === true) === undefined)  {
       return false
     }
 
     // Return the core logic check
-    return ( config.pagePDF.output === true && frontmatterSetting !== false ) || frontmatterSetting === true
-
+    return (config.pagePDF.output === true && frontmatterSetting !== false) || frontmatterSetting === true
   }
 
   return function (params) {
@@ -71,7 +70,7 @@ module.exports = function(eleventyConfig) {
       ? html`
           <section
             class="${classes} hero__image"
-           style="background-image: url('${path.join(imageDir, image)}');"
+            style="background-image: url('${path.join(imageDir, image)}');"
           >
           </section>
         `
@@ -87,15 +86,14 @@ module.exports = function(eleventyConfig) {
 
     let downloadLink = ''
 
-    if ( checkPagePDF(pdfConfig,outputs,pagePDFOutput) ) {
-
-      const text = pdfConfig.pagePDF.accessLinks.find( al => al.header === true ).label
-      const href = path.join( pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(key)}.pdf` )
+    if (checkPagePDF(pdfConfig,outputs,pagePDFOutput)) {
+      const text = pdfConfig.pagePDF.accessLinks.find((al) => al.header === true).label
+      const href = path.join(pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(key)}.pdf`)
       downloadLink = html`
-            <div class="quire-download" data-outputs-exclude="epub,pdf">
-              <a class="quire-download__link" href="${ href }" download><span>${ text }</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
-            </div>`
-
+        <div class="quire-download" data-outputs-exclude="epub,pdf">
+          <a class="quire-download__link" href="${ href }" download><span>${ text }</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
+        </div>
+      `
     }
 
     return html`

--- a/packages/11ty/_includes/components/table-of-contents/item/list.js
+++ b/packages/11ty/_includes/components/table-of-contents/item/list.js
@@ -67,18 +67,16 @@ module.exports = function (eleventyConfig) {
     // Returns abstract with any links stripped out
     const abstractText =
       presentation === 'abstract' && (abstract || summary)
-        ? `<div class="abstract-text">${ removeHTML(markdownify(abstract)) }</div>`
+        ? `<div class="abstract-text">${removeHTML(markdownify(abstract))}</div>`
         : ''
 
     let mainElement = `${markdownify(pageTitleElement)}${isPage && !children ? arrowIcon : ''}`
 
     if (isPage) {
       mainElement = `<a href="${page.url}">${mainElement}</a>`
-
       if (hasPagePDF && hasAccessLinks) {
-        const pdfText = pdfConfig.pagePDF.accessLinks.find( al => al.toc === true ).label
-        const pdfHref = path.join( pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(page.key)}.pdf` )
-
+        const pdfText = pdfConfig.pagePDF.accessLinks.find((al) => al.toc === true).label
+        const pdfHref = path.join(pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(page.key)}.pdf`)
         mainElement += `<a href="${pdfHref}"><span>${pdfText}</span></a>`
       }
     } else {

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -1,10 +1,8 @@
 const assert = require('node:assert')
-const fs = require('fs-extra')
-const path = require('path')
-
 const chalkFactory = require('~lib/chalk')
-
+const fs = require('fs-extra')
 const parser = require('./parser')
+const path = require('path')
 
 const logger = chalkFactory('[plugins:globalData]')
 
@@ -48,7 +46,7 @@ const checkForDuplicateIds = function (data, filename) {
  * 
  * @todo replace with ajv schema validation
  */
-const validateUserConfig = (type,data) => {
+const validateUserConfig = (type, data) => {
   switch (type) {
     case 'publication':
       try {
@@ -63,7 +61,7 @@ const validateUserConfig = (type,data) => {
       }
       break
     case 'config': // FIXME: *pretty* sure `strictEqual()` throws, but it's node so double check with bad data
-      if ( 'pdf' in data ) {
+      if ('pdf' in data) {
         // For now just use some quickie type-checking asserts
         assert.strictEqual(typeof data.pdf.outputDir,'string',new TypeError('pdf.outputDir must be a string'))
         assert.strictEqual(typeof data.pdf.filename,'string',new TypeError('pdf.filename must be a string'))
@@ -99,18 +97,14 @@ module.exports = function(eleventyConfig, directoryConfig) {
   const parse = parser(eleventyConfig)
 
   for (const file of files) {
-
     const { name: key } = path.parse(file)
     const parsed = parse(path.join(dir, file)) 
-    const value = validateUserConfig(key,parsed)
-
+    const value = validateUserConfig(key, parsed)
     if (!key || !value) { 
       continue
     }
-
     checkForDuplicateIds(value, file)
     eleventyConfig.addGlobalData(key, value)
-    
   }
 
   // Add directory config to globalData so that it is available to other plugins

--- a/packages/11ty/_plugins/shortcodes/bibliography.js
+++ b/packages/11ty/_plugins/shortcodes/bibliography.js
@@ -1,10 +1,9 @@
-const path = require('path')
 const { html, oneLine } = require('~lib/common-tags')
 const chalkFactory = require('~lib/chalk')
+const checkFormat = require('../collections/filters/output.js')
+const path = require('path')
 
 const logger = chalkFactory('configuration:bibliography')
-
-const checkFormat = require('../collections/filters/output.js')
 
 /**
  * @function checkPagePDF
@@ -14,22 +13,21 @@ const checkFormat = require('../collections/filters/output.js')
  * @param {bool} frontmatterSetting pdf page setting from page frontmatter
  * 
  * Check if the PDF link should be generated for this page
- **/
-const checkPagePDF = (config,outputs,frontmatterSetting) => {
+ */
+const checkPagePDF = (config, outputs, frontmatterSetting) => {
 
   // Is the output being created?
-  if ( !checkFormat('pdf',{data:{outputs}}) ) { 
+  if (!checkFormat('pdf', { data: { outputs } })) {
     return false 
   }
 
   // Are the footer links set?
-  if ( config.pagePDF.accessLinks.find( (al) => al.footer === true ) === undefined )  {
+  if (config.pagePDF.accessLinks.find((al) => al.footer === true) === undefined )  {
     return false
   }
 
   // Return the core logic check
-  return ( config.pagePDF.output === true && frontmatterSetting !== false ) || frontmatterSetting === true
-
+  return (config.pagePDF.output === true && frontmatterSetting !== false) || frontmatterSetting === true
 }
 
 /**
@@ -60,7 +58,7 @@ module.exports = function (eleventyConfig, { page }) {
    * @param  {Array}  referenceIds  An array of `references.yaml` entry ids
    *                                to include in the rendered bibliography
    */
-  return function (referenceIds = [],pagePDFOutput) {
+  return function (referenceIds = [], pagePDFOutput) {
 
     if (!page.citations && !referenceIds) return
 
@@ -88,10 +86,8 @@ module.exports = function (eleventyConfig, { page }) {
       }
     })
 
-    const bibliographyItems = sortReferences(Object.values(page.citations))
-
     const bibliographyHeading = () => heading ? `<h2>${heading}</h2>` : ''
-
+    const bibliographyItems = sortReferences(Object.values(page.citations))
     const definitionList = () => html`
       <dl>
         ${bibliographyItems.map(({ id, short, full }) => `
@@ -110,17 +106,16 @@ module.exports = function (eleventyConfig, { page }) {
     `
 
     const downloadLink = () => {
-
-      if ( !checkPagePDF(pdfConfig,outputs,pagePDFOutput) || page.data.layout === 'cover' ) {
+      if (!checkPagePDF(pdfConfig, outputs, pagePDFOutput) || page.data.layout === 'cover') {
         return ''
       }
         
-      const text = pdfConfig.pagePDF.accessLinks.find( al => al.footer === true ).label
-      const href = path.join( pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(page.data.key)}.pdf` )
-      return oneLine`<div class="quire-download quire-download-footer-link" data-outputs-exclude="epub,pdf">
-        <a class="quire-download__link" href="${ href }" download><span>${ text }</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
-      </div>`
+      const text = pdfConfig.pagePDF.accessLinks.find((al) => al.footer === true).label
+      const href = path.join(pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(page.data.key)}.pdf`)
 
+      return oneLine`<div class="quire-download quire-download-footer-link" data-outputs-exclude="epub,pdf">
+        <a class="quire-download__link" href="${href}" download><span>${text}</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
+      </div>`
     }
 
     /**
@@ -129,12 +124,12 @@ module.exports = function (eleventyConfig, { page }) {
     switch (true) {
       case bibliographyItems.length > 0:
         return html`
-            <div class="quire-page__content__references backmatter">
-              ${bibliographyHeading()}
-              ${displayShort ? definitionList() : unorderedList()}
-              ${downloadLink()}
-            </div>
-          `
+          <div class="quire-page__content__references backmatter">
+            ${bibliographyHeading()}
+            ${displayShort ? definitionList() : unorderedList()}
+            ${downloadLink()}
+          </div>
+        `
       case downloadLink() !== '':
         return html`${downloadLink()}`
       default:

--- a/packages/11ty/_plugins/shortcodes/tombstone.js
+++ b/packages/11ty/_plugins/shortcodes/tombstone.js
@@ -1,7 +1,6 @@
 const { html, oneLine } = require('~lib/common-tags')
-const path = require('path')
-
 const checkFormat = require('../collections/filters/output.js')
+const path = require('path')
 
 /**
  * @function checkPagePDF
@@ -11,22 +10,21 @@ const checkFormat = require('../collections/filters/output.js')
  * @param {bool} frontmatterSetting pdf page setting from page frontmatter
  * 
  * Check if the PDF link should be generated for this page
- **/
-const checkPagePDF = (config,outputs,frontmatterSetting) => {
+ */
+const checkPagePDF = (config, outputs, frontmatterSetting) => {
 
   // Is the output being created?
-  if ( !checkFormat('pdf',{data:{outputs}}) ) { 
+  if (!checkFormat('pdf', { data: { outputs } })) {
     return false 
   }
 
   // Are the header links set?
-  if ( config.pagePDF.accessLinks.find( (al) => al.header === true ) === undefined )  {
+  if (config.pagePDF.accessLinks.find((al) => al.header === true) === undefined)  {
     return false
   }
 
   // Return the core logic check
-  return ( config.pagePDF.output === true && frontmatterSetting !== false ) || frontmatterSetting === true
-
+  return (config.pagePDF.output === true && frontmatterSetting !== false) || frontmatterSetting === true
 }
 
 /**
@@ -39,7 +37,7 @@ module.exports = function(eleventyConfig, { page }) {
   const { objectLinkText } = config.entryPage
   const { pdf: pdfConfig } = config
 
-  return function (pageObjects = [],key,outputs,pagePDFOutput) {
+  return function (pageObjects = [], key, outputs, pagePDFOutput) {
     const titleCase = eleventyConfig.getFilter('titleCase')
     const icon = eleventyConfig.getFilter('icon')
     const markdownify = eleventyConfig.getFilter('markdownify')
@@ -69,7 +67,8 @@ module.exports = function(eleventyConfig, { page }) {
       const text = pdfConfig.pagePDF.accessLinks.find( al => al.header === true ).label
       const href = path.join( pdfConfig.outputDir, `${pdfConfig.filename}-${slugify(key)}.pdf` )
       downloadLink = oneLine`
-              <a class="button" href="${ href }" target="_blank" data-outputs-exclude="epub,pdf" ><span>${ text }</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>`
+        <a class="button" href="${href}" target="_blank" data-outputs-exclude="epub,pdf" ><span>${text}</span><svg class="quire-download__link__icon"><use xlink:href="#download-icon"></use></svg></a>
+      `
     }
     
     const table = (object) => html`

--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -1,9 +1,9 @@
-const jsdom = require('jsdom')
+const chalkFactory = require('~lib/chalk')
 const filterOutputs = require('../filter.js')
+const jsdom = require('jsdom')
 const truncate = require('~lib/truncate')
 const writer = require('./write')
 
-const chalkFactory = require('~lib/chalk')
 const logger = chalkFactory('pdf:transform')
 
 const { JSDOM } = jsdom
@@ -67,7 +67,6 @@ module.exports = async function(eleventyConfig, collections, content) {
     }
 
     dataset.pagePdf = true
-
   }
 
   /**
@@ -108,19 +107,16 @@ module.exports = async function(eleventyConfig, collections, content) {
       item.setAttribute('href', `#${prefix}-${href.replace(/^#/, '')}`)
       item.setAttribute('id', `${prefix}-${id}`)
     })
-    // 
   }
 
   /**
    * @function trimLeadingSeparator
    * 
-   * @param {Object} document JSDom `document` object of a section element
-   * 
-   * Trims the publication URL path from @src attribs and style background-image URLs 
-   * 
-   **/
-  const trimLeadingSeparator = (document) => {
+   * Trims the publication URL path from @src attribs and style background-image URLs
 
+   * @param {Object} document JSDom `document` object of a section element
+   */
+  const trimLeadingSeparator = (document) => {
     const urlPath = eleventyConfig.globalData.publication.pathname
 
     /**
@@ -131,8 +127,7 @@ module.exports = async function(eleventyConfig, collections, content) {
      * @example Pass any other @src attributes (incl. `http(s)://..`)
      * 
      * @todo Why does background-image carry the root asset path but no pathPrefix?
-     * 
-     **/
+     */
     const trimDeployPathComponentOrSlash = (srcAttr) => {
       switch (true) {
         case srcAttr.startsWith(urlPath):
@@ -153,7 +148,6 @@ module.exports = async function(eleventyConfig, collections, content) {
       const backgroundImageUrl = element.style.backgroundImage.match(/[(](.*)[)]/)[1] || ''
       element.style.backgroundImage = `url('${trimDeployPathComponentOrSlash(backgroundImageUrl)}')`
     })
-
   }
 
   /**
@@ -163,10 +157,8 @@ module.exports = async function(eleventyConfig, collections, content) {
    * @param {Object} pdfConfig - configuration for the pdf
    * 
    * @return {Object} data formatted for the layout at _layouts/pdf-cover-pages.liquid
-   *   
-   **/
-  function normalizeCoverPageData(page,pdfConfig) { 
-
+   */
+  function normalizeCoverPageData(page,pdfConfig) {
     const { pagePDFCoverPageCitationStyle } = page.data
 
     // NB: `id` must match the @id slug scheme in `base.11ty.js` so the cover pages have the same keys
@@ -203,10 +195,16 @@ module.exports = async function(eleventyConfig, collections, content) {
      **/
 
     // Feed the CSL processor an access date (@todo: either make this work or use the func above..)
-    const pageCiteData = citePage({page,context: 'page',type:'mla'})
-    const mla = formatCitation({...pageCiteData,accessed: '01 Oct 1999'},{page,context: 'page',type:'mla'})
-    const pageCitations = { mla, chicago: citation({context: 'page',page, type: 'chicago' }) }
-    const title = pageTitle({...page.data, label: ''})
+    const pageCiteData = citePage({ page, context: 'page', type: 'mla' })
+    const mla = formatCitation(
+      { ...pageCiteData, accessed: '01 Oct 1999' },
+      { page, context: 'page', type: 'mla' }
+    )
+    const pageCitations = {
+      chicago: citation({ context: 'page', page, type: 'chicago' }),
+      mla
+    };
+    const title = pageTitle({ ...page.data, label: '' })
 
     return { 
       accessURL, 
@@ -217,7 +215,6 @@ module.exports = async function(eleventyConfig, collections, content) {
       license, 
       title 
     }
-
   }
 
   const pdfPages = collections.pdf.map(({ outputPath }) => outputPath)

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -1,5 +1,5 @@
-import Command from '#src/Command.js'
 import { paths, projectRoot  } from '#lib/11ty/index.js'
+import Command from '#src/Command.js'
 import fs from 'fs-extra'
 import libPdf from '#lib/pdf/index.js'
 import open from 'open'
@@ -15,9 +15,8 @@ import yaml from 'js-yaml'
  * which uses the same validator(s) as the build proceess
  * 
  * @return {Object|undefined} User configuration object or undefined
- **/
+ */
 function loadConfig(path) {
-
   if (!fs.existsSync(path)) {
     return undefined
   }
@@ -26,7 +25,6 @@ function loadConfig(path) {
   const config = yaml.load(data)
 
   return config
-
 }
 
 const quireConfig = loadConfig(path.join(projectRoot,'content','_data','config.yaml'))

--- a/packages/cli/src/lib/pdf/paged.js
+++ b/packages/cli/src/lib/pdf/paged.js
@@ -87,28 +87,30 @@ export default async (publicationInput, coversInput, output, options = {}) => {
     const file = await printer.pdf(publicationInput, pdfOptions)
       .catch((error) => console.error(error))
 
-
     let pageMap
 
     // Now it's printed, create the pageMap by running JS in the printer's context
     // @todo: Abstract this into its own function
     let coversFile
+
     if (options.pdfConfig && options.pdfConfig.pagePDF.coverPage) {
       console.info(`[CLI:lib/pdf/pagedjs] printing ${coversInput}`)
       const pages = await printer.browser.pages()
+
       if (pages.length > 0) {
         pageMap = await pages[pages.length - 1].evaluate(() => {
           // Retrieves the pageMap from our plugin
           return window.pageMap ?? {}
         })
-
       }
 
       const coverPrinter = new Printer(printerOptions)
+
       coversFile = await coverPrinter.pdf(coversInput, pdfOptions)
         .catch((error) => console.error(error))
 
       const coverPages = await coverPrinter.browser.pages() 
+
       if (coverPages.length > 0) {
         const coversMap = await coverPages[coverPages.length - 1].evaluate(() => {
           // Retrieves the pageMap from our plugin
@@ -121,7 +123,6 @@ export default async (publicationInput, coversInput, output, options = {}) => {
           }
         })
       }
-
       coverPrinter.close()
     }
 
@@ -131,7 +132,6 @@ export default async (publicationInput, coversInput, output, options = {}) => {
     }
 
     if (file && output) {
-
       const { dir } = path.parse(output)
       if (!fs.existsSync(dir)) { 
         fs.mkdirsSync(dir)


### PR DESCRIPTION
Manually lint/format code

### Changed

- Sort `import` and `require` statements
- Remove parenthesis spacing and new lines after return statements 
  example `if (a === b)`
- Add arguments spacing
  example `fn(arg1, arg2, arg3: { a: { b } })`

