### PR TITLE
Fix a few issues remaining from v3 upgrade

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -15,7 +15,6 @@ import directoryOutputPlugin from '@11ty/eleventy-plugin-directory-output'
 import navigationPlugin from '@11ty/eleventy-navigation'
 import pluginWebc from '@11ty/eleventy-plugin-webc'
 import syntaxHighlightPlugin from '@11ty/eleventy-plugin-syntaxhighlight'
-import UpgradeHelper from '@11ty/eleventy-upgrade-help'
 
 /**
  * Quire plugins for Eleventy
@@ -72,12 +71,6 @@ const publicDir = process.env.ELEVENTY_ENV === 'production' ? 'public' : false /
  * @return     {Object}  A modified eleventy configuation
  */
 export default async function (eleventyConfig) {
-  /**
-   * Eleventy v2 to v3 upgrade helper
-   * @see https://www.11ty.dev/docs/plugins/upgrade-help/
-   */
-  eleventyConfig.addPlugin(UpgradeHelper)
-
   const dataDir = process.env.ELEVENTY_DATA || '_computed'
   const includesDir = process.env.ELEVENTY_INCLUDES || path.join('..', '_includes')
   const layoutsDir = process.env.ELEVENTY_LAYOUTS || path.join('..', '_layouts')

--- a/packages/11ty/_includes/components/lightbox/styles.js
+++ b/packages/11ty/_includes/components/lightbox/styles.js
@@ -2,7 +2,7 @@ import { html } from '#lib/common-tags/index.js'
 import chalkFactory from '#lib/chalk/index.js'
 import fs from 'fs'
 import path from 'node:path'
-import sass from 'sass'
+import * as sass from 'sass'
 
 const logger = chalkFactory('lightbox:styles')
 

--- a/packages/11ty/_plugins/transforms/outputs/epub/index.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import manifestFactory from './manifest.js'
 import path from 'node:path'
-import sass from 'sass'
+import * as sass from 'sass'
 import transform from './transform.js'
 import writer from './writer.js'
 

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -1,7 +1,7 @@
 import chalkFactory from '#lib/chalk/index.js'
 import fs from 'fs-extra'
 import path from 'node:path'
-import sass from 'sass'
+import * as sass from 'sass'
 
 /**
  * Nota bene:


### PR DESCRIPTION
This PR contains a few updates to complete the 11ty v3 migration:
- Removes 11ty v3 UpgradeHelper from `.eleventy.js`
- Refines the import syntax for `sass` in javascript for lightbox markup component, epub and pdf transforms 