### PR TITLE
Page PDF feature -- Additions from Greg

### DIFF
--- a/packages/11ty/_layouts/pdf-cover-page.liquid
+++ b/packages/11ty/_layouts/pdf-cover-page.liquid
@@ -28,38 +28,29 @@
             {% endcomment %}
 
             <dl class="cover-content">
-              {% if cover.accessURL %}
-                <dt class="cover-content-label">URL:</dt>
-                <dd class="cover-content-data">{{cover.accessURL}}</dd>
-              {% endif %}
 
               {% if cover.contributors.size > 0 %}
                 <dt class="cover-content-label">Author(s):</dt>
                 <dd class="cover-content-data">{% contributors context=cover.contributors format='string' %}</dd>
               {% endif %}
 
-              {% comment %}
-              # FIXME: missing About the authors
-              {% endcomment %}
+              {% if cover.accessURL %}
+                <dt class="cover-content-label">URL:</dt>
+                <dd class="cover-content-data">{{cover.accessURL}}</dd>
+              {% endif %}
               
               {% if cover.citations %}
-                <dt class="cover-content-label">Source (MLA):</dt>
-                <dd class="cover-content-data">{{cover.citations.mla}}</dd>                
-                <dt class="cover-content-label">Source (Chicago):</dt>
+                <dt class="cover-content-label">Citation (Chicago):</dt>
                 <dd class="cover-content-data">{{cover.citations.chicago}}</dd>
-              {% endif %}
-
-              {% if cover.license %}
-                <dt class="cover-content-label">License:</dt>
-                <dd class="cover-content-data">{{cover.license}}</dd>
-              {% endif %}
-
-              {% if cover.copyright %}
-                <dt class="cover-content-label">Copyright:</dt>
-                <dd class="cover-content-data">{{cover.copyright}}</dd>
+                <dt class="cover-content-label">Citation (MLA):</dt>
+                <dd class="cover-content-data">{{cover.citations.mla}}</dd>
               {% endif %}
 
             </dl>
+
+            <hr />
+
+            {% copyright %}
 
           </div>
         </div>

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -24,6 +24,12 @@ description: splash page layout
         {% contributors context=pageContributors, format=byline_format %}
       </div>
     {% endif %}
+    {% downloadLink
+      type="header"
+      key=key
+      outputs=outputs
+      page_pdf_output=page_pdf_output
+    %}
   </div>
 </section>
 
@@ -34,12 +40,6 @@ description: splash page layout
     {% endif %}
     <div class="container">
       <div class="content{% if image %}{% else %} no-image-above{% endif %}">
-        {% downloadLink
-          type="header"
-          key=key
-          outputs=outputs
-          page_pdf_output=page_pdf_output
-        %}
         {{ content }}
         {% bibliography citations outputs page_pdf_output %}
       </div>

--- a/packages/11ty/_plugins/citations/formatCitation.js
+++ b/packages/11ty/_plugins/citations/formatCitation.js
@@ -30,7 +30,7 @@ module.exports = function(options={}) {
     processor.cite({ citationItems: [{ id: item.id }] })
     const citation = processor.bibliography().value
     return type === 'mla'
-      ? `${citation.replace(/\s+$/, '')} Accessed <span class="cite-current-date">DD Mon. YYYY</span>.`
+      ? `${citation.replace(/\s+$/, '')} <span class="cite-current-date__statement">Accessed <span class="cite-current-date">DD Mon. YYYY</span>.</span>`
       : citation
   }
 }


### PR DESCRIPTION
This makes a few changes to support some of the outstanding issues in our [Quire: Individual Page PDFs QA](https://docs.google.com/spreadsheets/d/1JfEDQaAyR0R-bnYKWgp7Yj4waWaDUlqbOoB0X1vnV0A/edit?usp=sharing) Google sheet. In particular to the information presented on the PDF cover sheer, and to the position of the header download link on the splash page.

Screenshots below. See [quire-starter-default#43](https://github.com/thegetty/quire-starter-default/pull/43) with the necessary CSS changes.

![Screenshot 2024-07-12 at 9 58 14 AM](https://github.com/user-attachments/assets/f2ba2941-ec4f-46ab-a703-b47f6a13cfe0)

![Screenshot 2024-07-12 at 10 03 24 AM](https://github.com/user-attachments/assets/8ef56c42-a293-4aec-8e81-b9632a6d891c)

