### PR TITLE
updates default sort

### DIFF
--- a/packages/11ty/_plugins/collections/index.js
+++ b/packages/11ty/_plugins/collections/index.js
@@ -1,9 +1,9 @@
-const filters = require('./filters')
-const sortCollection = require('./sort')
+const filters = require("./filters");
+const sortCollection = require("./sort");
 
 /**
  * Add Collections and Apply Transforms
- * 
+ *
  * Nota bene: The Eleventy API does not make collections data accessible
  * from the plugin context. Adding `collections` and `transforms` sequentially
  * in the same file allows access to `collections` data from `transforms`
@@ -13,23 +13,23 @@ const sortCollection = require('./sort')
  * @return {Object} collections
  */
 module.exports = function (eleventyConfig, options = {}) {
-  let collections = {}
+  let collections = {};
 
   /**
    * Add sorted "all" collection
    */
-  eleventyConfig.addCollection('allSorted', function (collectionApi) {
-    return collectionApi.getAll().sort(sortCollection)
-  })
+  eleventyConfig.addCollection("allSorted", function (collectionApi) {
+    return collectionApi.getAllSorted().sort(sortCollection);
+  });
 
   /**
    * Add eleventy-generated collections to collections object
    */
-  eleventyConfig.addCollection('temp', function (collectionApi) {
-    const eleventyCollections = collectionApi.getAll()[0].data.collections
-    Object.assign(collections, eleventyCollections)
-    return []
-  })
+  eleventyConfig.addCollection("temp", function (collectionApi) {
+    const eleventyCollections = collectionApi.getAll()[0].data.collections;
+    Object.assign(collections, eleventyCollections);
+    return [];
+  });
 
   /**
    * Add custom collections
@@ -37,11 +37,11 @@ module.exports = function (eleventyConfig, options = {}) {
   for (const name in filters) {
     eleventyConfig.addCollection(name, function (collectionApi) {
       collections[name] = collectionApi
-        .getAll()
+        .getAllSorted()
         .filter(filters[name])
-        .sort(sortCollection)
-      return collections[name]
-    })
+        .sort(sortCollection);
+      return collections[name];
+    });
   }
-  return collections
-}
+  return collections;
+};


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [existing issue](https://github.com/thegetty/quire/issues).*

**Before submitting your PR, make sure that you can run the following commands: `quire preview`, `quire build`, `quire pdf`, and `quire epub`. If any of those core quire commands throw errors/yield unexpected behavior, we will NOT review the PR!**

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?


### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Developing locally I found that when `order` is not set or has many duplicate values, default sort was not [stable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description).

I think Hugo's default sort fallbacks and the way it uses `weight` is significantly different from the current behavior. I created a `useCustomSort` config key to implement a more flexible TOC sort based on title string.

At the very least, I propose you `getAllSorted` first in order to ensure that order is not different between builds when `order` is missing.


### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?


### Include screenshots of before/after if applicable.



### Additional Comments

