### PR TITLE
Resolve import URLs to paths for mutation and back to URLs for import

### DIFF
--- a/packages/11ty/_includes/components/figure/audio/index.js
+++ b/packages/11ty/_includes/components/figure/audio/index.js
@@ -1,8 +1,9 @@
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(fileURLToPath(import.meta.url), params)
+    return renderOutputs(path.dirname(fileURLToPath(import.meta.url)), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/audio/index.js
+++ b/packages/11ty/_includes/components/figure/audio/index.js
@@ -1,8 +1,8 @@
-import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(path.dirname(import.meta.url), params)
+    return renderOutputs(fileURLToPath(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/image/index.js
+++ b/packages/11ty/_includes/components/figure/image/index.js
@@ -1,10 +1,11 @@
-import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 /**
  * Render all `image` outputs
  */
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(path.dirname(import.meta.url), params)
+    return renderOutputs(fileURLToPath(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/image/index.js
+++ b/packages/11ty/_includes/components/figure/image/index.js
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
@@ -6,6 +7,6 @@ import { fileURLToPath } from 'node:url'
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(fileURLToPath(import.meta.url), params)
+    return renderOutputs(path.dirname(fileURLToPath(import.meta.url)), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/table/index.js
+++ b/packages/11ty/_includes/components/figure/table/index.js
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 /**
  * Render all `table` outputs
@@ -6,6 +6,6 @@ import path from 'node:path'
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(path.dirname(import.meta.url), params)
+    return renderOutputs(fileURLToPath(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/table/index.js
+++ b/packages/11ty/_includes/components/figure/table/index.js
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
@@ -6,6 +7,6 @@ import { fileURLToPath } from 'node:url'
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(fileURLToPath(import.meta.url), params)
+    return renderOutputs(path.dirname(fileURLToPath(import.meta.url)), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/video/index.js
+++ b/packages/11ty/_includes/components/figure/video/index.js
@@ -1,8 +1,9 @@
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(fileURLToPath(import.meta.url), params)
+    return renderOutputs(path.dirname(fileURLToPath(import.meta.url)), params)
   }
 }

--- a/packages/11ty/_includes/components/figure/video/index.js
+++ b/packages/11ty/_includes/components/figure/video/index.js
@@ -1,8 +1,8 @@
-import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(path.dirname(import.meta.url), params)
+    return renderOutputs(fileURLToPath(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/icons-cc/index.js
+++ b/packages/11ty/_includes/components/icons-cc/index.js
@@ -15,12 +15,12 @@ export default function (eleventyConfig) {
     if (!config.licenseIcons) return ''
 
     const ccIcons = fs
-      .readdirSync(path.join(fileURLToPath(import.meta.url), 'icons'))
+      .readdirSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'icons'))
       .map((filename) => {
         const id = path.basename(filename, '.svg')
         return fs
           .readFileSync(
-            path.join(fileURLToPath(import.meta.url), 'icons', filename),
+            path.join(path.dirname(fileURLToPath(import.meta.url)), 'icons', filename),
             { encoding: 'utf8' }
           )
           .replace('<svg', `<symbol id="${id}"`)

--- a/packages/11ty/_includes/components/icons-cc/index.js
+++ b/packages/11ty/_includes/components/icons-cc/index.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { html } from '#lib/common-tags/index.js'
 
 /**
@@ -14,12 +15,12 @@ export default function (eleventyConfig) {
     if (!config.licenseIcons) return ''
 
     const ccIcons = fs
-      .readdirSync(path.join(import.meta.dirname, 'icons'))
+      .readdirSync(path.join(fileURLToPath(import.meta.url), 'icons'))
       .map((filename) => {
         const id = path.basename(filename, '.svg')
         return fs
           .readFileSync(
-            path.join(import.meta.dirname, 'icons', filename),
+            path.join(fileURLToPath(import.meta.url), 'icons', filename),
             { encoding: 'utf8' }
           )
           .replace('<svg', `<symbol id="${id}"`)

--- a/packages/11ty/_includes/components/table-of-contents/index.js
+++ b/packages/11ty/_includes/components/table-of-contents/index.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 /**
  * Render all `table-of-contents` outputs
  *
@@ -10,6 +12,6 @@
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(import.meta.dirname, params)
+    return renderOutputs(fileURLToPath(import.meta.url), params)
   }
 }

--- a/packages/11ty/_includes/components/table-of-contents/index.js
+++ b/packages/11ty/_includes/components/table-of-contents/index.js
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
@@ -12,6 +13,6 @@ import { fileURLToPath } from 'node:url'
 export default function (eleventyConfig) {
   const renderOutputs = eleventyConfig.getFilter('renderOutputs')
   return function (params) {
-    return renderOutputs(fileURLToPath(import.meta.url), params)
+    return renderOutputs(path.dirname(fileURLToPath(import.meta.url)), params)
   }
 }

--- a/packages/11ty/_plugins/globalData/validator.js
+++ b/packages/11ty/_plugins/globalData/validator.js
@@ -1,8 +1,9 @@
 import Ajv from 'ajv'
 import fs from 'fs-extra'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const configSchema = fs.readJSONSync(path.resolve(import.meta.dirname, '../schemas/config.json'))
+const configSchema = fs.readJSONSync(path.resolve(fileURLToPath(import.meta.url), '../schemas/config.json'))
 /**
  *
  * @function validateUserConfig - throws error if user config data is not structured as expected

--- a/packages/11ty/_plugins/globalData/validator.js
+++ b/packages/11ty/_plugins/globalData/validator.js
@@ -3,7 +3,7 @@ import fs from 'fs-extra'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const configSchema = fs.readJSONSync(path.resolve(fileURLToPath(import.meta.url), '../schemas/config.json'))
+const configSchema = fs.readJSONSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../schemas/config.json'))
 /**
  *
  * @function validateUserConfig - throws error if user config data is not structured as expected


### PR DESCRIPTION
This PR fully resolves DEV-19999 by using node's internal URL -> File Path and File Path -> URL transforms for doing path math around `renderOutputs`. Primarily this affects figures but also table of contents items and copyright icons. Also resolves DEV-20261 