### PR TITLE
Fix #1003: missing filename in duplicate global data error message

### DIFF
--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -28,7 +28,7 @@ const checkForDuplicateIds = function (data, filename) {
   if (typeof data === 'object') {
     Object.keys(data).forEach((key) => {
       try {
-        checkForDuplicateIds(data[key])
+        checkForDuplicateIds(data[key], filename)
       } catch (error) {
         logger.error(`${filename} ${key} contains multiple entries with the same id.\nEach entry in ${key} must have a unique id. ${error.message}`)
       }


### PR DESCRIPTION
### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
#1003 

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.
Improve error reporting for duplicate IDs.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.
Carry the filename into the recursive call to `checkForDuplicateIds()` so that errors in nested objects still report the filename.

### Does this pull request necessitate changes to Quire's documentation?
No.

### Include screenshots of before/after if applicable.
Before:
```
[quire] ERROR    [plugins:globalData]           undefined contributors contains multiple entries with the same id.
[quire] ERROR    [plugins:globalData]           undefined contributors contains multiple entries with the same id.
```

After:
```
[quire] ERROR    [plugins:globalData]           all-issues.json contributors contains multiple entries with the same id.
[quire] ERROR    [plugins:globalData]           all-issues.json contributors contains multiple entries with the same id.
```


### Additional Comments

