### PR TITLE
Refine preprocessor check to be in URL space instead of filepath space

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -161,8 +161,10 @@ export default async function (eleventyConfig) {
    * Register a preprocessor to ignore HTML files from the input asset directory.
    * Preprocessors run on input templates before parsing.
    * @see https://www.11ty.dev/docs/config-preprocessors/
+   * 
+   * NB: `inputPath` is normalized to URL path separators (`/`) not the platform's separator
    */
-  const assetPathFragment = [inputDir, '_assets'].join(path.sep)
+  const assetPathFragment = [inputDir, '_assets'].join('/')
   const ignoreAssetHTML = ({ page }, content) => {
     if (page.inputPath.includes(assetPathFragment)) return false
     return content


### PR DESCRIPTION
This PR resolves DEV-19983 on Windows by moving the path join character to be '/' rather than the platform-specific separator. 11ty template input paths are in URL space so the platform specific separator is unnecessary.