### PR TITLE
Fix ESM errors when running PDF command on windows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.28",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {

--- a/packages/cli/src/commands/pdf.js
+++ b/packages/cli/src/commands/pdf.js
@@ -4,6 +4,7 @@ import fs from 'fs-extra'
 import libPdf from '#lib/pdf/index.js'
 import open from 'open'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import yaml from 'js-yaml'
 
 /**
@@ -29,7 +30,7 @@ async function loadConfig(configPath) {
 
   if (fs.existsSync(schemaPath) && fs.existsSync(validatorPath)) {
 
-    const { validateUserConfig } = await import(validatorPath)
+    const { validateUserConfig } = await import(pathToFileURL(validatorPath))
   
     const schemaJSON = fs.readFileSync(schemaPath)
     const schema = JSON.parse(schemaJSON)


### PR DESCRIPTION
This PR refines the import path used by the PDF command to import the configuration validator, which had been producing errors on Windows where ESM-aware Node requires File URL imports in all cases. This resolves DEV_20270. 