### PR TITLE
Fix `DEV-19745`: quire CLI fails to build 11ty v2-based projects 

### DIFF
--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -25,7 +25,8 @@ const factory = (options = {}) => {
   const eleventyModuleDir = path.join(eleventyRoot, 'node_modules', '@11ty', 'eleventy')
   const packagePath = path.join(eleventyModuleDir,'package.json')  
 
-  const pack = fs.readFileSync(packagePath)
+  const pack = JSON.parse(fs.readFileSync(packagePath))
+
   const { version } = pack
 
   const eleventyMajorVer = version.split('.').at(0)

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -1,4 +1,5 @@
 import { execa } from 'execa'
+import fs from 'node:fs'
 import path from 'node:path'
 import paths, { eleventyRoot, projectRoot } from './paths.js'
 
@@ -17,9 +18,23 @@ const factory = (options = {}) => {
 
   /**
    * Use the version of Eleventy installed to `lib/quire/versions`
+   * 
+   * NB: in eleventy v3 the CLI extension (".cjs") is load-bearing but v2 is simply ".js"
+   * 
    */
-  const eleventy =
-    path.join(eleventyRoot, 'node_modules', '@11ty', 'eleventy', 'cmd.cjs')
+  const eleventyModuleDir = path.join(eleventyRoot, 'node_modules', '@11ty', 'eleventy')
+  const packagePath = path.join(eleventyModuleDir,'package.json')  
+
+  const pack = fs.readFileSync(packagePath)
+  const { version } = pack
+
+  const eleventyMajorVer = version.split('.').at(0)
+
+  let eleventy = path.join(eleventyModuleDir,'cmd.cjs')
+
+  if ( Number(eleventyMajorVer) < 3 ) {
+    eleventy = path.join(eleventyModuleDir,'cmd.js')
+  }
 
   const command = [
     eleventy,


### PR DESCRIPTION
This PR updates the CLI wrapper that the quire CLI uses to call into eleventy to parse the major version of the 11ty version it's wrapping. Eleventy v3 now using ES modules means that its extensions determine whether core-js or esm is used so the command extension called needs to change accordingly:
- For v3 projects, use `node_modules/@11ty/eleventy/cmd.cjs`
- For v2 projects, continue to use `node_modules/@11ty/eleventy/cmd.js`
