### PR TITLE
Ensure filepaths in renderOutputs are converted to file URLs for import

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/render.js
+++ b/packages/11ty/_plugins/transforms/outputs/render.js
@@ -13,7 +13,7 @@ export default async function (eleventyConfig, dir, params, page) {
 
   const filePaths = fileNames.flatMap((output) => {
     const filePath = path.join(dir, `${output}.js`)
-    return (!fs.existsSync(filePath)) ? [] : filePath
+    return (fs.existsSync(filePath)) ? filePath : []
   })
 
   const content = await Promise.all(filePaths.flatMap(async (filePath, index) => {

--- a/packages/11ty/_plugins/transforms/outputs/render.js
+++ b/packages/11ty/_plugins/transforms/outputs/render.js
@@ -17,7 +17,7 @@ export default async function (eleventyConfig, dir, params, page) {
   })
 
   const content = await Promise.all(filePaths.flatMap(async (filePath, index) => {
-    const { default: init } = await import( pathToFileURL(filePath) )
+    const { default: init } = await import(pathToFileURL(filePath))
 
     const renderFn = init(eleventyConfig, { page })
     const component = await renderFn(params)

--- a/packages/11ty/_plugins/transforms/outputs/render.js
+++ b/packages/11ty/_plugins/transforms/outputs/render.js
@@ -2,6 +2,7 @@ import { JSDOM } from 'jsdom'
 import { html } from '#lib/common-tags/index.js'
 import fs from 'fs-extra'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 /**
  * Iterate over output files and render with a `data` attribute
@@ -11,12 +12,13 @@ export default async function (eleventyConfig, dir, params, page) {
   const fileNames = ['epub', 'html', 'pdf', 'print']
 
   const filePaths = fileNames.flatMap((output) => {
-    const filePath = path.join(dir, output)
-    return (!fs.existsSync(`${filePath}.js`)) ? [] : filePath
+    const filePath = path.join(dir, `${output}.js`)
+    return (!fs.existsSync(filePath)) ? [] : filePath
   })
 
   const content = await Promise.all(filePaths.flatMap(async (filePath, index) => {
-    const { default: init } = await import(`${filePath}.js`)
+    const { default: init } = await import( pathToFileURL(filePath) )
+
     const renderFn = init(eleventyConfig, { page })
     const component = await renderFn(params)
     const fragment = JSDOM.fragment(component)


### PR DESCRIPTION
This PR adds a missed commit from #1011 that ensures file paths passed to `renderOutputs` are converted to file URLs for import  