### PR TITLE
DEV-18240: Fix PDF config validation across old and new projects

### DIFF
--- a/packages/11ty/_plugins/globalData/validator.js
+++ b/packages/11ty/_plugins/globalData/validator.js
@@ -13,6 +13,8 @@ const configSchema = require('../schemas/config.json')
  * @param {Object} data - Deserialized config data from `config.yaml`, `publication.yaml`, etc
  * @param {Object} schemas - Object of schemas to use for validation `config`, `publication`, etc. Schemas should be deserialized JSONSchema objects.
  * 
+ * NB: This is also imported by CLI commands
+ *  
  */
 const validateUserConfig = (type, data, schemas = { config: configSchema }) => {
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -11,10 +11,9 @@ import yaml from 'js-yaml'
  *  
  * @param {path} string - file path to config file
  * 
- * @todo refactor loading configs to a separate module,
- * which uses the same validator(s) as the build proceess
- * 
  * @return {Object|undefined} User configuration object or undefined
+ * 
+ * @todo consider hardcoding a version check against .quire / project's package.json ver
  */
 async function loadConfig(configPath) {
   if (!fs.existsSync(configPath)) {
@@ -28,10 +27,9 @@ async function loadConfig(configPath) {
   const schemaPath = path.join(projectRoot,'_plugins','schemas','config.json')
   const validatorPlugin = path.join(projectRoot, '_plugins', 'globalData', 'validator.js')
 
-  const validateUserConfig = await import(validatorPlugin)
+  const { validateUserConfig } = await import(validatorPlugin)
 
-  // TODO: Check the project version string for whether we should check the schema
-  if (fs.existsSync(schemaPath)) {
+  if (fs.existsSync(schemaPath) && fs.existsSync(validatorPlugin)) {
     const schemaJSON = fs.readFileSync(schemaPath)
     const schema = JSON.parse(schemaJSON)
 

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -96,7 +96,7 @@ export default class PDFCommand extends Command {
 
     const output = quireConfig.pdf !== undefined
       ? path.join(paths.output, quireConfig.pdf.outputDir, `${quireConfig.pdf.filename}.pdf`)
-      : path.join(projectRoot, `${options.lib}.pdf`);
+      : path.join(projectRoot, `${options.lib}.pdf`)
 
     const pdfLib = await libPdf(options.lib, { ...options, pdfConfig: quireConfig.pdf })
     await pdfLib(publicationInput, coversInput, output)

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -23,13 +23,13 @@ async function loadConfig(configPath) {
   const data = fs.readFileSync(configPath)
   let config = yaml.load(data)
 
-  // NB: Schemas may be project specific so the CLI must loads from project root rather than package root
+  // NB: Schemas and validators are specific to the 11ty version of the project being built
   const schemaPath = path.join(projectRoot,'_plugins','schemas','config.json')
-  const validatorPlugin = path.join(projectRoot, '_plugins', 'globalData', 'validator.js')
+  const validatorPath = path.join(projectRoot, '_plugins', 'globalData', 'validator.js')
 
-  if (fs.existsSync(schemaPath) && fs.existsSync(validatorPlugin)) {
+  if (fs.existsSync(schemaPath) && fs.existsSync(validatorPath)) {
 
-    const { validateUserConfig } = await import(validatorPlugin)
+    const { validateUserConfig } = await import(validatorPath)
   
     const schemaJSON = fs.readFileSync(schemaPath)
     const schema = JSON.parse(schemaJSON)

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -27,9 +27,10 @@ async function loadConfig(configPath) {
   const schemaPath = path.join(projectRoot,'_plugins','schemas','config.json')
   const validatorPlugin = path.join(projectRoot, '_plugins', 'globalData', 'validator.js')
 
-  const { validateUserConfig } = await import(validatorPlugin)
-
   if (fs.existsSync(schemaPath) && fs.existsSync(validatorPlugin)) {
+
+    const { validateUserConfig } = await import(validatorPlugin)
+  
     const schemaJSON = fs.readFileSync(schemaPath)
     const schema = JSON.parse(schemaJSON)
 


### PR DESCRIPTION
This PR fixes DEV-18240, "`quire pdf` throws error in new version of CLI (rc.13)":
- Fixes dynamic import syntax to unwrap function property 
- Checks file presence of validator and moves import to file-exists scope