### PR TITLE
Fix - ensure search plugin writes JSON to configured output directory

### DIFF
--- a/packages/11ty/_plugins/search/index.js
+++ b/packages/11ty/_plugins/search/index.js
@@ -17,6 +17,8 @@ export default function (eleventyConfig, collections, options) {
    * Write index
    */
   eleventyConfig.on('eleventy.after', async () => {
-    write(collections)
+    const { outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
+
+    write(collections, publicDir || outputDir)
   })
 }

--- a/packages/11ty/_plugins/search/write.js
+++ b/packages/11ty/_plugins/search/write.js
@@ -7,9 +7,10 @@ const logger = chalkFactory('Search Index')
  * Write JSON index of page content in `collections.html`
  *
  * @param   {Object}  collections
+ * @param   {String}  outputDir
  * @return     {Object}  Page content index JSON
  */
-export default function (collections) {
+export default function (collections, outputDir) {
   const wordcount = (content) => {
     if (!content) return 0
     return content.split(' ').length
@@ -29,7 +30,6 @@ export default function (collections) {
     }
   })
 
-  const outputDir = process.env.ELEVENTY_ENV === 'production' ? 'public' : '_site'
   const outputPath = path.join(outputDir, 'search-index.json')
 
   try {


### PR DESCRIPTION
This PR fixes an issue where the search plugin does not correctly use a build run's configured publicDir and outputDir by  replacing hard coded string values with the appropriate entries from directoryConfig.