### PR TITLE
Escape HTML entities where attributes are sourced from YAML or headmatter

### DIFF
--- a/packages/11ty/_includes/components/contributor/bio.js
+++ b/packages/11ty/_includes/components/contributor/bio.js
@@ -1,3 +1,4 @@
+import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
 import path from 'node:path'
 
@@ -40,7 +41,7 @@ export default function (eleventyConfig) {
     const contributorImage = image
       ? html`
           <div class="media-left">
-            <img class="image quire-contributor__pic" src="${path.join(config.figures.imageDir, image)}" alt="Picture of ${name}">
+            <img class="image quire-contributor__pic" src="${path.join(config.figures.imageDir, image)}" alt="Picture of ${escape(name)}">
           </div>
       `
       : ''

--- a/packages/11ty/_includes/components/figure/image/image-service.js
+++ b/packages/11ty/_includes/components/figure/image/image-service.js
@@ -1,4 +1,4 @@
-import ecsape from 'html-escape'
+import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
 
 /**

--- a/packages/11ty/_includes/components/figure/image/image-service.js
+++ b/packages/11ty/_includes/components/figure/image/image-service.js
@@ -1,3 +1,4 @@
+import ecsape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
 
 /**
@@ -20,7 +21,7 @@ export default function (eleventyConfig) {
   }) {
     return html`
       <image-service 
-        alt="${alt}"
+        alt="${escape(alt)}"
         class="q-figure__image"
         height="${height}"
         preset="${preset}"

--- a/packages/11ty/_includes/components/figure/image/image-tag.js
+++ b/packages/11ty/_includes/components/figure/image/image-tag.js
@@ -1,3 +1,4 @@
+import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
 import path from 'node:path'
 
@@ -18,7 +19,7 @@ export default function (eleventyConfig) {
 
     return html`
       <img
-        alt="${alt}"
+        alt="${escape(alt)}"
         class="q-figure__image"
         decoding="async"
         loading="${lazyLoading}"

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -1,3 +1,4 @@
+import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
 import path from 'node:path'
 
@@ -40,7 +41,7 @@ export default function (eleventyConfig) {
 
     // console.log(imageSrc)
     return html`
-      <img alt="${alt}" class="q-figure__image" src="${imageSrc}"/>
+      <img alt="${escape(alt)}" class="q-figure__image" src="${imageSrc}"/>
       ${figureCaption({ caption, content: labelElement, credit })}
     `
   }

--- a/packages/11ty/_includes/components/figure/placeholder.js
+++ b/packages/11ty/_includes/components/figure/placeholder.js
@@ -1,3 +1,4 @@
+import escape from 'escape'
 import path from 'node:path'
 import { html } from '#lib/common-tags/index.js'
 
@@ -16,13 +17,13 @@ export default function (eleventyConfig) {
           id="${id}"
           class="q-figure__image"
           src="${imagePath}"
-          alt="${alt}"
+          alt="${escape(alt)}"
         />
       `
     } else {
       const imagePath = path.join(imageDir, 'icons', `${mediaType}.png`)
       imageElement = `
-        <img src="${imagePath}" class="q-figure__media-fallback" alt="${alt}" />
+        <img src="${imagePath}" class="q-figure__media-fallback" alt="${escape(alt)}" />
       `
     }
 
@@ -30,7 +31,7 @@ export default function (eleventyConfig) {
 
     const captionElement = `
       <figcaption class="quire-figure__caption">
-        <a href="${src}" target="_blank" alt=>${src}</a>
+        <a href="${src}" target="_blank">${src}</a>
       </figcaption>
     `
 

--- a/packages/11ty/_includes/components/head-tags/opengraph.js
+++ b/packages/11ty/_includes/components/head-tags/opengraph.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-
+import escape from 'html-escape'
 /**
  * Renders <head> <meta> data tags for Open Graph protocol data
  *
@@ -69,7 +69,7 @@ export default function (eleventyConfig) {
     })
 
     const metaTags = meta.map(({ property, content }) => (
-      `<meta property="${property}" content="${content}">`
+      `<meta property="${property}" content="${escape(content)}">`
     ))
     return `${metaTags.join('\n')}`
   }

--- a/packages/11ty/_includes/components/head-tags/twitter-card.js
+++ b/packages/11ty/_includes/components/head-tags/twitter-card.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-
+import escape from 'html-escape'
 import path from 'node:path'
 
 /**
@@ -52,7 +52,7 @@ export default function (eleventyConfig) {
     ]
 
     const metaTags = meta.map(({ name, content }) => (
-      `<meta name="${name}" content="${content}">`
+      `<meta name="${name}" content="${escape(content)}">`
     ))
     return `${metaTags.join('\n')}`
   }

--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -1,3 +1,5 @@
+import escape from 'html-escape'
+
 /**
  * Head Tag
  *
@@ -50,8 +52,8 @@ export default function (eleventyConfig) {
 
         <title>${pageTitle}</title>
 
-        <meta name="description" content="${description}">
-        <meta name="keywords" content="${keywords}">
+        <meta name="description" content="${escape(description)}">
+        <meta name="keywords" content="${escape(keywords)}">
 
         <link rel="canonical" href="${canonicalURL}">
         <link rel="version-history" href="${publication.repositoryUrl}">

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "exifr": "^7.1.3",
         "globals": "^15.0.0",
+        "html-escape": "^2.0.0",
         "js-yaml": "^4.1.0",
         "jsdom": "^24.0.0",
         "json5": "^2.2.3",
@@ -5013,6 +5014,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escape/-/html-escape-2.0.0.tgz",
+      "integrity": "sha512-BYh0wceM2Vm4/Q8TNfnKaHXs4DCv2DuYVS87DR40elSvFc+8a6B9mE9ej+8nCOkdqPx7puEx9+hm+GoJ3f9PzA==",
+      "dev": true,
+      "license": "Public Domain"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "exifr": "^7.1.3",
     "globals": "^15.0.0",
+    "html-escape": "^2.0.0",
     "js-yaml": "^4.1.0",
     "jsdom": "^24.0.0",
     "json5": "^2.2.3",


### PR DESCRIPTION
This PR adds HTML entity escaping (via `html-escape`) on HTML element attributes that insert user-provided data. This resolves DEV-18179 -- `Twitter descriptions are not properly escaped` -- but also resolves on alt tags (on-page image tag, print image, and contributor image) and in other opengraph tags.  