### PR TITLE
Fix: correct failing IIIF tests

### DIFF
--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -75,8 +75,8 @@ export default class Annotation {
     const uri = () => {
       switch (true) {
         case isImageService:
-          // NB: Annotations for imageServices are *max jpeg*s not the service endpoint
-          return path.join(outputDir, name, printImage)
+          // NB: Annotations for imageServices are *jpeg*s not the service endpoint
+          return new URL(path.join(baseURI, printImage)).href
         default:
           try {
             return new URL(path.join(baseURI, outputDir, base)).href

--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/annotations-checkbox/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/annotations-checkbox/manifest.json
@@ -24,7 +24,7 @@
               "target": "http://localhost:8080/iiif/checkbox-annotations/canvas",
               "type": "Annotation",
               "body": {
-                "id": "http://localhost:8080/iiif/checkbox-annotations/base/tiles/info.json",
+                "id": "http://localhost:8080/iiif/checkbox-annotations/base/print-image.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
                 "height": 1455,

--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/zoomable/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/zoomable/manifest.json
@@ -24,7 +24,7 @@
               "target": "http://localhost:8080/iiif/zoom/canvas",
               "type": "Annotation",
               "body": {
-                "id": "http://localhost:8080/iiif/zoom/irises/tiles/info.json",
+                "id": "http://localhost:8080/iiif/zoom/irises/print-image.jpg",
                 "type": "Image",
                 "format": "image/jpeg",
                 "height": 3221,


### PR DESCRIPTION
This PR fixes failing tests in the IIIF module, correcting the pathing used to be correct for both in-11ty and in-test uses. It also updates the figure test fixtures to correct the annotation body ID expected (now JPEG-returning URI, was info.json URI). 