### PR TITLE
Fix miscellaneous merge issues from v3 sprints

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -337,4 +337,8 @@ export default async function (eleventyConfig) {
    */
   eleventyConfig.setDataFileBaseName('index')
   eleventyConfig.setDataFileSuffixes(['.data', ''])
+
+  const { pathname } = globalData.publication
+
+  return { pathPrefix: pathname }
 }

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -15,7 +15,7 @@ const alt = ({ data }) => typeof data.thumbnail === 'object' ? data.thumbnail.al
 const assetSrc = (srcPath) => {
   const regexp = new RegExp(/^(https?:\/\/|\/iiif\/)/)
   const { imageDir } = this.config.figures
-  return regexp.test(srcPath)) ? srcPath : `${imageDir}/${srcPath}`
+  return regexp.test(srcPath) ? srcPath : `${imageDir}/${srcPath}`
 }
 
 /**
@@ -28,13 +28,13 @@ const src = ({ data }) => {
   let value = ''
   switch (true) {
    case thumbnail: 
-      value = figure; 
+      value = thumbnail; 
       break;
    case figure: 
       value = figure.thumbnail || figure.src; 
       break;
    default: 
-      value = '';
+      return '';
   }
 
   return assetSrc(value)

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -26,7 +26,7 @@ export default function (eleventyConfig, { directoryConfig, publication }) {
       root: outputDir,
       base: pathname,
       resolve: {
-        alias: pathname === '/' ? [] : [{ find: pathname, replacement: '/' }]
+        alias: pathname === '/' ? {} : { [pathname]: '/' }
       },
       build: {
         assetsDir: '_assets',


### PR DESCRIPTION
This PR fixes various errors introduced during pre-release merges:
- Corrects syntax and logic of asset URL code paths in object pages components
- Restores `pathPrefix` logic in eleventy config and corrects typing of `resolve.alias` in vite config