### PR TITLE
Configure Sass options to silence deprecation warnings

### DIFF
--- a/packages/11ty/_includes/components/lightbox/styles.js
+++ b/packages/11ty/_includes/components/lightbox/styles.js
@@ -20,7 +20,18 @@ module.exports = function (eleventyConfig) {
   if (!fs.existsSync(lightboxStylesPath)) {
     logger.warn(`q-lightbox component styles were not found at ${lightboxStylesPath}, this may cause the lightbox to behave unexpectedly.`)
   } else {
-    lightboxCSS = sass.compile(lightboxStylesPath)
+    const sassOptions = {
+      api: 'modern-compiler',
+      loadPaths: [path.resolve('node_modules')],
+      silenceDeprecations: [
+        'color-functions',
+        'global-builtin',
+        'import',
+        'legacy-js-api',
+        'mixed-decls'
+      ]
+    }
+    lightboxCSS = sass.compile(lightboxStylesPath, sassOptions)
   }
 
   return function () {

--- a/packages/11ty/_plugins/transforms/outputs/epub/index.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/index.js
@@ -43,8 +43,14 @@ module.exports = (eleventyConfig, collections) => {
      * Copy styles
      */
     const sassOptions = {
-      loadPaths: [
-        path.resolve('node_modules')
+      api: 'modern-compiler',
+      loadPaths: [path.resolve('node_modules')],
+      silenceDeprecations: [
+        'color-functions',
+        'global-builtin',
+        'import',
+        'legacy-js-api',
+        'mixed-decls'
       ]
     }
     const styles = sass.compile(path.resolve('content', assetsDir, 'styles', 'epub.scss'), sassOptions)

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -57,9 +57,16 @@ module.exports = (eleventyConfig) => {
     }
 
     const sassOptions = {
-      loadPaths: [
-        path.resolve('node_modules')
-      ]
+      api: 'modern-compiler',
+      loadPaths: [path.resolve('node_modules')],
+      // logger: {
+      //   warn(message, options) {
+      //     if (options.deprecation) return;
+      //     console.warn('Warning: %O', message)
+      //   }
+      // },
+      quietDeps: true,
+      silenceDeprecations: ['color-functions', 'import', 'mixed-decls']
     }
 
     try {

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -59,14 +59,13 @@ module.exports = (eleventyConfig) => {
     const sassOptions = {
       api: 'modern-compiler',
       loadPaths: [path.resolve('node_modules')],
-      // logger: {
-      //   warn(message, options) {
-      //     if (options.deprecation) return;
-      //     console.warn('Warning: %O', message)
-      //   }
-      // },
-      quietDeps: true,
-      silenceDeprecations: ['color-functions', 'import', 'mixed-decls']
+      silenceDeprecations: [
+        'color-functions',
+        'global-builtin',
+        'import',
+        'legacy-js-api',
+        'mixed-decls'
+      ]
     }
 
     try {

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -84,13 +84,13 @@ module.exports = function (eleventyConfig, { directoryConfig, publication }) {
         preprocessorOptions: {
           scss: {
             api: 'modern-compiler',
-            logger: {
-              warn(message, options) {
-                if (options.deprecation) return;
-                console.warn('Warning: %O', message)
-              }
-            },
-            silenceDeprecations: ['color-functions', 'import', 'mixed-decls']
+            silenceDeprecations: [
+              'color-functions',
+              'global-builtin',
+              'import',
+              'legacy-js-api',
+              'mixed-decls'
+            ]
           }
         }
       },

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -84,7 +84,13 @@ module.exports = function (eleventyConfig, { directoryConfig, publication }) {
         preprocessorOptions: {
           scss: {
             api: 'modern-compiler',
-            quietDeps: true,
+            logger: {
+              warn(message, options) {
+                if (options.deprecation) return;
+                console.warn('Warning: %O', message)
+              }
+            },
+            silenceDeprecations: ['color-functions', 'import', 'mixed-decls']
           }
         }
       },

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -76,6 +76,19 @@ module.exports = function (eleventyConfig, { directoryConfig, publication }) {
         sourcemap: true
       },
       /**
+       * Configure style pre-procssing
+       * @see https://vite.dev/config/shared-options#css-preprocessoroptions
+       * @see https://sass-lang.com/documentation/js-api/interfaces/options/
+       */
+      css: {
+        preprocessorOptions: {
+          scss: {
+            api: 'modern-compiler',
+            quietDeps: true,
+          }
+        }
+      },
+      /**
        * Set to false to prevent Vite from clearing the terminal screen
        * and have Vite logging messages rendered alongside Eleventy output.
        */


### PR DESCRIPTION
### Changed

- Configure Vite with `css` preprocessor options for the `sass` compiler
- Pass options to the `sass` compiler for the `lightbox` component styles
- Pass options to the `sass` compiler when generating epub output
- Pass options to the `sass` compiler when generating PDF output

### Fixed

- Silence Sass deprecation warnings

See also https://github.com/thegetty/quire-starter-default/pull/47
