### PR TITLE
Feature: Use `debug` for logging

### DIFF
--- a/packages/11ty/_lib/chalk/index.js
+++ b/packages/11ty/_lib/chalk/index.js
@@ -33,9 +33,9 @@ export default function (prefix = '', loglevel = 2) {
 
   /**
    * Initialize loggers for each loglevel.
-   * 
+   *
    * NB: colors are manually disabled to use color-per-loglevel styling
-   * 
+   *
    * @see https://github.com/debug-js/debug
    */
   const loggers = {
@@ -43,12 +43,12 @@ export default function (prefix = '', loglevel = 2) {
     error: debug(styles.error(`[quire] ${prefix} ${chalk.bold('ERROR')}\t`)),
     info: debug(styles.info(`[quire] ${prefix} ${chalk.bold('INFO')}\t`)),
     trace: debug(styles.trace(`[quire] ${prefix} ${chalk.bold('TRACE')}\t`)),
-    warn: debug(styles.warn(`[quire] ${prefix} ${chalk.bold('WARN')}\t`)),
+    warn: debug(styles.warn(`[quire] ${prefix} ${chalk.bold('WARN')}\t`))
   }
 
-  Object.entries(loggers).forEach(([logLevel,logger]) => {
+  Object.entries(loggers).forEach(([logLevel, logger]) => {
     logger.enabled = true
-    logger.useColors = false    
+    logger.useColors = false
   })
 
   const logFn = (type) => {

--- a/packages/11ty/_lib/chalk/index.js
+++ b/packages/11ty/_lib/chalk/index.js
@@ -47,7 +47,6 @@ export default function (prefix = '', loglevel = 2) {
   }
 
   Object.entries(loggers).forEach(([logLevel, logger]) => {
-    logger.enabled = true
     logger.useColors = false
   })
 
@@ -57,7 +56,7 @@ export default function (prefix = '', loglevel = 2) {
     const logger = loggers[type]
     const style = styles[type]
     prefix = prefix.padEnd(30, '\u0020')
-    return (message) => logger(style(chalk.bold(`${type.toUpperCase()}\t`), message))
+    return (message) => logger(style(message))
   }
 
   /**

--- a/packages/11ty/_lib/chalk/index.js
+++ b/packages/11ty/_lib/chalk/index.js
@@ -38,6 +38,8 @@ export default function (prefix = '', loglevel = 2) {
    *
    * @see https://github.com/debug-js/debug
    */
+  prefix = prefix.padEnd(30, '\u0020')
+
   const loggers = {
     debug: debug(styles.debug(`[quire] ${prefix} ${chalk.bold('DEBUG')}\t`)),
     error: debug(styles.error(`[quire] ${prefix} ${chalk.bold('ERROR')}\t`)),
@@ -51,11 +53,8 @@ export default function (prefix = '', loglevel = 2) {
   })
 
   const logFn = (type) => {
-    // logger(styles[type])
-
     const logger = loggers[type]
     const style = styles[type]
-    prefix = prefix.padEnd(30, '\u0020')
     return (message) => logger(style(message))
   }
 

--- a/packages/11ty/_lib/chalk/index.js
+++ b/packages/11ty/_lib/chalk/index.js
@@ -1,8 +1,8 @@
 import chalk from 'chalk'
-import log from 'loglevel'
+import debug from 'debug'
 
 /**
- * A factory function for custom logging methods using loglevel and chalk
+ * A factory function for custom logging methods using debug and chalk
  *
  * @typedef Loglevel {Number|String} A numeric index or case-insensitive name
  *  [0]: 'trace'
@@ -19,13 +19,6 @@ import log from 'loglevel'
  */
 export default function (prefix = '', loglevel = 2) {
   /**
-   * Get a new logger object and set logging level (non-persistent)
-   * @see https://github.com/pimterry/loglevel
-   */
-  const logger = log.getLogger(prefix)
-  logger.setLevel(loglevel, false)
-
-  /**
    * chalk themes
    * @see https://www.w3.org/wiki/CSS/Properties/color/keywords
    * @see https://github.com/chalk/chalk/tree/v4.1.2#usage
@@ -38,11 +31,33 @@ export default function (prefix = '', loglevel = 2) {
     warn: chalk.inverse.yellow
   }
 
+  /**
+   * Initialize loggers for each loglevel.
+   * 
+   * NB: colors are manually disabled to use color-per-loglevel styling
+   * 
+   * @see https://github.com/debug-js/debug
+   */
+  const loggers = {
+    debug: debug(styles.debug(`[quire] ${prefix} ${chalk.bold('DEBUG')}\t`)),
+    error: debug(styles.error(`[quire] ${prefix} ${chalk.bold('ERROR')}\t`)),
+    info: debug(styles.info(`[quire] ${prefix} ${chalk.bold('INFO')}\t`)),
+    trace: debug(styles.trace(`[quire] ${prefix} ${chalk.bold('TRACE')}\t`)),
+    warn: debug(styles.warn(`[quire] ${prefix} ${chalk.bold('WARN')}\t`)),
+  }
+
+  Object.entries(loggers).forEach(([logLevel,logger]) => {
+    logger.enabled = true
+    logger.useColors = false    
+  })
+
   const logFn = (type) => {
-    const log = logger[type]
+    // logger(styles[type])
+
+    const logger = loggers[type]
     const style = styles[type]
     prefix = prefix.padEnd(30, '\u0020')
-    return (message) => log(style(chalk.bold(`[quire] ${type.toUpperCase()}\t`), `${prefix}`, message))
+    return (message) => logger(style(chalk.bold(`${type.toUpperCase()}\t`), message))
   }
 
   /**

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -25,7 +25,7 @@
   "main": ".eleventy.js",
   "scripts": {
     "benchmark": "cross-env DEBUG=Eleventy:Benchmark* eleventy",
-    "build": "cross-env ELEVENTY_ENV=production eleventy",
+    "build": "cross-env ELEVENTY_ENV=production DEBUG=\"\" eleventy",
     "clean": "del-cli _epub _site public",
     "debug": "cross-env DEBUG=Eleventy* eleventy --dryrun",
     "dev": "cross-env ELEVENTY_ENV=development eleventy --serve",


### PR DESCRIPTION
This PR improves logging in quire build processes (`npm run build`, `quire dev`, etc) by replacing loglevel with debug-js, the package 11ty also uses for debug logging. The major changes are:
- Log lines are now expressed in the format: `[quire] component:subComponent LEVEL ...message...`
- Log level selection responds to globs on the `DEBUG` environment variable, so `cross-env DEBUG='Eleventy*,*quire*' eleventy` will turn on logging for Eleventy itself and for quire while `cross-env DEBUG='*quire*' eleventy` would only emit quire logs
- Update documentation of logging concern