### PR TITLE
Fix "URI/URL issues are breaking preview and build on Windows" - DEV-19999

### DIFF
--- a/packages/11ty/_includes/components/figure/audio/index.js
+++ b/packages/11ty/_includes/components/figure/audio/index.js
@@ -1,6 +1,8 @@
+import path from 'node:path'
+
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(import.meta.dirname, params)
+    return renderOutputs(path.dirname(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/image/index.js
+++ b/packages/11ty/_includes/components/figure/image/index.js
@@ -1,9 +1,10 @@
+import path from 'node:path'
 /**
  * Render all `image` outputs
  */
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(import.meta.dirname, params)
+    return renderOutputs(path.dirname(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/table/index.js
+++ b/packages/11ty/_includes/components/figure/table/index.js
@@ -1,9 +1,11 @@
+import path from 'node:path'
+
 /**
  * Render all `table` outputs
  */
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(import.meta.dirname, params)
+    return renderOutputs(path.dirname(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/video/index.js
+++ b/packages/11ty/_includes/components/figure/video/index.js
@@ -1,6 +1,8 @@
+import path from 'node:path'
+
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(import.meta.dirname, params)
+    return renderOutputs(path.dirname(import.meta.url), params)
   }
 }


### PR DESCRIPTION
This PR resolves DEV-19999, "URI/URL issues are breaking preview and build on Windows". The core issue was the use of `import.meta.dirname` in the figure component factories (`packages/11ty/_includes/components/figures/*/index.js`). On Windows node expects a full URL for import and `import.meta.dirname` returns the dirname of `import.meta.filename` instead (ie, without `file://`).