### PR TITLE
Fixes epub builds on windows - DEV-20269

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -60,7 +60,8 @@ export default (eleventyConfig) => {
       logger.error('Epub requires a cover image defined in publication.promo_image or config.epub.defaultCoverImage.')
       return
     }
-    return path.join(imageDir, image).replace(/^\//, '')
+
+    return path.join(imageDir.replace(/^\//, ''), image)
   }
 
   /**


### PR DESCRIPTION
This PR resolves DEV-20269, "On windows, epub transform incorrectly calculates paths". Most of that pathing in the epub manifest is safe because the source of the path strings are URLs. But the cover getter in the epub manifest was stripping leading '/'s from joined paths instead of the imageDir itself.

With that corrected Windows epub builds succeed and the error about the cover JPEG path is no longer present.