### PR TITLE
Refactor object grid image component to accept manually-assigned thumbnails

### DIFF
--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -19,7 +19,7 @@ const assetSrc = (srcPath) => {
 }
 
 /**
- * Get object image `src` from `figures` or `thumbnail` properties.
+ * Get object image src from either the thumbnail (preferred) or figures data.
  */
 const src = ({ data }) => {
   const { figures, thumbnail } = data

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -9,23 +9,38 @@
 const alt = ({ data }) => typeof data.thumbnail === 'object' ? data.thumbnail.alt : '';
 
 /**
- * Get object image `src` from `figures` or `thumbnail` properties
+ * Returns the served asset location for this src
+ **/
+const assetSrc = (srcPath) => {
+  if ( srcPath.startsWith('/iiif') || 
+          srcPath.startsWith('http://') || 
+          srcPath.startsWith('https://') ) return srcPath
+
+  // TODO: Account for pathPrefix here
+  // Everything else is a hosted asset
+  console.log(`${this.config.figures.imageDir}/${srcPath}`)
+  return `${this.config.figures.imageDir}/${srcPath}`
+}
+
+/**
+ * Get object image `src` from `figures` or `thumbnail` properties.
+ * 
+ * @TODO: Find source of thumbnail string / object type ambiguity, refactor it out of state spcae
  */
 const src = ({ data }) => {
-  const { figures } = data;
-  const thumbnail = figures
-    ? figures.find(({ mediaType }) => mediaType === 'image').thumbnail
-    : data.thumbnail
+  const { figures, thumbnail } = data;
 
-  const src = typeof thumbnail === 'object'
-    ? thumbnail.src
-    : thumbnail
+  if (thumbnail && typeof thumbnail === 'string') return assetSrc(thumbnail)
+  if (thumbnail && typeof thumbnail === 'object') return assetSrc(thumbnail.src)
 
-  /**
-   * If no IIIF images, point to the raw assets directory
-   */
-  return src && !src.startsWith('/iiif')
-    ? `${this.config.figures.imageDir}/${src}`
-    : src;
+  if (!figures) return ''
+
+  const thumbFig = figures?.find(({ mediaType }) => mediaType === 'image')
+
+  if (thumbFig && thumbFig.thumbnail && typeof thumbFig.thumbnail == 'string' ) return assetSrc(thumbFig.thumbnail)
+
+  if (thumbFig && thumbFig.thumbnail && typeof thumbFig.thumbnail == 'object' ) return assetSrc(thumbFig.thumbnail.src)
+
+  return ''
 };
 </script>

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -9,17 +9,14 @@
 const alt = ({ data }) => typeof data.thumbnail === 'object' ? data.thumbnail.alt : '';
 
 /**
- * Returns the served asset location for this src
- **/
+ * Returns the served asset location for this image
+ * accounting for fully qualified asset URLs
+ * @TODO account for pathPrefix of hosted assets
+ */
 const assetSrc = (srcPath) => {
-  if ( srcPath.startsWith('/iiif') || 
-          srcPath.startsWith('http://') || 
-          srcPath.startsWith('https://') ) return srcPath
-
-  // TODO: Account for pathPrefix here
-  // Everything else is a hosted asset
-  console.log(`${this.config.figures.imageDir}/${srcPath}`)
-  return `${this.config.figures.imageDir}/${srcPath}`
+  const regexp = new RegExp(/^(https?:\/\/|\/iiif\/)/)
+  const { imageDir } = this.config.figures
+  return regexp.test(srcPath)) ? srcPath : `${imageDir}/${srcPath}`
 }
 
 /**

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -30,11 +30,8 @@ const src = ({ data }) => {
    case thumbnail: 
       value = figure; 
       break;
-   case figure && figure.thumbnail: 
-      value = figure.thumbnail; 
-      break;
    case figure: 
-      value = figure.src; 
+      value = figure.thumbnail || figure.src; 
       break;
    default: 
       value = '';

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -11,7 +11,6 @@ const alt = ({ data }) => typeof data.thumbnail === 'object' ? data.thumbnail.al
 /**
  * Returns the served asset location for this image
  * accounting for fully qualified asset URLs
- * @TODO account for pathPrefix of hosted assets
  */
 const assetSrc = (srcPath) => {
   const regexp = new RegExp(/^(https?:\/\/|\/iiif\/)/)
@@ -21,23 +20,26 @@ const assetSrc = (srcPath) => {
 
 /**
  * Get object image `src` from `figures` or `thumbnail` properties.
- * 
- * @TODO: Find source of thumbnail string / object type ambiguity, refactor it out of state spcae
  */
 const src = ({ data }) => {
-  const { figures, thumbnail } = data;
+  const { figures, thumbnail } = data
+  const figure = figures?.find(({ mediaType }) => mediaType === 'image')
+  
+  let value = ''
+  switch (true) {
+   case thumbnail: 
+      value = figure; 
+      break;
+   case figure && figure.thumbnail: 
+      value = figure.thumbnail; 
+      break;
+   case figure: 
+      value = figure.src; 
+      break;
+   default: 
+      value = '';
+  }
 
-  if (thumbnail && typeof thumbnail === 'string') return assetSrc(thumbnail)
-  if (thumbnail && typeof thumbnail === 'object') return assetSrc(thumbnail.src)
-
-  if (!figures) return ''
-
-  const thumbFig = figures?.find(({ mediaType }) => mediaType === 'image')
-
-  if (thumbFig && thumbFig.thumbnail && typeof thumbFig.thumbnail == 'string' ) return assetSrc(thumbFig.thumbnail)
-
-  if (thumbFig && thumbFig.thumbnail && typeof thumbFig.thumbnail == 'object' ) return assetSrc(thumbFig.thumbnail.src)
-
-  return ''
+  return assetSrc(value)
 };
 </script>


### PR DESCRIPTION
This PR refines the src attribute derivation logic in the object grid card image component. It resolves #984 and DEV-19295. Changes include:
- Separates the concerns of path logic (ie, hosted in `content/`, externally-sourced ala `http:`/`https:`, or internally hosted IIIF)
- Refine the logic for selecting thumbnail from the passed data or thumbnail from the object figure if it exists
 