### PR TITLE
Fix `quire info` crash (DEV-19984)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,12 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.27]
+
+### Fixed
+
+- Fixed post-v3 `quire info` bug (DEV-19984)
+
 ## [1.0.0-rc.26]
 
 ### Changed

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "1.0.0-rc.25",
+  "version": "1.0.0-rc.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-rc.25",
+      "version": "1.0.0-rc.27",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.26",
+  "version": "1.0.0-rc.27",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -45,9 +45,9 @@ export default class InfoCommand extends Command {
     let versionInfo = { cli: '<=1.0.0.rc-7' }
 
     try {
-      const fileBytes = fs.readFileSync(versionFileName, { encoding: 'utf8' })
+      const versionFileData = fs.readFileSync(versionFileName, { encoding: 'utf8' })
 
-      versionInfo = JSON.parse(fileBytes)      
+      versionInfo = JSON.parse(versionFileData)      
     } catch (error) {
       console.warn(
         `This project was generated with the quire-cli prior to version 1.0.0.rc-8. Updating the version file to the new format, though this project's version file will not contain specific starter version information.`

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -40,17 +40,19 @@ export default class InfoCommand extends Command {
       console.debug('[CLI] Command \'%s\' called', this.name())
     }
 
+    // Load filename from config with a default constraint if it doesn't exist
     const versionFileName = this.config.get('versionFile')
+    let versionInfo = { cli: '<=1.0.0.rc-7' }
 
     try {
-      // the quire version file is always local to the project root
-      let fileData = fs.readFileSync(versionFileName, { encoding: 'utf8' })
-      versionInfo = JSON.parse(fileData)
+      const fileBytes = fs.readFileSync(versionFileName, { encoding: 'utf8' })
+
+      versionInfo = JSON.parse(fileBytes)      
     } catch (error) {
       console.warn(
         `This project was generated with the quire-cli prior to version 1.0.0.rc-8. Updating the version file to the new format, though this project's version file will not contain specific starter version information.`
       )
-      versionInfo = { cli: '<=1.0.0.rc-7' }
+
       fs.writeFileSync(versionFileName, JSON.stringify(versionInfo))
     }
 


### PR DESCRIPTION
This PR resolves DEV-19984, "`quire info` command doesn't return expected information in newer version of CLI" by resolving a mis-merge in the `info` command and refining the default-CLI version constraint if no version file exists.