### PR TITLE
Fix table assets rendering as pages in 11ty v3-based projects - DEV-19983

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -160,15 +160,11 @@ export default async function (eleventyConfig) {
   /**
    * Register a preprocessor to ignore HTML files from the input asset directory.
    * Preprocessors run on input templates before parsing.
-   *
-   * See https://www.11ty.dev/docs/config-preprocessors/
-   **/
-  const assetPathFrag = [inputDir, '_assets'].join(path.sep)
-  const ignoreAssetHTML = (data, content) => {
-    if (data.page.inputPath.includes(assetPathFrag)) return false
-
-    return content
-  }
+   * @see https://www.11ty.dev/docs/config-preprocessors/
+   */
+  const assetPathFragment = [inputDir, '_assets'].join(path.sep)
+  const ignoreAssetHTML = ({ page }, content) => 
+    (page.inputPath.includes(assetPathFragment)) ? false : content;
   eleventyConfig.addPreprocessor('html-files', 'html', ignoreAssetHTML)
   
   /**

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -163,8 +163,11 @@ export default async function (eleventyConfig) {
    * @see https://www.11ty.dev/docs/config-preprocessors/
    */
   const assetPathFragment = [inputDir, '_assets'].join(path.sep)
-  const ignoreAssetHTML = ({ page }, content) => 
-    (page.inputPath.includes(assetPathFragment)) ? false : content;
+  const ignoreAssetHTML = ({ page }, content) => {
+    if (page.inputPath.includes(assetPathFragment)) return false 
+    return content;
+  }
+  
   eleventyConfig.addPreprocessor('html-files', 'html', ignoreAssetHTML)
   
   /**

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -158,6 +158,20 @@ export default async function (eleventyConfig) {
   })
 
   /**
+   * Register a preprocessor to ignore HTML files from the input asset directory.
+   * Preprocessors run on input templates before parsing.
+   *
+   * See https://www.11ty.dev/docs/config-preprocessors/
+   **/
+  const assetPathFrag = [inputDir, '_assets'].join(path.sep)
+  const ignoreAssetHTML = (data, content) => {
+    if (data.page.inputPath.includes(assetPathFrag)) return false
+
+    return content
+  }
+  eleventyConfig.addPreprocessor('html-files', 'html', ignoreAssetHTML)
+  
+  /**
    * Configure build output
    * @see https://www.11ty.dev/docs/plugins/directory-output/#directory-output
    */

--- a/packages/11ty/_includes/components/figure/placeholder.js
+++ b/packages/11ty/_includes/components/figure/placeholder.js
@@ -1,4 +1,4 @@
-import escape from 'escape'
+import escape from 'html-escape'
 import path from 'node:path'
 import { html } from '#lib/common-tags/index.js'
 


### PR DESCRIPTION
This PR resolves an issue where 11ty v3 based projects were including figure table HTML as pages in the collections API and thus nav header / footer / etc. 

11ty makes a [preprocessor API](https://www.11ty.dev/docs/config-preprocessors/) available for this kind of ignoring / pre-parsing so we've added a filter there to ignore HTML files in the input directory's assets directory to preserve authors' ability to use HTML if they choose. 

ETA: This PR also fixes an issue where the figure component JS was causing builds to break due to a misnamed package (`escape` rather than `html-escape`)