### PR TITLE
DEV-18256: Fix prince PDF generation on pre-`rc.17` projects

### DIFF
--- a/packages/cli/src/lib/pdf/prince.js
+++ b/packages/cli/src/lib/pdf/prince.js
@@ -61,7 +61,7 @@ export default async (publicationInput, coversInput, output, options = {}) => {
 
   let coversData
 
-  if (pdfConfig?.pagePDF?.coverPage === true) {
+  if (pdfConfig?.pagePDF?.coverPage === true && fs.existsSync(coversInput)) {
 
     const coversPageMapOutput = await execa('prince', [...pageMapOptions, coversInput])
     const coversMap = JSON.parse(coversPageMapOutput.stdout)


### PR DESCRIPTION
This PR fixes `DEV-18256 Error running PrinceXML with cli rc.14 on older projects` by adding a synchronous check for the PDF covers file. 