### PR TITLE
Feature: Create sitemap - DEV-13152

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -193,7 +193,7 @@ export default async function (eleventyConfig) {
   const globalData = globalDataPlugin(eleventyConfig, { inputDir, outputDir, publicDir })
   const collections = collectionsPlugin(eleventyConfig)
   vitePlugin(eleventyConfig, globalData)
-  
+
   eleventyConfig.addPlugin(i18nPlugin)
   eleventyConfig.addPlugin(figuresPlugin)
 

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -42,6 +42,7 @@ import lintersPlugin from '#plugins/linters/index.js'
 import markdownPlugin from '#plugins/markdown/index.js'
 import searchPlugin from '#plugins/search/index.js'
 import shortcodesPlugin from '#plugins/shortcodes/index.js'
+import sitemapPlugin from '#plugins/sitemap/index.js'
 import transformsPlugin from '#plugins/transforms/index.js'
 import vitePlugin from '#plugins/vite/index.js'
 
@@ -192,7 +193,7 @@ export default async function (eleventyConfig) {
   const globalData = globalDataPlugin(eleventyConfig, { inputDir, outputDir, publicDir })
   const collections = collectionsPlugin(eleventyConfig)
   vitePlugin(eleventyConfig, globalData)
-
+  
   eleventyConfig.addPlugin(i18nPlugin)
   eleventyConfig.addPlugin(figuresPlugin)
 
@@ -223,6 +224,9 @@ export default async function (eleventyConfig) {
    * @see {@link https://www.11ty.dev/docs/_plugins/render/}
    */
   eleventyConfig.addPlugin(EleventyRenderPlugin)
+
+  // Uses RenderPlugin so must load second
+  sitemapPlugin(eleventyConfig, collections)
 
   /**
    * Add plugin for WebC support

--- a/packages/11ty/_plugins/sitemap/README.md
+++ b/packages/11ty/_plugins/sitemap/README.md
@@ -1,0 +1,8 @@
+# sitemap plugin
+This plugin creates quire's sitemap using HTML pages from the publication
+
+## Overview
+
+- The plugin uses https://github.com/quasibit/eleventy-plugin-sitemap to generate sitemap with quire's `publication.url` set as the hostname. Rather than creating a template file (eg, `sitemap.md`), the plugin dyanmically renders the collection using 11ty's render plugin. *NB*: This means the quire sitemap plugin must be loaded after the render plugin.  
+
+- On eleventy.after, the plugin builds the sitemap using pages collections.html and serializes output to `public/sitemap.xml` (or directly to `_site/sitemap.xml` in dev builds)

--- a/packages/11ty/_plugins/sitemap/index.js
+++ b/packages/11ty/_plugins/sitemap/index.js
@@ -1,0 +1,22 @@
+import fs from 'node:fs'
+import sitemapPlugin from '@quasibit/eleventy-plugin-sitemap'
+
+/**
+ * Quire sitemamp plugin 
+ * 
+ * Wraps eleventy-plugin-sitemap to make the sitemap file plugin-internal
+ **/ 
+export default async function (eleventyConfig,collections) {
+  eleventyConfig.addPlugin(sitemapPlugin, {
+    sitemap: {
+        hostname: eleventyConfig.globalData.publication.url
+    }
+  })
+
+  eleventyConfig.on('eleventy.after', async () => {
+	  const sitemapXML = await eleventyConfig.javascript.functions.renderTemplate(`{% sitemap collections.html %}`, 'liquid,md',{ collections })
+	  // TODO: Use eleventyConfig.directoryAssignments.output
+	  const output = 'public/sitemap.xml'
+	  fs.writeFileSync(output,sitemapXML)  	
+  })
+}

--- a/packages/11ty/_plugins/sitemap/index.js
+++ b/packages/11ty/_plugins/sitemap/index.js
@@ -1,17 +1,18 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import sitemapPlugin from '@quasibit/eleventy-plugin-sitemap'
+import eleventySitemapPlugin from '@quasibit/eleventy-plugin-sitemap'
 
 /**
- * Quire sitemamp plugin
+ * Eleventy plugin to dynamically generate a sitemap from publication content.
  *
- * Wraps eleventy-plugin-sitemap to make the sitemap file plugin-internal
+ * @param {Object} eleventyConfig
+ * @param {Object} collections
  **/
 export default async function (eleventyConfig, collections) {
   const { url: hostname } = eleventyConfig.globalData.publication
   const { outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
 
-  eleventyConfig.addPlugin(sitemapPlugin, {
+  eleventyConfig.addPlugin(eleventySitemapPlugin, {
     sitemap: { hostname }
   })
 

--- a/packages/11ty/_plugins/sitemap/index.js
+++ b/packages/11ty/_plugins/sitemap/index.js
@@ -1,22 +1,26 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import sitemapPlugin from '@quasibit/eleventy-plugin-sitemap'
 
 /**
- * Quire sitemamp plugin 
- * 
+ * Quire sitemamp plugin
+ *
  * Wraps eleventy-plugin-sitemap to make the sitemap file plugin-internal
- **/ 
-export default async function (eleventyConfig,collections) {
+ **/
+export default async function (eleventyConfig, collections) {
+  const { url: hostname } = eleventyConfig.globalData.publication
+  const { inputDir, outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
+
   eleventyConfig.addPlugin(sitemapPlugin, {
-    sitemap: {
-        hostname: eleventyConfig.globalData.publication.url
-    }
+    sitemap: { hostname }
   })
 
   eleventyConfig.on('eleventy.after', async () => {
-	  const sitemapXML = await eleventyConfig.javascript.functions.renderTemplate(`{% sitemap collections.html %}`, 'liquid,md',{ collections })
-	  // TODO: Use eleventyConfig.directoryAssignments.output
-	  const output = 'public/sitemap.xml'
-	  fs.writeFileSync(output,sitemapXML)  	
+    const sitemap = await eleventyConfig.javascript.functions.renderTemplate('{% sitemap collections.html %}', 'liquid,md', { collections })
+    
+    const directory = publicDir ? publicDir : outputDir
+    const outputPath = path.join(directory, 'sitemap.xml')
+
+    fs.writeFileSync(outputPath, sitemap)
   })
 }

--- a/packages/11ty/_plugins/sitemap/index.js
+++ b/packages/11ty/_plugins/sitemap/index.js
@@ -9,7 +9,7 @@ import sitemapPlugin from '@quasibit/eleventy-plugin-sitemap'
  **/
 export default async function (eleventyConfig, collections) {
   const { url: hostname } = eleventyConfig.globalData.publication
-  const { inputDir, outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
+  const { outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
 
   eleventyConfig.addPlugin(sitemapPlugin, {
     sitemap: { hostname }
@@ -17,9 +17,7 @@ export default async function (eleventyConfig, collections) {
 
   eleventyConfig.on('eleventy.after', async () => {
     const sitemap = await eleventyConfig.javascript.functions.renderTemplate('{% sitemap collections.html %}', 'liquid,md', { collections })
-    
-    const directory = publicDir ? publicDir : outputDir
-    const outputPath = path.join(directory, 'sitemap.xml')
+    const outputPath = path.join(publicDir || outputDir, 'sitemap.xml')
 
     fs.writeFileSync(outputPath, sitemap)
   })

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -34,6 +34,7 @@
         "@eslint/js": "^9.1.1",
         "@iiif/parser": "^2.1.7",
         "@iiif/vault": "^0.9.22",
+        "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
         "ajv": "^8.12.0",
         "camelize": "^1.0.1",
         "chalk": "^5.3.0",
@@ -1929,6 +1930,20 @@
         "preact": "*"
       }
     },
+    "node_modules/@quasibit/eleventy-plugin-sitemap": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@quasibit/eleventy-plugin-sitemap/-/eleventy-plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-7YoU4jjipLjifBhZwttLWbAAkImmBfeMQ0+1ST6mJO45z2mFLHZcgnfHwGF2joNk74wiYNsNOB1ennouzQFZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-flat-polyfill": "^1.0.1",
+        "sitemap": "^6.3.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@react-hook/media-query": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@react-hook/media-query/-/media-query-1.1.1.tgz",
@@ -2334,6 +2349,16 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2471,6 +2496,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2500,6 +2532,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/array-includes": {
@@ -8147,6 +8189,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -8465,6 +8514,33 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
+    },
+    "node_modules/sitemap": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-6.4.0.tgz",
+      "integrity": "sha512-DoPKNc2/apQZTUnfiOONWctwq7s6dZVspxAZe2VPMNtoqNq7HgXRvlRnbIpKjf+8+piQdWncwcy+YhhTGY5USQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.14.28",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=10.3.0",
+        "npm": ">=5.6.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "4.0.0",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -73,6 +73,7 @@
     "@eslint/js": "^9.1.1",
     "@iiif/parser": "^2.1.7",
     "@iiif/vault": "^0.9.22",
+    "@quasibit/eleventy-plugin-sitemap": "^2.2.0",
     "ajv": "^8.12.0",
     "camelize": "^1.0.1",
     "chalk": "^5.3.0",


### PR DESCRIPTION
This PR adds a plugin to create a sitemap for HTML pages in a quire publication. Implementation notes:
- Uses https://github.com/quasibit/eleventy-plugin-sitemap to generate sitemap with quire's `publication.url` set as the hostname
- After publication build, the plugin builds the sitemap using pages collections.html and serializes output to `public/sitemap.xml` (or directly to `_site` in dev builds) 