### PR TITLE
Improve asset path safety on Windows

### DIFF
--- a/packages/11ty/_includes/components/figure/image/image-tag.js
+++ b/packages/11ty/_includes/components/figure/image/image-tag.js
@@ -15,7 +15,13 @@ export default function (eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
 
   return function ({ alt = '', src = '', isStatic = false, lazyLoading = 'lazy' }) {
-    const imageSrc = src.startsWith('http') || isStatic ? src : path.join(imageDir, src)
+    const extOrIiifRegex = new RegExp(/^(https?:\/\/|\/iiif\/|\\iiif\\)/)
+    let imageSrc = extOrIiifRegex.test(src) || isStatic ? src : path.join(imageDir, src)
+
+    // HACK: If an URL-unsafe path separator has made it this far, remove it
+    if (path.sep !== '/') {
+      imageSrc = imageSrc.replaceAll(path.sep,'/')
+    }
 
     return html`
       <img

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -22,9 +22,12 @@ export default function (eleventyConfig) {
     if (!src && !staticInlineFigureImage) return ''
 
     const labelElement = figureLabel({ caption, id, label })
+    const extOrIiifRegex = new RegExp(/^(https?:\/\/|\/iiif\/|\\iiif\\)/)
 
+    /**
+     * NB: Image assets can be: external, in the asset dir, or in the IIIF directory 
+     **/
     let imageSrc
-
     switch (true) {
       case figure.isSequence:
         imageSrc = figure.staticInlineFigureImage
@@ -32,14 +35,13 @@ export default function (eleventyConfig) {
       case figure.isCanvas || figure.isImageService:
         imageSrc = figure.printImage
         break
-      default:
-        imageSrc = src.startsWith('http')
-          ? src
-          : path.join(imageDir, src)
+      case extOrIiifRegex.test(src):
+        imageSrc = src
         break
+      default:
+        path.join(imageDir, src)
     }
 
-    // console.log(imageSrc)
     return html`
       <img alt="${escape(alt)}" class="q-figure__image" src="${imageSrc}"/>
       ${figureCaption({ caption, content: labelElement, credit })}

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -13,7 +13,7 @@ const alt = ({ data }) => typeof data.thumbnail === 'object' ? data.thumbnail.al
  * accounting for fully qualified asset URLs
  */
 const assetSrc = (srcPath) => {
-  const regexp = new RegExp(/^(https?:\/\/|\/iiif\/)/)
+  const regexp = new RegExp(/^(https?:\/\/|\/iiif\/|\\iiif\\)/)
   const { imageDir } = this.config.figures
   return regexp.test(srcPath) ? srcPath : `${imageDir}/${srcPath}`
 }

--- a/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
+++ b/packages/11ty/_includes/components/object-filters/object-card/object-image.webc
@@ -22,21 +22,17 @@ const assetSrc = (srcPath) => {
  * Get object image src from either the thumbnail (preferred) or figures data.
  */
 const src = ({ data }) => {
-  const { figures, thumbnail } = data
-  const figure = figures?.find(({ mediaType }) => mediaType === 'image')
-  
-  let value = ''
+  const { figures, thumbnail } = data;
+  const figure = figures?.find(({ mediaType }) => mediaType === 'image');
+
   switch (true) {
-   case thumbnail: 
-      value = thumbnail; 
-      break;
-   case figure: 
-      value = figure.thumbnail || figure.src; 
-      break;
+   case (thumbnail): 
+      return assetSrc(value)
+   case figure !== undefined:
+      const imagePath = figure.thumbnail ?? figure.src;
+      return assetSrc(imagePath)
    default: 
       return '';
   }
-
-  return assetSrc(value)
 };
 </script>

--- a/packages/11ty/_plugins/transforms/outputs/epub/index.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/index.js
@@ -69,8 +69,9 @@ export default (eleventyConfig, collections) => {
     for (const asset of assets) {
       let assetDir
 
+      // Fetch assets from content/_assets, otherwise use public or _site
       switch (true) {
-        case asset.startsWith('_assets'):
+        case asset.split(path.sep).at(0) === '_assets':
           assetDir = eleventyConfig.directoryAssignments.input
           break
         case eleventyConfig.globalData.directoryConfig.publicDir !== false:

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -61,7 +61,11 @@ export default (eleventyConfig) => {
       return
     }
 
-    return path.join(imageDir.replace(/^\//, ''), image)
+    // Remove leading absolute pathing
+    let imageDirPath = path.normalize(imageDir)
+    if (imageDirPath.split(path.sep).at(0) === '') imageDirPath = imageDirPath.split(path.sep).slice(1).join(path.sep)
+    
+    return path.join(imageDirPath, image)
   }
 
   /**

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -21,7 +21,7 @@ export default function (eleventyConfig, collections, content) {
   const write = writer(outputDir)
 
   /**
-   * Gather asset filepaths
+   * Gather asset filepaths, normalizing to platform paths for consumers
    *
    * @param      {HTMLElement}  element
    */
@@ -30,12 +30,10 @@ export default function (eleventyConfig, collections, content) {
     images.forEach((img) => {
       const src = img.getAttribute('src')
       if (!src) return
-      const pattern = `^(${imageDir}|/${iiifOutputDir})`
-      const regex = new RegExp(pattern, 'g')
-      if (src.match(regex)) {
-        const relativePath = src.replace(/^\//, '')
-        assets.push(relativePath)
-      }
+
+      const relativePath = path.normalize(src).split(path.sep).at(0) === '' ?
+                              path.normalize(src).split(path.sep).slice(1).join(path.sep) : src
+      assets.push(relativePath)
     })
   }
 


### PR DESCRIPTION
This PR refines the image source paths in HTML and the epub asset handling to ensure that both are safe on windows. In particular it:
- Forces img@src attributes to use forward slash separators to ensure `vite`'s resolve process (or quire's vite config?) can find assets on windows
- Refines asset path checks in image tags, image print representations, and object pages representations. This resolves _many_ latent path bugs on Windows
- Normalizes paths emitted in epub transform helper functions to use platform-specific versions for asset moves (eg, copying assets to the epub bundle)  