### PR TITLE
Fix failing Windows tests -- join IIIF resource IDs with '/' instead of path.sep

### DIFF
--- a/packages/11ty/_plugins/figures/annotation/index.js
+++ b/packages/11ty/_plugins/figures/annotation/index.js
@@ -63,10 +63,11 @@ export default class Annotation {
       (annotationCount === 0 || src === figureSrc)
     const info = () => {
       if (!isImageService) return
-      const tilesPath = path.join(outputDir, name, tilesDirName)
-      const infoPath = path.join(tilesPath, 'info.json')
+      // NB: Not joining by path.sep because these are URLs
+      const tilesPath = [outputDir, name, tilesDirName].join('/')
+      const infoPath = [tilesPath, 'info.json'].join('/')
       try {
-        return new URL(path.join(baseURI, infoPath)).href
+        return new URL(`${baseURI}/${infoPath}`).href
       } catch (error) {
         logger.error(`Error creating info.json. Either the tile path (${tilesPath}) or base URI (${baseURI}) are invalid to form a fully qualified URI.`)
       }
@@ -76,10 +77,10 @@ export default class Annotation {
       switch (true) {
         case isImageService:
           // NB: Annotations for imageServices are *jpeg*s not the service endpoint
-          return new URL(path.join(baseURI, printImage)).href
+          return new URL(`${baseURI}${printImage}`).href
         default:
           try {
-            return new URL(path.join(baseURI, outputDir, base)).href
+            return new URL(`${baseURI}/${outputDir}/${base}`).href
           } catch (error) {
             logger.error(`Error creating annotation URI. Either the output directory (${outputDir}), filename (${base}) or base URI (${baseURI}) are invalid to form a fully qualified URI.`)
           }

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -4,7 +4,6 @@ import CanvasBuilder from './canvas-builder.js'
 import SequenceBuilder from './sequence-builder.js'
 import Writer from './writer.js'
 import chalkFactory from '#lib/chalk/index.js'
-import path from 'node:path'
 
 const logger = chalkFactory('Figures:IIIF:Manifest', 'DEBUG')
 
@@ -71,7 +70,7 @@ export default class Manifest {
       .figure.sequences
       .flatMap(({ items }) => items)
       .map((item) => {
-        const canvasId = path.join(this.figure.canvasId, item.id)
+        const canvasId = [this.figure.canvasId, item.id].join('/')
         const sequenceItemImage = ({ format, info, label, src, uri }) => {
           return {
             format,
@@ -92,7 +91,7 @@ export default class Manifest {
         }
         return {
           body: sequenceItemImage(item),
-          id: path.join(canvasId, 'annotation-page', item.id),
+          id: [canvasId, 'annotation-page', item.id].join('/'),
           motivation: 'painting',
           target: canvasId,
           type: 'Annotation'

--- a/packages/11ty/_plugins/figures/iiif/manifest/sequence-builder.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/sequence-builder.js
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 export default class SequenceBuilder {
   static create (manifestObject, data) {
     const sequenceBuilder = new SequenceBuilder(data)
@@ -27,7 +29,13 @@ export default class SequenceBuilder {
     const { iiifConfig, outputDir } = figure
     const { baseURI } = iiifConfig
     const items = this.items.slice(sequence.startIndex)
-    const id = [baseURI, outputDir, 'ranges', `${index}`].join('/')
+
+    // Construct URL-safe path if outputDir has a platform-specific url separator
+    const outputUrlPath = path.sep !== '/' && outputDir.includes(path.sep)
+      ? outputDir.replace(path.sep, '/')
+      : outputDir
+
+    const id = [baseURI, outputUrlPath, 'ranges', `${index}`].join('/')
     const structure = {
       id,
       items,

--- a/packages/11ty/_plugins/figures/iiif/manifest/sequence-builder.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/sequence-builder.js
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 export default class SequenceBuilder {
   static create (manifestObject, data) {
     const sequenceBuilder = new SequenceBuilder(data)
@@ -29,7 +27,7 @@ export default class SequenceBuilder {
     const { iiifConfig, outputDir } = figure
     const { baseURI } = iiifConfig
     const items = this.items.slice(sequence.startIndex)
-    const id = path.join(baseURI, outputDir, 'ranges', `${index}`)
+    const id = [baseURI, outputDir, 'ranges', `${index}`].join('/')
     const structure = {
       id,
       items,

--- a/packages/11ty/_plugins/figures/sequence/index.js
+++ b/packages/11ty/_plugins/figures/sequence/index.js
@@ -29,7 +29,7 @@ export default class Sequence {
   get items () {
     const { label } = this.figure.data
     return this.files.map((filename) => {
-      const src = path.join(this.dir, filename)
+      const src = `${this.dir}/${filename}`
       return new Annotation(this.figure, { label, src })
     })
   }
@@ -57,7 +57,7 @@ export default class Sequence {
       const { base } = path.parse(src)
       return this.start === base
     })
-    return startCanvasItem ? path.join(this.figure.canvasId, startCanvasItem.id) : null
+    return startCanvasItem ? `${this.figure.canvasId}/${startCanvasItem.id}` : null
   }
 
   get startCanvasIndex () {

--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/sequence-with-annotations/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/sequence-with-annotations/manifest.json
@@ -15,19 +15,19 @@
   },
   "items": [
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000/annotation-page/fountain02_00000",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000/annotation-page/fountain02_00000",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00000.png",
@@ -47,19 +47,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004/annotation-page/fountain02_00004",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004/annotation-page/fountain02_00004",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00004.png",
@@ -79,19 +79,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008/annotation-page/fountain02_00008",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008/annotation-page/fountain02_00008",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00008.png",
@@ -111,19 +111,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012/annotation-page/fountain02_00012",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012/annotation-page/fountain02_00012",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00012.png",
@@ -143,19 +143,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016/annotation-page/fountain02_00016",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016/annotation-page/fountain02_00016",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00016.png",
@@ -175,19 +175,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020/annotation-page/fountain02_00020",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020/annotation-page/fountain02_00020",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00020.png",
@@ -207,19 +207,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024/annotation-page/fountain02_00024",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024/annotation-page/fountain02_00024",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00024.png",
@@ -239,19 +239,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028/annotation-page/fountain02_00028",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028/annotation-page/fountain02_00028",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00028.png",
@@ -271,19 +271,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032/annotation-page/fountain02_00032",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032/annotation-page/fountain02_00032",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00032.png",
@@ -303,19 +303,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036/annotation-page/fountain02_00036",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036/annotation-page/fountain02_00036",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00036.png",
@@ -335,19 +335,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040/annotation-page/fountain02_00040",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040/annotation-page/fountain02_00040",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00040.png",
@@ -367,19 +367,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044/annotation-page/fountain02_00044",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044/annotation-page/fountain02_00044",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00044.png",
@@ -399,19 +399,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048/annotation-page/fountain02_00048",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048/annotation-page/fountain02_00048",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00048.png",
@@ -431,19 +431,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052/annotation-page/fountain02_00052",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052/annotation-page/fountain02_00052",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00052.png",
@@ -463,19 +463,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056/annotation-page/fountain02_00056",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056/annotation-page/fountain02_00056",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00056.png",
@@ -495,19 +495,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060/annotation-page/fountain02_00060",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060/annotation-page/fountain02_00060",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00060.png",
@@ -527,19 +527,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064/annotation-page/fountain02_00064",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064/annotation-page/fountain02_00064",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00064.png",
@@ -559,19 +559,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068/annotation-page/fountain02_00068",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068/annotation-page/fountain02_00068",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00068.png",
@@ -591,19 +591,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072/annotation-page/fountain02_00072",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072/annotation-page/fountain02_00072",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00072.png",
@@ -623,19 +623,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076/annotation-page/fountain02_00076",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076/annotation-page/fountain02_00076",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00076.png",
@@ -655,19 +655,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080/annotation-page/fountain02_00080",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080/annotation-page/fountain02_00080",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00080.png",
@@ -687,19 +687,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084/annotation-page/fountain02_00084",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084/annotation-page/fountain02_00084",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00084.png",
@@ -719,19 +719,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088/annotation-page/fountain02_00088",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088/annotation-page/fountain02_00088",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00088.png",
@@ -751,19 +751,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092/annotation-page/fountain02_00092",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092/annotation-page/fountain02_00092",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00092.png",
@@ -783,19 +783,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096/annotation-page/fountain02_00096",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096/annotation-page/fountain02_00096",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00096.png",
@@ -815,19 +815,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100/annotation-page/fountain02_00100",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100/annotation-page/fountain02_00100",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00100.png",
@@ -847,19 +847,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104/annotation-page/fountain02_00104",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104/annotation-page/fountain02_00104",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00104.png",
@@ -879,19 +879,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108/annotation-page/fountain02_00108",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108/annotation-page/fountain02_00108",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00108.png",
@@ -911,19 +911,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112/annotation-page/fountain02_00112",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112/annotation-page/fountain02_00112",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00112.png",
@@ -943,19 +943,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116/annotation-page/fountain02_00116",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116/annotation-page/fountain02_00116",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00116.png",
@@ -975,19 +975,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120/annotation-page/fountain02_00120",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120/annotation-page/fountain02_00120",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00120.png",
@@ -1007,19 +1007,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124/annotation-page/fountain02_00124",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124/annotation-page/fountain02_00124",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00124.png",
@@ -1039,19 +1039,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128/annotation-page/fountain02_00128",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128/annotation-page/fountain02_00128",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00128.png",
@@ -1071,19 +1071,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132/annotation-page/fountain02_00132",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132/annotation-page/fountain02_00132",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00132.png",
@@ -1103,19 +1103,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136/annotation-page/fountain02_00136",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136/annotation-page/fountain02_00136",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00136.png",
@@ -1135,19 +1135,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140/annotation-page/fountain02_00140",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140/annotation-page/fountain02_00140",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00140.png",
@@ -1167,19 +1167,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144/annotation-page/fountain02_00144",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144/annotation-page/fountain02_00144",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00144.png",
@@ -1199,19 +1199,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148/annotation-page/fountain02_00148",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148/annotation-page/fountain02_00148",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00148.png",
@@ -1231,19 +1231,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152/annotation-page/fountain02_00152",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152/annotation-page/fountain02_00152",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00152.png",
@@ -1263,19 +1263,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156/annotation-page/fountain02_00156",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156/annotation-page/fountain02_00156",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00156.png",
@@ -1295,19 +1295,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160/annotation-page/fountain02_00160",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160/annotation-page/fountain02_00160",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00160.png",
@@ -1327,19 +1327,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164/annotation-page/fountain02_00164",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164/annotation-page/fountain02_00164",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00164.png",
@@ -1359,19 +1359,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168/annotation-page/fountain02_00168",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168/annotation-page/fountain02_00168",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00168.png",
@@ -1391,19 +1391,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172/annotation-page/fountain02_00172",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172/annotation-page/fountain02_00172",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00172.png",
@@ -1423,19 +1423,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176",
+      "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176",
       "type": "Canvas",
       "height": 2048,
       "width": 1536,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176/annotation-page/fountain02_00176",
+              "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176/annotation-page/fountain02_00176",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176",
+              "target": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating-annotation/fountain02_00176.png",
@@ -1457,186 +1457,186 @@
   ],
   "structures": [
     {
-      "id": "http:/localhost:8080/iiif/rotating-annotation/ranges/0",
+      "id": "http://localhost:8080/iiif/rotating-annotation/ranges/0",
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00000",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00004",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00008",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00012",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00016",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00020",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00024",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00028",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00032",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00036",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00040",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00044",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00048",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00052",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00056",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00060",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00064",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00068",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00072",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00076",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00080",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00084",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00088",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00092",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00096",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00100",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00104",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00108",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00112",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00116",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00120",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00124",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00128",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00132",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00136",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00140",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00144",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00148",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00152",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00156",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00160",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00164",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00168",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00172",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176",
+          "id": "http://localhost:8080/iiif/rotating-annotation/canvas/fountain02_00176",
           "type": "Canvas"
         }
       ],

--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/sequence/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/sequence/manifest.json
@@ -15,19 +15,19 @@
   },
   "items": [
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/001",
+      "id": "http://localhost:8080/iiif/rotating/canvas/001",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/001/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/001/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/001/annotation-page/001",
+              "id": "http://localhost:8080/iiif/rotating/canvas/001/annotation-page/001",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/001",
+              "target": "http://localhost:8080/iiif/rotating/canvas/001",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/001.jpg",
@@ -47,19 +47,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/003",
+      "id": "http://localhost:8080/iiif/rotating/canvas/003",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/003/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/003/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/003/annotation-page/003",
+              "id": "http://localhost:8080/iiif/rotating/canvas/003/annotation-page/003",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/003",
+              "target": "http://localhost:8080/iiif/rotating/canvas/003",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/003.jpg",
@@ -79,19 +79,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/005",
+      "id": "http://localhost:8080/iiif/rotating/canvas/005",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/005/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/005/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/005/annotation-page/005",
+              "id": "http://localhost:8080/iiif/rotating/canvas/005/annotation-page/005",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/005",
+              "target": "http://localhost:8080/iiif/rotating/canvas/005",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/005.jpg",
@@ -111,19 +111,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/007",
+      "id": "http://localhost:8080/iiif/rotating/canvas/007",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/007/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/007/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/007/annotation-page/007",
+              "id": "http://localhost:8080/iiif/rotating/canvas/007/annotation-page/007",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/007",
+              "target": "http://localhost:8080/iiif/rotating/canvas/007",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/007.jpg",
@@ -143,19 +143,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/009",
+      "id": "http://localhost:8080/iiif/rotating/canvas/009",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/009/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/009/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/009/annotation-page/009",
+              "id": "http://localhost:8080/iiif/rotating/canvas/009/annotation-page/009",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/009",
+              "target": "http://localhost:8080/iiif/rotating/canvas/009",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/009.jpg",
@@ -175,19 +175,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/011",
+      "id": "http://localhost:8080/iiif/rotating/canvas/011",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/011/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/011/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/011/annotation-page/011",
+              "id": "http://localhost:8080/iiif/rotating/canvas/011/annotation-page/011",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/011",
+              "target": "http://localhost:8080/iiif/rotating/canvas/011",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/011.jpg",
@@ -207,19 +207,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/013",
+      "id": "http://localhost:8080/iiif/rotating/canvas/013",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/013/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/013/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/013/annotation-page/013",
+              "id": "http://localhost:8080/iiif/rotating/canvas/013/annotation-page/013",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/013",
+              "target": "http://localhost:8080/iiif/rotating/canvas/013",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/013.jpg",
@@ -239,19 +239,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/015",
+      "id": "http://localhost:8080/iiif/rotating/canvas/015",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/015/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/015/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/015/annotation-page/015",
+              "id": "http://localhost:8080/iiif/rotating/canvas/015/annotation-page/015",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/015",
+              "target": "http://localhost:8080/iiif/rotating/canvas/015",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/015.jpg",
@@ -271,19 +271,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/017",
+      "id": "http://localhost:8080/iiif/rotating/canvas/017",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/017/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/017/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/017/annotation-page/017",
+              "id": "http://localhost:8080/iiif/rotating/canvas/017/annotation-page/017",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/017",
+              "target": "http://localhost:8080/iiif/rotating/canvas/017",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/017.jpg",
@@ -303,19 +303,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/019",
+      "id": "http://localhost:8080/iiif/rotating/canvas/019",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/019/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/019/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/019/annotation-page/019",
+              "id": "http://localhost:8080/iiif/rotating/canvas/019/annotation-page/019",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/019",
+              "target": "http://localhost:8080/iiif/rotating/canvas/019",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/019.jpg",
@@ -335,19 +335,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/021",
+      "id": "http://localhost:8080/iiif/rotating/canvas/021",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/021/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/021/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/021/annotation-page/021",
+              "id": "http://localhost:8080/iiif/rotating/canvas/021/annotation-page/021",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/021",
+              "target": "http://localhost:8080/iiif/rotating/canvas/021",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/021.jpg",
@@ -367,19 +367,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/023",
+      "id": "http://localhost:8080/iiif/rotating/canvas/023",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/023/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/023/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/023/annotation-page/023",
+              "id": "http://localhost:8080/iiif/rotating/canvas/023/annotation-page/023",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/023",
+              "target": "http://localhost:8080/iiif/rotating/canvas/023",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/023.jpg",
@@ -399,19 +399,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/025",
+      "id": "http://localhost:8080/iiif/rotating/canvas/025",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/025/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/025/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/025/annotation-page/025",
+              "id": "http://localhost:8080/iiif/rotating/canvas/025/annotation-page/025",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/025",
+              "target": "http://localhost:8080/iiif/rotating/canvas/025",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/025.jpg",
@@ -431,19 +431,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/027",
+      "id": "http://localhost:8080/iiif/rotating/canvas/027",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/027/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/027/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/027/annotation-page/027",
+              "id": "http://localhost:8080/iiif/rotating/canvas/027/annotation-page/027",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/027",
+              "target": "http://localhost:8080/iiif/rotating/canvas/027",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/027.jpg",
@@ -463,19 +463,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/029",
+      "id": "http://localhost:8080/iiif/rotating/canvas/029",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/029/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/029/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/029/annotation-page/029",
+              "id": "http://localhost:8080/iiif/rotating/canvas/029/annotation-page/029",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/029",
+              "target": "http://localhost:8080/iiif/rotating/canvas/029",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/029.jpg",
@@ -495,19 +495,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/031",
+      "id": "http://localhost:8080/iiif/rotating/canvas/031",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/031/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/031/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/031/annotation-page/031",
+              "id": "http://localhost:8080/iiif/rotating/canvas/031/annotation-page/031",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/031",
+              "target": "http://localhost:8080/iiif/rotating/canvas/031",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/031.jpg",
@@ -527,19 +527,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/033",
+      "id": "http://localhost:8080/iiif/rotating/canvas/033",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/033/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/033/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/033/annotation-page/033",
+              "id": "http://localhost:8080/iiif/rotating/canvas/033/annotation-page/033",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/033",
+              "target": "http://localhost:8080/iiif/rotating/canvas/033",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/033.jpg",
@@ -559,19 +559,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/035",
+      "id": "http://localhost:8080/iiif/rotating/canvas/035",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/035/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/035/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/035/annotation-page/035",
+              "id": "http://localhost:8080/iiif/rotating/canvas/035/annotation-page/035",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/035",
+              "target": "http://localhost:8080/iiif/rotating/canvas/035",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/035.jpg",
@@ -591,19 +591,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/037",
+      "id": "http://localhost:8080/iiif/rotating/canvas/037",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/037/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/037/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/037/annotation-page/037",
+              "id": "http://localhost:8080/iiif/rotating/canvas/037/annotation-page/037",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/037",
+              "target": "http://localhost:8080/iiif/rotating/canvas/037",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/037.jpg",
@@ -623,19 +623,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/039",
+      "id": "http://localhost:8080/iiif/rotating/canvas/039",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/039/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/039/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/039/annotation-page/039",
+              "id": "http://localhost:8080/iiif/rotating/canvas/039/annotation-page/039",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/039",
+              "target": "http://localhost:8080/iiif/rotating/canvas/039",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/039.jpg",
@@ -655,19 +655,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/041",
+      "id": "http://localhost:8080/iiif/rotating/canvas/041",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/041/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/041/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/041/annotation-page/041",
+              "id": "http://localhost:8080/iiif/rotating/canvas/041/annotation-page/041",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/041",
+              "target": "http://localhost:8080/iiif/rotating/canvas/041",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/041.jpg",
@@ -687,19 +687,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/043",
+      "id": "http://localhost:8080/iiif/rotating/canvas/043",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/043/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/043/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/043/annotation-page/043",
+              "id": "http://localhost:8080/iiif/rotating/canvas/043/annotation-page/043",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/043",
+              "target": "http://localhost:8080/iiif/rotating/canvas/043",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/043.jpg",
@@ -719,19 +719,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/045",
+      "id": "http://localhost:8080/iiif/rotating/canvas/045",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/045/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/045/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/045/annotation-page/045",
+              "id": "http://localhost:8080/iiif/rotating/canvas/045/annotation-page/045",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/045",
+              "target": "http://localhost:8080/iiif/rotating/canvas/045",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/045.jpg",
@@ -751,19 +751,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/047",
+      "id": "http://localhost:8080/iiif/rotating/canvas/047",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/047/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/047/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/047/annotation-page/047",
+              "id": "http://localhost:8080/iiif/rotating/canvas/047/annotation-page/047",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/047",
+              "target": "http://localhost:8080/iiif/rotating/canvas/047",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/047.jpg",
@@ -783,19 +783,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/049",
+      "id": "http://localhost:8080/iiif/rotating/canvas/049",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/049/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/049/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/049/annotation-page/049",
+              "id": "http://localhost:8080/iiif/rotating/canvas/049/annotation-page/049",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/049",
+              "target": "http://localhost:8080/iiif/rotating/canvas/049",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/049.jpg",
@@ -815,19 +815,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/051",
+      "id": "http://localhost:8080/iiif/rotating/canvas/051",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/051/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/051/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/051/annotation-page/051",
+              "id": "http://localhost:8080/iiif/rotating/canvas/051/annotation-page/051",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/051",
+              "target": "http://localhost:8080/iiif/rotating/canvas/051",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/051.jpg",
@@ -847,19 +847,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/053",
+      "id": "http://localhost:8080/iiif/rotating/canvas/053",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/053/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/053/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/053/annotation-page/053",
+              "id": "http://localhost:8080/iiif/rotating/canvas/053/annotation-page/053",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/053",
+              "target": "http://localhost:8080/iiif/rotating/canvas/053",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/053.jpg",
@@ -879,19 +879,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/055",
+      "id": "http://localhost:8080/iiif/rotating/canvas/055",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/055/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/055/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/055/annotation-page/055",
+              "id": "http://localhost:8080/iiif/rotating/canvas/055/annotation-page/055",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/055",
+              "target": "http://localhost:8080/iiif/rotating/canvas/055",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/055.jpg",
@@ -911,19 +911,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/057",
+      "id": "http://localhost:8080/iiif/rotating/canvas/057",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/057/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/057/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/057/annotation-page/057",
+              "id": "http://localhost:8080/iiif/rotating/canvas/057/annotation-page/057",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/057",
+              "target": "http://localhost:8080/iiif/rotating/canvas/057",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/057.jpg",
@@ -943,19 +943,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/059",
+      "id": "http://localhost:8080/iiif/rotating/canvas/059",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/059/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/059/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/059/annotation-page/059",
+              "id": "http://localhost:8080/iiif/rotating/canvas/059/annotation-page/059",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/059",
+              "target": "http://localhost:8080/iiif/rotating/canvas/059",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/059.jpg",
@@ -975,19 +975,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/061",
+      "id": "http://localhost:8080/iiif/rotating/canvas/061",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/061/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/061/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/061/annotation-page/061",
+              "id": "http://localhost:8080/iiif/rotating/canvas/061/annotation-page/061",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/061",
+              "target": "http://localhost:8080/iiif/rotating/canvas/061",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/061.jpg",
@@ -1007,19 +1007,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/063",
+      "id": "http://localhost:8080/iiif/rotating/canvas/063",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/063/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/063/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/063/annotation-page/063",
+              "id": "http://localhost:8080/iiif/rotating/canvas/063/annotation-page/063",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/063",
+              "target": "http://localhost:8080/iiif/rotating/canvas/063",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/063.jpg",
@@ -1039,19 +1039,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/065",
+      "id": "http://localhost:8080/iiif/rotating/canvas/065",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/065/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/065/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/065/annotation-page/065",
+              "id": "http://localhost:8080/iiif/rotating/canvas/065/annotation-page/065",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/065",
+              "target": "http://localhost:8080/iiif/rotating/canvas/065",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/065.jpg",
@@ -1071,19 +1071,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/067",
+      "id": "http://localhost:8080/iiif/rotating/canvas/067",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/067/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/067/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/067/annotation-page/067",
+              "id": "http://localhost:8080/iiif/rotating/canvas/067/annotation-page/067",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/067",
+              "target": "http://localhost:8080/iiif/rotating/canvas/067",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/067.jpg",
@@ -1103,19 +1103,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/069",
+      "id": "http://localhost:8080/iiif/rotating/canvas/069",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/069/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/069/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/069/annotation-page/069",
+              "id": "http://localhost:8080/iiif/rotating/canvas/069/annotation-page/069",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/069",
+              "target": "http://localhost:8080/iiif/rotating/canvas/069",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/069.jpg",
@@ -1135,19 +1135,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/071",
+      "id": "http://localhost:8080/iiif/rotating/canvas/071",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/071/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/071/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/071/annotation-page/071",
+              "id": "http://localhost:8080/iiif/rotating/canvas/071/annotation-page/071",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/071",
+              "target": "http://localhost:8080/iiif/rotating/canvas/071",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/071.jpg",
@@ -1167,19 +1167,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/073",
+      "id": "http://localhost:8080/iiif/rotating/canvas/073",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/073/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/073/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/073/annotation-page/073",
+              "id": "http://localhost:8080/iiif/rotating/canvas/073/annotation-page/073",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/073",
+              "target": "http://localhost:8080/iiif/rotating/canvas/073",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/073.jpg",
@@ -1199,19 +1199,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/075",
+      "id": "http://localhost:8080/iiif/rotating/canvas/075",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/075/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/075/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/075/annotation-page/075",
+              "id": "http://localhost:8080/iiif/rotating/canvas/075/annotation-page/075",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/075",
+              "target": "http://localhost:8080/iiif/rotating/canvas/075",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/075.jpg",
@@ -1231,19 +1231,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/077",
+      "id": "http://localhost:8080/iiif/rotating/canvas/077",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/077/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/077/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/077/annotation-page/077",
+              "id": "http://localhost:8080/iiif/rotating/canvas/077/annotation-page/077",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/077",
+              "target": "http://localhost:8080/iiif/rotating/canvas/077",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/077.jpg",
@@ -1263,19 +1263,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/079",
+      "id": "http://localhost:8080/iiif/rotating/canvas/079",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/079/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/079/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/079/annotation-page/079",
+              "id": "http://localhost:8080/iiif/rotating/canvas/079/annotation-page/079",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/079",
+              "target": "http://localhost:8080/iiif/rotating/canvas/079",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/079.jpg",
@@ -1295,19 +1295,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/081",
+      "id": "http://localhost:8080/iiif/rotating/canvas/081",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/081/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/081/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/081/annotation-page/081",
+              "id": "http://localhost:8080/iiif/rotating/canvas/081/annotation-page/081",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/081",
+              "target": "http://localhost:8080/iiif/rotating/canvas/081",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/081.jpg",
@@ -1327,19 +1327,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/083",
+      "id": "http://localhost:8080/iiif/rotating/canvas/083",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/083/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/083/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/083/annotation-page/083",
+              "id": "http://localhost:8080/iiif/rotating/canvas/083/annotation-page/083",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/083",
+              "target": "http://localhost:8080/iiif/rotating/canvas/083",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/083.jpg",
@@ -1359,19 +1359,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/085",
+      "id": "http://localhost:8080/iiif/rotating/canvas/085",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/085/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/085/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/085/annotation-page/085",
+              "id": "http://localhost:8080/iiif/rotating/canvas/085/annotation-page/085",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/085",
+              "target": "http://localhost:8080/iiif/rotating/canvas/085",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/085.jpg",
@@ -1391,19 +1391,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/087",
+      "id": "http://localhost:8080/iiif/rotating/canvas/087",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/087/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/087/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/087/annotation-page/087",
+              "id": "http://localhost:8080/iiif/rotating/canvas/087/annotation-page/087",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/087",
+              "target": "http://localhost:8080/iiif/rotating/canvas/087",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/087.jpg",
@@ -1423,19 +1423,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/089",
+      "id": "http://localhost:8080/iiif/rotating/canvas/089",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/089/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/089/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/089/annotation-page/089",
+              "id": "http://localhost:8080/iiif/rotating/canvas/089/annotation-page/089",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/089",
+              "target": "http://localhost:8080/iiif/rotating/canvas/089",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/089.jpg",
@@ -1455,19 +1455,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/091",
+      "id": "http://localhost:8080/iiif/rotating/canvas/091",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/091/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/091/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/091/annotation-page/091",
+              "id": "http://localhost:8080/iiif/rotating/canvas/091/annotation-page/091",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/091",
+              "target": "http://localhost:8080/iiif/rotating/canvas/091",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/091.jpg",
@@ -1487,19 +1487,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/093",
+      "id": "http://localhost:8080/iiif/rotating/canvas/093",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/093/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/093/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/093/annotation-page/093",
+              "id": "http://localhost:8080/iiif/rotating/canvas/093/annotation-page/093",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/093",
+              "target": "http://localhost:8080/iiif/rotating/canvas/093",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/093.jpg",
@@ -1519,19 +1519,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/095",
+      "id": "http://localhost:8080/iiif/rotating/canvas/095",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/095/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/095/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/095/annotation-page/095",
+              "id": "http://localhost:8080/iiif/rotating/canvas/095/annotation-page/095",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/095",
+              "target": "http://localhost:8080/iiif/rotating/canvas/095",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/095.jpg",
@@ -1551,19 +1551,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/097",
+      "id": "http://localhost:8080/iiif/rotating/canvas/097",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/097/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/097/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/097/annotation-page/097",
+              "id": "http://localhost:8080/iiif/rotating/canvas/097/annotation-page/097",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/097",
+              "target": "http://localhost:8080/iiif/rotating/canvas/097",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/097.jpg",
@@ -1583,19 +1583,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/099",
+      "id": "http://localhost:8080/iiif/rotating/canvas/099",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/099/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/099/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/099/annotation-page/099",
+              "id": "http://localhost:8080/iiif/rotating/canvas/099/annotation-page/099",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/099",
+              "target": "http://localhost:8080/iiif/rotating/canvas/099",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/099.jpg",
@@ -1615,19 +1615,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/101",
+      "id": "http://localhost:8080/iiif/rotating/canvas/101",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/101/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/101/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/101/annotation-page/101",
+              "id": "http://localhost:8080/iiif/rotating/canvas/101/annotation-page/101",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/101",
+              "target": "http://localhost:8080/iiif/rotating/canvas/101",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/101.jpg",
@@ -1647,19 +1647,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/103",
+      "id": "http://localhost:8080/iiif/rotating/canvas/103",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/103/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/103/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/103/annotation-page/103",
+              "id": "http://localhost:8080/iiif/rotating/canvas/103/annotation-page/103",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/103",
+              "target": "http://localhost:8080/iiif/rotating/canvas/103",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/103.jpg",
@@ -1679,19 +1679,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/105",
+      "id": "http://localhost:8080/iiif/rotating/canvas/105",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/105/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/105/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/105/annotation-page/105",
+              "id": "http://localhost:8080/iiif/rotating/canvas/105/annotation-page/105",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/105",
+              "target": "http://localhost:8080/iiif/rotating/canvas/105",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/105.jpg",
@@ -1711,19 +1711,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/107",
+      "id": "http://localhost:8080/iiif/rotating/canvas/107",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/107/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/107/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/107/annotation-page/107",
+              "id": "http://localhost:8080/iiif/rotating/canvas/107/annotation-page/107",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/107",
+              "target": "http://localhost:8080/iiif/rotating/canvas/107",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/107.jpg",
@@ -1743,19 +1743,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/109",
+      "id": "http://localhost:8080/iiif/rotating/canvas/109",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/109/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/109/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/109/annotation-page/109",
+              "id": "http://localhost:8080/iiif/rotating/canvas/109/annotation-page/109",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/109",
+              "target": "http://localhost:8080/iiif/rotating/canvas/109",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/109.jpg",
@@ -1775,19 +1775,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/111",
+      "id": "http://localhost:8080/iiif/rotating/canvas/111",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/111/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/111/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/111/annotation-page/111",
+              "id": "http://localhost:8080/iiif/rotating/canvas/111/annotation-page/111",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/111",
+              "target": "http://localhost:8080/iiif/rotating/canvas/111",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/111.jpg",
@@ -1807,19 +1807,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/113",
+      "id": "http://localhost:8080/iiif/rotating/canvas/113",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/113/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/113/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/113/annotation-page/113",
+              "id": "http://localhost:8080/iiif/rotating/canvas/113/annotation-page/113",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/113",
+              "target": "http://localhost:8080/iiif/rotating/canvas/113",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/113.jpg",
@@ -1839,19 +1839,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/115",
+      "id": "http://localhost:8080/iiif/rotating/canvas/115",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/115/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/115/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/115/annotation-page/115",
+              "id": "http://localhost:8080/iiif/rotating/canvas/115/annotation-page/115",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/115",
+              "target": "http://localhost:8080/iiif/rotating/canvas/115",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/115.jpg",
@@ -1871,19 +1871,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/117",
+      "id": "http://localhost:8080/iiif/rotating/canvas/117",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/117/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/117/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/117/annotation-page/117",
+              "id": "http://localhost:8080/iiif/rotating/canvas/117/annotation-page/117",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/117",
+              "target": "http://localhost:8080/iiif/rotating/canvas/117",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/117.jpg",
@@ -1903,19 +1903,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/119",
+      "id": "http://localhost:8080/iiif/rotating/canvas/119",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/119/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/119/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/119/annotation-page/119",
+              "id": "http://localhost:8080/iiif/rotating/canvas/119/annotation-page/119",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/119",
+              "target": "http://localhost:8080/iiif/rotating/canvas/119",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/119.jpg",
@@ -1935,19 +1935,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/121",
+      "id": "http://localhost:8080/iiif/rotating/canvas/121",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/121/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/121/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/121/annotation-page/121",
+              "id": "http://localhost:8080/iiif/rotating/canvas/121/annotation-page/121",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/121",
+              "target": "http://localhost:8080/iiif/rotating/canvas/121",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/121.jpg",
@@ -1967,19 +1967,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/123",
+      "id": "http://localhost:8080/iiif/rotating/canvas/123",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/123/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/123/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/123/annotation-page/123",
+              "id": "http://localhost:8080/iiif/rotating/canvas/123/annotation-page/123",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/123",
+              "target": "http://localhost:8080/iiif/rotating/canvas/123",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/123.jpg",
@@ -1999,19 +1999,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/125",
+      "id": "http://localhost:8080/iiif/rotating/canvas/125",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/125/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/125/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/125/annotation-page/125",
+              "id": "http://localhost:8080/iiif/rotating/canvas/125/annotation-page/125",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/125",
+              "target": "http://localhost:8080/iiif/rotating/canvas/125",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/125.jpg",
@@ -2031,19 +2031,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/127",
+      "id": "http://localhost:8080/iiif/rotating/canvas/127",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/127/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/127/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/127/annotation-page/127",
+              "id": "http://localhost:8080/iiif/rotating/canvas/127/annotation-page/127",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/127",
+              "target": "http://localhost:8080/iiif/rotating/canvas/127",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/127.jpg",
@@ -2063,19 +2063,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/129",
+      "id": "http://localhost:8080/iiif/rotating/canvas/129",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/129/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/129/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/129/annotation-page/129",
+              "id": "http://localhost:8080/iiif/rotating/canvas/129/annotation-page/129",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/129",
+              "target": "http://localhost:8080/iiif/rotating/canvas/129",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/129.jpg",
@@ -2095,19 +2095,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/131",
+      "id": "http://localhost:8080/iiif/rotating/canvas/131",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/131/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/131/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/131/annotation-page/131",
+              "id": "http://localhost:8080/iiif/rotating/canvas/131/annotation-page/131",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/131",
+              "target": "http://localhost:8080/iiif/rotating/canvas/131",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/131.jpg",
@@ -2127,19 +2127,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/133",
+      "id": "http://localhost:8080/iiif/rotating/canvas/133",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/133/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/133/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/133/annotation-page/133",
+              "id": "http://localhost:8080/iiif/rotating/canvas/133/annotation-page/133",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/133",
+              "target": "http://localhost:8080/iiif/rotating/canvas/133",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/133.jpg",
@@ -2159,19 +2159,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/135",
+      "id": "http://localhost:8080/iiif/rotating/canvas/135",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/135/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/135/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/135/annotation-page/135",
+              "id": "http://localhost:8080/iiif/rotating/canvas/135/annotation-page/135",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/135",
+              "target": "http://localhost:8080/iiif/rotating/canvas/135",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/135.jpg",
@@ -2191,19 +2191,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/137",
+      "id": "http://localhost:8080/iiif/rotating/canvas/137",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/137/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/137/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/137/annotation-page/137",
+              "id": "http://localhost:8080/iiif/rotating/canvas/137/annotation-page/137",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/137",
+              "target": "http://localhost:8080/iiif/rotating/canvas/137",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/137.jpg",
@@ -2223,19 +2223,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/139",
+      "id": "http://localhost:8080/iiif/rotating/canvas/139",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/139/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/139/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/139/annotation-page/139",
+              "id": "http://localhost:8080/iiif/rotating/canvas/139/annotation-page/139",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/139",
+              "target": "http://localhost:8080/iiif/rotating/canvas/139",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/139.jpg",
@@ -2255,19 +2255,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/141",
+      "id": "http://localhost:8080/iiif/rotating/canvas/141",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/141/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/141/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/141/annotation-page/141",
+              "id": "http://localhost:8080/iiif/rotating/canvas/141/annotation-page/141",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/141",
+              "target": "http://localhost:8080/iiif/rotating/canvas/141",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/141.jpg",
@@ -2287,19 +2287,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/143",
+      "id": "http://localhost:8080/iiif/rotating/canvas/143",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/143/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/143/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/143/annotation-page/143",
+              "id": "http://localhost:8080/iiif/rotating/canvas/143/annotation-page/143",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/143",
+              "target": "http://localhost:8080/iiif/rotating/canvas/143",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/143.jpg",
@@ -2319,19 +2319,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/145",
+      "id": "http://localhost:8080/iiif/rotating/canvas/145",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/145/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/145/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/145/annotation-page/145",
+              "id": "http://localhost:8080/iiif/rotating/canvas/145/annotation-page/145",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/145",
+              "target": "http://localhost:8080/iiif/rotating/canvas/145",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/145.jpg",
@@ -2351,19 +2351,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/147",
+      "id": "http://localhost:8080/iiif/rotating/canvas/147",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/147/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/147/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/147/annotation-page/147",
+              "id": "http://localhost:8080/iiif/rotating/canvas/147/annotation-page/147",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/147",
+              "target": "http://localhost:8080/iiif/rotating/canvas/147",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/147.jpg",
@@ -2383,19 +2383,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/149",
+      "id": "http://localhost:8080/iiif/rotating/canvas/149",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/149/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/149/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/149/annotation-page/149",
+              "id": "http://localhost:8080/iiif/rotating/canvas/149/annotation-page/149",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/149",
+              "target": "http://localhost:8080/iiif/rotating/canvas/149",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/149.jpg",
@@ -2415,19 +2415,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/151",
+      "id": "http://localhost:8080/iiif/rotating/canvas/151",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/151/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/151/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/151/annotation-page/151",
+              "id": "http://localhost:8080/iiif/rotating/canvas/151/annotation-page/151",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/151",
+              "target": "http://localhost:8080/iiif/rotating/canvas/151",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/151.jpg",
@@ -2447,19 +2447,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/153",
+      "id": "http://localhost:8080/iiif/rotating/canvas/153",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/153/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/153/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/153/annotation-page/153",
+              "id": "http://localhost:8080/iiif/rotating/canvas/153/annotation-page/153",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/153",
+              "target": "http://localhost:8080/iiif/rotating/canvas/153",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/153.jpg",
@@ -2479,19 +2479,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/155",
+      "id": "http://localhost:8080/iiif/rotating/canvas/155",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/155/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/155/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/155/annotation-page/155",
+              "id": "http://localhost:8080/iiif/rotating/canvas/155/annotation-page/155",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/155",
+              "target": "http://localhost:8080/iiif/rotating/canvas/155",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/155.jpg",
@@ -2511,19 +2511,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/157",
+      "id": "http://localhost:8080/iiif/rotating/canvas/157",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/157/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/157/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/157/annotation-page/157",
+              "id": "http://localhost:8080/iiif/rotating/canvas/157/annotation-page/157",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/157",
+              "target": "http://localhost:8080/iiif/rotating/canvas/157",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/157.jpg",
@@ -2543,19 +2543,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/159",
+      "id": "http://localhost:8080/iiif/rotating/canvas/159",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/159/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/159/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/159/annotation-page/159",
+              "id": "http://localhost:8080/iiif/rotating/canvas/159/annotation-page/159",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/159",
+              "target": "http://localhost:8080/iiif/rotating/canvas/159",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/159.jpg",
@@ -2575,19 +2575,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/161",
+      "id": "http://localhost:8080/iiif/rotating/canvas/161",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/161/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/161/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/161/annotation-page/161",
+              "id": "http://localhost:8080/iiif/rotating/canvas/161/annotation-page/161",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/161",
+              "target": "http://localhost:8080/iiif/rotating/canvas/161",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/161.jpg",
@@ -2607,19 +2607,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/163",
+      "id": "http://localhost:8080/iiif/rotating/canvas/163",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/163/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/163/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/163/annotation-page/163",
+              "id": "http://localhost:8080/iiif/rotating/canvas/163/annotation-page/163",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/163",
+              "target": "http://localhost:8080/iiif/rotating/canvas/163",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/163.jpg",
@@ -2639,19 +2639,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/165",
+      "id": "http://localhost:8080/iiif/rotating/canvas/165",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/165/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/165/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/165/annotation-page/165",
+              "id": "http://localhost:8080/iiif/rotating/canvas/165/annotation-page/165",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/165",
+              "target": "http://localhost:8080/iiif/rotating/canvas/165",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/165.jpg",
@@ -2671,19 +2671,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/167",
+      "id": "http://localhost:8080/iiif/rotating/canvas/167",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/167/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/167/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/167/annotation-page/167",
+              "id": "http://localhost:8080/iiif/rotating/canvas/167/annotation-page/167",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/167",
+              "target": "http://localhost:8080/iiif/rotating/canvas/167",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/167.jpg",
@@ -2703,19 +2703,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/169",
+      "id": "http://localhost:8080/iiif/rotating/canvas/169",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/169/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/169/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/169/annotation-page/169",
+              "id": "http://localhost:8080/iiif/rotating/canvas/169/annotation-page/169",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/169",
+              "target": "http://localhost:8080/iiif/rotating/canvas/169",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/169.jpg",
@@ -2735,19 +2735,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/171",
+      "id": "http://localhost:8080/iiif/rotating/canvas/171",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/171/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/171/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/171/annotation-page/171",
+              "id": "http://localhost:8080/iiif/rotating/canvas/171/annotation-page/171",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/171",
+              "target": "http://localhost:8080/iiif/rotating/canvas/171",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/171.jpg",
@@ -2767,19 +2767,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/173",
+      "id": "http://localhost:8080/iiif/rotating/canvas/173",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/173/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/173/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/173/annotation-page/173",
+              "id": "http://localhost:8080/iiif/rotating/canvas/173/annotation-page/173",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/173",
+              "target": "http://localhost:8080/iiif/rotating/canvas/173",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/173.jpg",
@@ -2799,19 +2799,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/175",
+      "id": "http://localhost:8080/iiif/rotating/canvas/175",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/175/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/175/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/175/annotation-page/175",
+              "id": "http://localhost:8080/iiif/rotating/canvas/175/annotation-page/175",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/175",
+              "target": "http://localhost:8080/iiif/rotating/canvas/175",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/175.jpg",
@@ -2831,19 +2831,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/177",
+      "id": "http://localhost:8080/iiif/rotating/canvas/177",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/177/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/177/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/177/annotation-page/177",
+              "id": "http://localhost:8080/iiif/rotating/canvas/177/annotation-page/177",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/177",
+              "target": "http://localhost:8080/iiif/rotating/canvas/177",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/177.jpg",
@@ -2863,19 +2863,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/179",
+      "id": "http://localhost:8080/iiif/rotating/canvas/179",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/179/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/179/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/179/annotation-page/179",
+              "id": "http://localhost:8080/iiif/rotating/canvas/179/annotation-page/179",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/179",
+              "target": "http://localhost:8080/iiif/rotating/canvas/179",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/179.jpg",
@@ -2897,366 +2897,366 @@
   ],
   "structures": [
     {
-      "id": "http:/localhost:8080/iiif/rotating/ranges/0",
+      "id": "http://localhost:8080/iiif/rotating/ranges/0",
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/001",
+          "id": "http://localhost:8080/iiif/rotating/canvas/001",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/003",
+          "id": "http://localhost:8080/iiif/rotating/canvas/003",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/005",
+          "id": "http://localhost:8080/iiif/rotating/canvas/005",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/007",
+          "id": "http://localhost:8080/iiif/rotating/canvas/007",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/009",
+          "id": "http://localhost:8080/iiif/rotating/canvas/009",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/011",
+          "id": "http://localhost:8080/iiif/rotating/canvas/011",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/013",
+          "id": "http://localhost:8080/iiif/rotating/canvas/013",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/015",
+          "id": "http://localhost:8080/iiif/rotating/canvas/015",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/017",
+          "id": "http://localhost:8080/iiif/rotating/canvas/017",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/019",
+          "id": "http://localhost:8080/iiif/rotating/canvas/019",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/021",
+          "id": "http://localhost:8080/iiif/rotating/canvas/021",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/023",
+          "id": "http://localhost:8080/iiif/rotating/canvas/023",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/025",
+          "id": "http://localhost:8080/iiif/rotating/canvas/025",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/027",
+          "id": "http://localhost:8080/iiif/rotating/canvas/027",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/029",
+          "id": "http://localhost:8080/iiif/rotating/canvas/029",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/031",
+          "id": "http://localhost:8080/iiif/rotating/canvas/031",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/033",
+          "id": "http://localhost:8080/iiif/rotating/canvas/033",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/035",
+          "id": "http://localhost:8080/iiif/rotating/canvas/035",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/037",
+          "id": "http://localhost:8080/iiif/rotating/canvas/037",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/039",
+          "id": "http://localhost:8080/iiif/rotating/canvas/039",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/041",
+          "id": "http://localhost:8080/iiif/rotating/canvas/041",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/043",
+          "id": "http://localhost:8080/iiif/rotating/canvas/043",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/045",
+          "id": "http://localhost:8080/iiif/rotating/canvas/045",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/047",
+          "id": "http://localhost:8080/iiif/rotating/canvas/047",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/049",
+          "id": "http://localhost:8080/iiif/rotating/canvas/049",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/051",
+          "id": "http://localhost:8080/iiif/rotating/canvas/051",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/053",
+          "id": "http://localhost:8080/iiif/rotating/canvas/053",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/055",
+          "id": "http://localhost:8080/iiif/rotating/canvas/055",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/057",
+          "id": "http://localhost:8080/iiif/rotating/canvas/057",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/059",
+          "id": "http://localhost:8080/iiif/rotating/canvas/059",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/061",
+          "id": "http://localhost:8080/iiif/rotating/canvas/061",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/063",
+          "id": "http://localhost:8080/iiif/rotating/canvas/063",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/065",
+          "id": "http://localhost:8080/iiif/rotating/canvas/065",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/067",
+          "id": "http://localhost:8080/iiif/rotating/canvas/067",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/069",
+          "id": "http://localhost:8080/iiif/rotating/canvas/069",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/071",
+          "id": "http://localhost:8080/iiif/rotating/canvas/071",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/073",
+          "id": "http://localhost:8080/iiif/rotating/canvas/073",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/075",
+          "id": "http://localhost:8080/iiif/rotating/canvas/075",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/077",
+          "id": "http://localhost:8080/iiif/rotating/canvas/077",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/079",
+          "id": "http://localhost:8080/iiif/rotating/canvas/079",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/081",
+          "id": "http://localhost:8080/iiif/rotating/canvas/081",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/083",
+          "id": "http://localhost:8080/iiif/rotating/canvas/083",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/085",
+          "id": "http://localhost:8080/iiif/rotating/canvas/085",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/087",
+          "id": "http://localhost:8080/iiif/rotating/canvas/087",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/089",
+          "id": "http://localhost:8080/iiif/rotating/canvas/089",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/091",
+          "id": "http://localhost:8080/iiif/rotating/canvas/091",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/093",
+          "id": "http://localhost:8080/iiif/rotating/canvas/093",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/095",
+          "id": "http://localhost:8080/iiif/rotating/canvas/095",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/097",
+          "id": "http://localhost:8080/iiif/rotating/canvas/097",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/099",
+          "id": "http://localhost:8080/iiif/rotating/canvas/099",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/101",
+          "id": "http://localhost:8080/iiif/rotating/canvas/101",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/103",
+          "id": "http://localhost:8080/iiif/rotating/canvas/103",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/105",
+          "id": "http://localhost:8080/iiif/rotating/canvas/105",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/107",
+          "id": "http://localhost:8080/iiif/rotating/canvas/107",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/109",
+          "id": "http://localhost:8080/iiif/rotating/canvas/109",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/111",
+          "id": "http://localhost:8080/iiif/rotating/canvas/111",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/113",
+          "id": "http://localhost:8080/iiif/rotating/canvas/113",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/115",
+          "id": "http://localhost:8080/iiif/rotating/canvas/115",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/117",
+          "id": "http://localhost:8080/iiif/rotating/canvas/117",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/119",
+          "id": "http://localhost:8080/iiif/rotating/canvas/119",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/121",
+          "id": "http://localhost:8080/iiif/rotating/canvas/121",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/123",
+          "id": "http://localhost:8080/iiif/rotating/canvas/123",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/125",
+          "id": "http://localhost:8080/iiif/rotating/canvas/125",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/127",
+          "id": "http://localhost:8080/iiif/rotating/canvas/127",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/129",
+          "id": "http://localhost:8080/iiif/rotating/canvas/129",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/131",
+          "id": "http://localhost:8080/iiif/rotating/canvas/131",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/133",
+          "id": "http://localhost:8080/iiif/rotating/canvas/133",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/135",
+          "id": "http://localhost:8080/iiif/rotating/canvas/135",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/137",
+          "id": "http://localhost:8080/iiif/rotating/canvas/137",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/139",
+          "id": "http://localhost:8080/iiif/rotating/canvas/139",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/141",
+          "id": "http://localhost:8080/iiif/rotating/canvas/141",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/143",
+          "id": "http://localhost:8080/iiif/rotating/canvas/143",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/145",
+          "id": "http://localhost:8080/iiif/rotating/canvas/145",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/147",
+          "id": "http://localhost:8080/iiif/rotating/canvas/147",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/149",
+          "id": "http://localhost:8080/iiif/rotating/canvas/149",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/151",
+          "id": "http://localhost:8080/iiif/rotating/canvas/151",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/153",
+          "id": "http://localhost:8080/iiif/rotating/canvas/153",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/155",
+          "id": "http://localhost:8080/iiif/rotating/canvas/155",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/157",
+          "id": "http://localhost:8080/iiif/rotating/canvas/157",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/159",
+          "id": "http://localhost:8080/iiif/rotating/canvas/159",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/161",
+          "id": "http://localhost:8080/iiif/rotating/canvas/161",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/163",
+          "id": "http://localhost:8080/iiif/rotating/canvas/163",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/165",
+          "id": "http://localhost:8080/iiif/rotating/canvas/165",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/167",
+          "id": "http://localhost:8080/iiif/rotating/canvas/167",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/169",
+          "id": "http://localhost:8080/iiif/rotating/canvas/169",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/171",
+          "id": "http://localhost:8080/iiif/rotating/canvas/171",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/173",
+          "id": "http://localhost:8080/iiif/rotating/canvas/173",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/175",
+          "id": "http://localhost:8080/iiif/rotating/canvas/175",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/177",
+          "id": "http://localhost:8080/iiif/rotating/canvas/177",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/179",
+          "id": "http://localhost:8080/iiif/rotating/canvas/179",
           "type": "Canvas"
         }
       ],

--- a/packages/11ty/_plugins/figures/test/__fixtures__/figures/zoomable-sequence/manifest.json
+++ b/packages/11ty/_plugins/figures/test/__fixtures__/figures/zoomable-sequence/manifest.json
@@ -15,19 +15,19 @@
   },
   "items": [
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/001",
+      "id": "http://localhost:8080/iiif/rotating/canvas/001",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/001/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/001/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/001/annotation-page/001",
+              "id": "http://localhost:8080/iiif/rotating/canvas/001/annotation-page/001",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/001",
+              "target": "http://localhost:8080/iiif/rotating/canvas/001",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/001/tiles/info.json",
@@ -55,19 +55,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/003",
+      "id": "http://localhost:8080/iiif/rotating/canvas/003",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/003/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/003/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/003/annotation-page/003",
+              "id": "http://localhost:8080/iiif/rotating/canvas/003/annotation-page/003",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/003",
+              "target": "http://localhost:8080/iiif/rotating/canvas/003",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/003/tiles/info.json",
@@ -95,19 +95,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/005",
+      "id": "http://localhost:8080/iiif/rotating/canvas/005",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/005/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/005/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/005/annotation-page/005",
+              "id": "http://localhost:8080/iiif/rotating/canvas/005/annotation-page/005",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/005",
+              "target": "http://localhost:8080/iiif/rotating/canvas/005",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/005/tiles/info.json",
@@ -135,19 +135,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/007",
+      "id": "http://localhost:8080/iiif/rotating/canvas/007",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/007/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/007/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/007/annotation-page/007",
+              "id": "http://localhost:8080/iiif/rotating/canvas/007/annotation-page/007",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/007",
+              "target": "http://localhost:8080/iiif/rotating/canvas/007",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/007/tiles/info.json",
@@ -175,19 +175,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/009",
+      "id": "http://localhost:8080/iiif/rotating/canvas/009",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/009/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/009/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/009/annotation-page/009",
+              "id": "http://localhost:8080/iiif/rotating/canvas/009/annotation-page/009",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/009",
+              "target": "http://localhost:8080/iiif/rotating/canvas/009",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/009/tiles/info.json",
@@ -215,19 +215,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/011",
+      "id": "http://localhost:8080/iiif/rotating/canvas/011",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/011/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/011/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/011/annotation-page/011",
+              "id": "http://localhost:8080/iiif/rotating/canvas/011/annotation-page/011",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/011",
+              "target": "http://localhost:8080/iiif/rotating/canvas/011",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/011/tiles/info.json",
@@ -255,19 +255,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/013",
+      "id": "http://localhost:8080/iiif/rotating/canvas/013",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/013/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/013/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/013/annotation-page/013",
+              "id": "http://localhost:8080/iiif/rotating/canvas/013/annotation-page/013",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/013",
+              "target": "http://localhost:8080/iiif/rotating/canvas/013",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/013/tiles/info.json",
@@ -295,19 +295,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/015",
+      "id": "http://localhost:8080/iiif/rotating/canvas/015",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/015/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/015/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/015/annotation-page/015",
+              "id": "http://localhost:8080/iiif/rotating/canvas/015/annotation-page/015",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/015",
+              "target": "http://localhost:8080/iiif/rotating/canvas/015",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/015/tiles/info.json",
@@ -335,19 +335,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/017",
+      "id": "http://localhost:8080/iiif/rotating/canvas/017",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/017/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/017/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/017/annotation-page/017",
+              "id": "http://localhost:8080/iiif/rotating/canvas/017/annotation-page/017",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/017",
+              "target": "http://localhost:8080/iiif/rotating/canvas/017",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/017/tiles/info.json",
@@ -375,19 +375,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/019",
+      "id": "http://localhost:8080/iiif/rotating/canvas/019",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/019/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/019/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/019/annotation-page/019",
+              "id": "http://localhost:8080/iiif/rotating/canvas/019/annotation-page/019",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/019",
+              "target": "http://localhost:8080/iiif/rotating/canvas/019",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/019/tiles/info.json",
@@ -415,19 +415,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/021",
+      "id": "http://localhost:8080/iiif/rotating/canvas/021",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/021/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/021/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/021/annotation-page/021",
+              "id": "http://localhost:8080/iiif/rotating/canvas/021/annotation-page/021",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/021",
+              "target": "http://localhost:8080/iiif/rotating/canvas/021",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/021/tiles/info.json",
@@ -455,19 +455,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/023",
+      "id": "http://localhost:8080/iiif/rotating/canvas/023",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/023/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/023/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/023/annotation-page/023",
+              "id": "http://localhost:8080/iiif/rotating/canvas/023/annotation-page/023",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/023",
+              "target": "http://localhost:8080/iiif/rotating/canvas/023",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/023/tiles/info.json",
@@ -495,19 +495,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/025",
+      "id": "http://localhost:8080/iiif/rotating/canvas/025",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/025/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/025/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/025/annotation-page/025",
+              "id": "http://localhost:8080/iiif/rotating/canvas/025/annotation-page/025",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/025",
+              "target": "http://localhost:8080/iiif/rotating/canvas/025",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/025/tiles/info.json",
@@ -535,19 +535,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/027",
+      "id": "http://localhost:8080/iiif/rotating/canvas/027",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/027/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/027/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/027/annotation-page/027",
+              "id": "http://localhost:8080/iiif/rotating/canvas/027/annotation-page/027",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/027",
+              "target": "http://localhost:8080/iiif/rotating/canvas/027",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/027/tiles/info.json",
@@ -575,19 +575,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/029",
+      "id": "http://localhost:8080/iiif/rotating/canvas/029",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/029/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/029/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/029/annotation-page/029",
+              "id": "http://localhost:8080/iiif/rotating/canvas/029/annotation-page/029",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/029",
+              "target": "http://localhost:8080/iiif/rotating/canvas/029",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/029/tiles/info.json",
@@ -615,19 +615,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/031",
+      "id": "http://localhost:8080/iiif/rotating/canvas/031",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/031/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/031/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/031/annotation-page/031",
+              "id": "http://localhost:8080/iiif/rotating/canvas/031/annotation-page/031",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/031",
+              "target": "http://localhost:8080/iiif/rotating/canvas/031",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/031/tiles/info.json",
@@ -655,19 +655,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/033",
+      "id": "http://localhost:8080/iiif/rotating/canvas/033",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/033/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/033/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/033/annotation-page/033",
+              "id": "http://localhost:8080/iiif/rotating/canvas/033/annotation-page/033",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/033",
+              "target": "http://localhost:8080/iiif/rotating/canvas/033",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/033/tiles/info.json",
@@ -695,19 +695,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/035",
+      "id": "http://localhost:8080/iiif/rotating/canvas/035",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/035/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/035/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/035/annotation-page/035",
+              "id": "http://localhost:8080/iiif/rotating/canvas/035/annotation-page/035",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/035",
+              "target": "http://localhost:8080/iiif/rotating/canvas/035",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/035/tiles/info.json",
@@ -735,19 +735,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/037",
+      "id": "http://localhost:8080/iiif/rotating/canvas/037",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/037/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/037/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/037/annotation-page/037",
+              "id": "http://localhost:8080/iiif/rotating/canvas/037/annotation-page/037",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/037",
+              "target": "http://localhost:8080/iiif/rotating/canvas/037",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/037/tiles/info.json",
@@ -775,19 +775,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/039",
+      "id": "http://localhost:8080/iiif/rotating/canvas/039",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/039/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/039/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/039/annotation-page/039",
+              "id": "http://localhost:8080/iiif/rotating/canvas/039/annotation-page/039",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/039",
+              "target": "http://localhost:8080/iiif/rotating/canvas/039",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/039/tiles/info.json",
@@ -815,19 +815,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/041",
+      "id": "http://localhost:8080/iiif/rotating/canvas/041",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/041/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/041/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/041/annotation-page/041",
+              "id": "http://localhost:8080/iiif/rotating/canvas/041/annotation-page/041",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/041",
+              "target": "http://localhost:8080/iiif/rotating/canvas/041",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/041/tiles/info.json",
@@ -855,19 +855,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/043",
+      "id": "http://localhost:8080/iiif/rotating/canvas/043",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/043/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/043/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/043/annotation-page/043",
+              "id": "http://localhost:8080/iiif/rotating/canvas/043/annotation-page/043",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/043",
+              "target": "http://localhost:8080/iiif/rotating/canvas/043",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/043/tiles/info.json",
@@ -895,19 +895,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/045",
+      "id": "http://localhost:8080/iiif/rotating/canvas/045",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/045/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/045/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/045/annotation-page/045",
+              "id": "http://localhost:8080/iiif/rotating/canvas/045/annotation-page/045",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/045",
+              "target": "http://localhost:8080/iiif/rotating/canvas/045",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/045/tiles/info.json",
@@ -935,19 +935,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/047",
+      "id": "http://localhost:8080/iiif/rotating/canvas/047",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/047/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/047/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/047/annotation-page/047",
+              "id": "http://localhost:8080/iiif/rotating/canvas/047/annotation-page/047",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/047",
+              "target": "http://localhost:8080/iiif/rotating/canvas/047",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/047/tiles/info.json",
@@ -975,19 +975,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/049",
+      "id": "http://localhost:8080/iiif/rotating/canvas/049",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/049/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/049/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/049/annotation-page/049",
+              "id": "http://localhost:8080/iiif/rotating/canvas/049/annotation-page/049",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/049",
+              "target": "http://localhost:8080/iiif/rotating/canvas/049",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/049/tiles/info.json",
@@ -1015,19 +1015,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/051",
+      "id": "http://localhost:8080/iiif/rotating/canvas/051",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/051/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/051/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/051/annotation-page/051",
+              "id": "http://localhost:8080/iiif/rotating/canvas/051/annotation-page/051",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/051",
+              "target": "http://localhost:8080/iiif/rotating/canvas/051",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/051/tiles/info.json",
@@ -1055,19 +1055,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/053",
+      "id": "http://localhost:8080/iiif/rotating/canvas/053",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/053/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/053/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/053/annotation-page/053",
+              "id": "http://localhost:8080/iiif/rotating/canvas/053/annotation-page/053",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/053",
+              "target": "http://localhost:8080/iiif/rotating/canvas/053",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/053/tiles/info.json",
@@ -1095,19 +1095,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/055",
+      "id": "http://localhost:8080/iiif/rotating/canvas/055",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/055/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/055/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/055/annotation-page/055",
+              "id": "http://localhost:8080/iiif/rotating/canvas/055/annotation-page/055",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/055",
+              "target": "http://localhost:8080/iiif/rotating/canvas/055",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/055/tiles/info.json",
@@ -1135,19 +1135,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/057",
+      "id": "http://localhost:8080/iiif/rotating/canvas/057",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/057/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/057/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/057/annotation-page/057",
+              "id": "http://localhost:8080/iiif/rotating/canvas/057/annotation-page/057",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/057",
+              "target": "http://localhost:8080/iiif/rotating/canvas/057",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/057/tiles/info.json",
@@ -1175,19 +1175,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/059",
+      "id": "http://localhost:8080/iiif/rotating/canvas/059",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/059/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/059/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/059/annotation-page/059",
+              "id": "http://localhost:8080/iiif/rotating/canvas/059/annotation-page/059",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/059",
+              "target": "http://localhost:8080/iiif/rotating/canvas/059",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/059/tiles/info.json",
@@ -1215,19 +1215,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/061",
+      "id": "http://localhost:8080/iiif/rotating/canvas/061",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/061/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/061/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/061/annotation-page/061",
+              "id": "http://localhost:8080/iiif/rotating/canvas/061/annotation-page/061",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/061",
+              "target": "http://localhost:8080/iiif/rotating/canvas/061",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/061/tiles/info.json",
@@ -1255,19 +1255,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/063",
+      "id": "http://localhost:8080/iiif/rotating/canvas/063",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/063/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/063/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/063/annotation-page/063",
+              "id": "http://localhost:8080/iiif/rotating/canvas/063/annotation-page/063",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/063",
+              "target": "http://localhost:8080/iiif/rotating/canvas/063",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/063/tiles/info.json",
@@ -1295,19 +1295,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/065",
+      "id": "http://localhost:8080/iiif/rotating/canvas/065",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/065/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/065/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/065/annotation-page/065",
+              "id": "http://localhost:8080/iiif/rotating/canvas/065/annotation-page/065",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/065",
+              "target": "http://localhost:8080/iiif/rotating/canvas/065",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/065/tiles/info.json",
@@ -1335,19 +1335,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/067",
+      "id": "http://localhost:8080/iiif/rotating/canvas/067",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/067/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/067/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/067/annotation-page/067",
+              "id": "http://localhost:8080/iiif/rotating/canvas/067/annotation-page/067",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/067",
+              "target": "http://localhost:8080/iiif/rotating/canvas/067",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/067/tiles/info.json",
@@ -1375,19 +1375,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/069",
+      "id": "http://localhost:8080/iiif/rotating/canvas/069",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/069/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/069/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/069/annotation-page/069",
+              "id": "http://localhost:8080/iiif/rotating/canvas/069/annotation-page/069",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/069",
+              "target": "http://localhost:8080/iiif/rotating/canvas/069",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/069/tiles/info.json",
@@ -1415,19 +1415,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/071",
+      "id": "http://localhost:8080/iiif/rotating/canvas/071",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/071/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/071/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/071/annotation-page/071",
+              "id": "http://localhost:8080/iiif/rotating/canvas/071/annotation-page/071",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/071",
+              "target": "http://localhost:8080/iiif/rotating/canvas/071",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/071/tiles/info.json",
@@ -1455,19 +1455,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/073",
+      "id": "http://localhost:8080/iiif/rotating/canvas/073",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/073/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/073/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/073/annotation-page/073",
+              "id": "http://localhost:8080/iiif/rotating/canvas/073/annotation-page/073",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/073",
+              "target": "http://localhost:8080/iiif/rotating/canvas/073",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/073/tiles/info.json",
@@ -1495,19 +1495,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/075",
+      "id": "http://localhost:8080/iiif/rotating/canvas/075",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/075/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/075/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/075/annotation-page/075",
+              "id": "http://localhost:8080/iiif/rotating/canvas/075/annotation-page/075",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/075",
+              "target": "http://localhost:8080/iiif/rotating/canvas/075",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/075/tiles/info.json",
@@ -1535,19 +1535,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/077",
+      "id": "http://localhost:8080/iiif/rotating/canvas/077",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/077/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/077/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/077/annotation-page/077",
+              "id": "http://localhost:8080/iiif/rotating/canvas/077/annotation-page/077",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/077",
+              "target": "http://localhost:8080/iiif/rotating/canvas/077",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/077/tiles/info.json",
@@ -1575,19 +1575,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/079",
+      "id": "http://localhost:8080/iiif/rotating/canvas/079",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/079/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/079/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/079/annotation-page/079",
+              "id": "http://localhost:8080/iiif/rotating/canvas/079/annotation-page/079",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/079",
+              "target": "http://localhost:8080/iiif/rotating/canvas/079",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/079/tiles/info.json",
@@ -1615,19 +1615,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/081",
+      "id": "http://localhost:8080/iiif/rotating/canvas/081",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/081/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/081/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/081/annotation-page/081",
+              "id": "http://localhost:8080/iiif/rotating/canvas/081/annotation-page/081",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/081",
+              "target": "http://localhost:8080/iiif/rotating/canvas/081",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/081/tiles/info.json",
@@ -1655,19 +1655,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/083",
+      "id": "http://localhost:8080/iiif/rotating/canvas/083",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/083/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/083/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/083/annotation-page/083",
+              "id": "http://localhost:8080/iiif/rotating/canvas/083/annotation-page/083",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/083",
+              "target": "http://localhost:8080/iiif/rotating/canvas/083",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/083/tiles/info.json",
@@ -1695,19 +1695,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/085",
+      "id": "http://localhost:8080/iiif/rotating/canvas/085",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/085/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/085/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/085/annotation-page/085",
+              "id": "http://localhost:8080/iiif/rotating/canvas/085/annotation-page/085",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/085",
+              "target": "http://localhost:8080/iiif/rotating/canvas/085",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/085/tiles/info.json",
@@ -1735,19 +1735,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/087",
+      "id": "http://localhost:8080/iiif/rotating/canvas/087",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/087/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/087/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/087/annotation-page/087",
+              "id": "http://localhost:8080/iiif/rotating/canvas/087/annotation-page/087",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/087",
+              "target": "http://localhost:8080/iiif/rotating/canvas/087",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/087/tiles/info.json",
@@ -1775,19 +1775,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/089",
+      "id": "http://localhost:8080/iiif/rotating/canvas/089",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/089/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/089/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/089/annotation-page/089",
+              "id": "http://localhost:8080/iiif/rotating/canvas/089/annotation-page/089",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/089",
+              "target": "http://localhost:8080/iiif/rotating/canvas/089",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/089/tiles/info.json",
@@ -1815,19 +1815,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/091",
+      "id": "http://localhost:8080/iiif/rotating/canvas/091",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/091/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/091/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/091/annotation-page/091",
+              "id": "http://localhost:8080/iiif/rotating/canvas/091/annotation-page/091",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/091",
+              "target": "http://localhost:8080/iiif/rotating/canvas/091",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/091/tiles/info.json",
@@ -1855,19 +1855,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/093",
+      "id": "http://localhost:8080/iiif/rotating/canvas/093",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/093/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/093/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/093/annotation-page/093",
+              "id": "http://localhost:8080/iiif/rotating/canvas/093/annotation-page/093",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/093",
+              "target": "http://localhost:8080/iiif/rotating/canvas/093",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/093/tiles/info.json",
@@ -1895,19 +1895,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/095",
+      "id": "http://localhost:8080/iiif/rotating/canvas/095",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/095/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/095/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/095/annotation-page/095",
+              "id": "http://localhost:8080/iiif/rotating/canvas/095/annotation-page/095",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/095",
+              "target": "http://localhost:8080/iiif/rotating/canvas/095",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/095/tiles/info.json",
@@ -1935,19 +1935,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/097",
+      "id": "http://localhost:8080/iiif/rotating/canvas/097",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/097/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/097/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/097/annotation-page/097",
+              "id": "http://localhost:8080/iiif/rotating/canvas/097/annotation-page/097",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/097",
+              "target": "http://localhost:8080/iiif/rotating/canvas/097",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/097/tiles/info.json",
@@ -1975,19 +1975,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/099",
+      "id": "http://localhost:8080/iiif/rotating/canvas/099",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/099/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/099/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/099/annotation-page/099",
+              "id": "http://localhost:8080/iiif/rotating/canvas/099/annotation-page/099",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/099",
+              "target": "http://localhost:8080/iiif/rotating/canvas/099",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/099/tiles/info.json",
@@ -2015,19 +2015,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/101",
+      "id": "http://localhost:8080/iiif/rotating/canvas/101",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/101/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/101/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/101/annotation-page/101",
+              "id": "http://localhost:8080/iiif/rotating/canvas/101/annotation-page/101",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/101",
+              "target": "http://localhost:8080/iiif/rotating/canvas/101",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/101/tiles/info.json",
@@ -2055,19 +2055,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/103",
+      "id": "http://localhost:8080/iiif/rotating/canvas/103",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/103/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/103/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/103/annotation-page/103",
+              "id": "http://localhost:8080/iiif/rotating/canvas/103/annotation-page/103",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/103",
+              "target": "http://localhost:8080/iiif/rotating/canvas/103",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/103/tiles/info.json",
@@ -2095,19 +2095,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/105",
+      "id": "http://localhost:8080/iiif/rotating/canvas/105",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/105/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/105/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/105/annotation-page/105",
+              "id": "http://localhost:8080/iiif/rotating/canvas/105/annotation-page/105",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/105",
+              "target": "http://localhost:8080/iiif/rotating/canvas/105",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/105/tiles/info.json",
@@ -2135,19 +2135,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/107",
+      "id": "http://localhost:8080/iiif/rotating/canvas/107",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/107/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/107/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/107/annotation-page/107",
+              "id": "http://localhost:8080/iiif/rotating/canvas/107/annotation-page/107",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/107",
+              "target": "http://localhost:8080/iiif/rotating/canvas/107",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/107/tiles/info.json",
@@ -2175,19 +2175,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/109",
+      "id": "http://localhost:8080/iiif/rotating/canvas/109",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/109/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/109/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/109/annotation-page/109",
+              "id": "http://localhost:8080/iiif/rotating/canvas/109/annotation-page/109",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/109",
+              "target": "http://localhost:8080/iiif/rotating/canvas/109",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/109/tiles/info.json",
@@ -2215,19 +2215,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/111",
+      "id": "http://localhost:8080/iiif/rotating/canvas/111",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/111/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/111/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/111/annotation-page/111",
+              "id": "http://localhost:8080/iiif/rotating/canvas/111/annotation-page/111",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/111",
+              "target": "http://localhost:8080/iiif/rotating/canvas/111",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/111/tiles/info.json",
@@ -2255,19 +2255,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/113",
+      "id": "http://localhost:8080/iiif/rotating/canvas/113",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/113/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/113/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/113/annotation-page/113",
+              "id": "http://localhost:8080/iiif/rotating/canvas/113/annotation-page/113",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/113",
+              "target": "http://localhost:8080/iiif/rotating/canvas/113",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/113/tiles/info.json",
@@ -2295,19 +2295,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/115",
+      "id": "http://localhost:8080/iiif/rotating/canvas/115",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/115/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/115/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/115/annotation-page/115",
+              "id": "http://localhost:8080/iiif/rotating/canvas/115/annotation-page/115",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/115",
+              "target": "http://localhost:8080/iiif/rotating/canvas/115",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/115/tiles/info.json",
@@ -2335,19 +2335,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/117",
+      "id": "http://localhost:8080/iiif/rotating/canvas/117",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/117/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/117/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/117/annotation-page/117",
+              "id": "http://localhost:8080/iiif/rotating/canvas/117/annotation-page/117",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/117",
+              "target": "http://localhost:8080/iiif/rotating/canvas/117",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/117/tiles/info.json",
@@ -2375,19 +2375,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/119",
+      "id": "http://localhost:8080/iiif/rotating/canvas/119",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/119/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/119/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/119/annotation-page/119",
+              "id": "http://localhost:8080/iiif/rotating/canvas/119/annotation-page/119",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/119",
+              "target": "http://localhost:8080/iiif/rotating/canvas/119",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/119/tiles/info.json",
@@ -2415,19 +2415,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/121",
+      "id": "http://localhost:8080/iiif/rotating/canvas/121",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/121/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/121/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/121/annotation-page/121",
+              "id": "http://localhost:8080/iiif/rotating/canvas/121/annotation-page/121",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/121",
+              "target": "http://localhost:8080/iiif/rotating/canvas/121",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/121/tiles/info.json",
@@ -2455,19 +2455,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/123",
+      "id": "http://localhost:8080/iiif/rotating/canvas/123",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/123/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/123/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/123/annotation-page/123",
+              "id": "http://localhost:8080/iiif/rotating/canvas/123/annotation-page/123",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/123",
+              "target": "http://localhost:8080/iiif/rotating/canvas/123",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/123/tiles/info.json",
@@ -2495,19 +2495,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/125",
+      "id": "http://localhost:8080/iiif/rotating/canvas/125",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/125/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/125/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/125/annotation-page/125",
+              "id": "http://localhost:8080/iiif/rotating/canvas/125/annotation-page/125",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/125",
+              "target": "http://localhost:8080/iiif/rotating/canvas/125",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/125/tiles/info.json",
@@ -2535,19 +2535,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/127",
+      "id": "http://localhost:8080/iiif/rotating/canvas/127",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/127/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/127/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/127/annotation-page/127",
+              "id": "http://localhost:8080/iiif/rotating/canvas/127/annotation-page/127",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/127",
+              "target": "http://localhost:8080/iiif/rotating/canvas/127",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/127/tiles/info.json",
@@ -2575,19 +2575,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/129",
+      "id": "http://localhost:8080/iiif/rotating/canvas/129",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/129/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/129/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/129/annotation-page/129",
+              "id": "http://localhost:8080/iiif/rotating/canvas/129/annotation-page/129",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/129",
+              "target": "http://localhost:8080/iiif/rotating/canvas/129",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/129/tiles/info.json",
@@ -2615,19 +2615,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/131",
+      "id": "http://localhost:8080/iiif/rotating/canvas/131",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/131/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/131/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/131/annotation-page/131",
+              "id": "http://localhost:8080/iiif/rotating/canvas/131/annotation-page/131",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/131",
+              "target": "http://localhost:8080/iiif/rotating/canvas/131",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/131/tiles/info.json",
@@ -2655,19 +2655,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/133",
+      "id": "http://localhost:8080/iiif/rotating/canvas/133",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/133/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/133/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/133/annotation-page/133",
+              "id": "http://localhost:8080/iiif/rotating/canvas/133/annotation-page/133",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/133",
+              "target": "http://localhost:8080/iiif/rotating/canvas/133",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/133/tiles/info.json",
@@ -2695,19 +2695,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/135",
+      "id": "http://localhost:8080/iiif/rotating/canvas/135",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/135/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/135/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/135/annotation-page/135",
+              "id": "http://localhost:8080/iiif/rotating/canvas/135/annotation-page/135",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/135",
+              "target": "http://localhost:8080/iiif/rotating/canvas/135",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/135/tiles/info.json",
@@ -2735,19 +2735,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/137",
+      "id": "http://localhost:8080/iiif/rotating/canvas/137",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/137/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/137/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/137/annotation-page/137",
+              "id": "http://localhost:8080/iiif/rotating/canvas/137/annotation-page/137",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/137",
+              "target": "http://localhost:8080/iiif/rotating/canvas/137",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/137/tiles/info.json",
@@ -2775,19 +2775,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/139",
+      "id": "http://localhost:8080/iiif/rotating/canvas/139",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/139/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/139/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/139/annotation-page/139",
+              "id": "http://localhost:8080/iiif/rotating/canvas/139/annotation-page/139",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/139",
+              "target": "http://localhost:8080/iiif/rotating/canvas/139",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/139/tiles/info.json",
@@ -2815,19 +2815,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/141",
+      "id": "http://localhost:8080/iiif/rotating/canvas/141",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/141/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/141/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/141/annotation-page/141",
+              "id": "http://localhost:8080/iiif/rotating/canvas/141/annotation-page/141",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/141",
+              "target": "http://localhost:8080/iiif/rotating/canvas/141",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/141/tiles/info.json",
@@ -2855,19 +2855,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/143",
+      "id": "http://localhost:8080/iiif/rotating/canvas/143",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/143/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/143/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/143/annotation-page/143",
+              "id": "http://localhost:8080/iiif/rotating/canvas/143/annotation-page/143",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/143",
+              "target": "http://localhost:8080/iiif/rotating/canvas/143",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/143/tiles/info.json",
@@ -2895,19 +2895,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/145",
+      "id": "http://localhost:8080/iiif/rotating/canvas/145",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/145/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/145/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/145/annotation-page/145",
+              "id": "http://localhost:8080/iiif/rotating/canvas/145/annotation-page/145",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/145",
+              "target": "http://localhost:8080/iiif/rotating/canvas/145",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/145/tiles/info.json",
@@ -2935,19 +2935,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/147",
+      "id": "http://localhost:8080/iiif/rotating/canvas/147",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/147/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/147/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/147/annotation-page/147",
+              "id": "http://localhost:8080/iiif/rotating/canvas/147/annotation-page/147",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/147",
+              "target": "http://localhost:8080/iiif/rotating/canvas/147",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/147/tiles/info.json",
@@ -2975,19 +2975,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/149",
+      "id": "http://localhost:8080/iiif/rotating/canvas/149",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/149/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/149/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/149/annotation-page/149",
+              "id": "http://localhost:8080/iiif/rotating/canvas/149/annotation-page/149",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/149",
+              "target": "http://localhost:8080/iiif/rotating/canvas/149",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/149/tiles/info.json",
@@ -3015,19 +3015,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/151",
+      "id": "http://localhost:8080/iiif/rotating/canvas/151",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/151/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/151/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/151/annotation-page/151",
+              "id": "http://localhost:8080/iiif/rotating/canvas/151/annotation-page/151",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/151",
+              "target": "http://localhost:8080/iiif/rotating/canvas/151",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/151/tiles/info.json",
@@ -3055,19 +3055,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/153",
+      "id": "http://localhost:8080/iiif/rotating/canvas/153",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/153/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/153/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/153/annotation-page/153",
+              "id": "http://localhost:8080/iiif/rotating/canvas/153/annotation-page/153",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/153",
+              "target": "http://localhost:8080/iiif/rotating/canvas/153",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/153/tiles/info.json",
@@ -3095,19 +3095,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/155",
+      "id": "http://localhost:8080/iiif/rotating/canvas/155",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/155/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/155/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/155/annotation-page/155",
+              "id": "http://localhost:8080/iiif/rotating/canvas/155/annotation-page/155",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/155",
+              "target": "http://localhost:8080/iiif/rotating/canvas/155",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/155/tiles/info.json",
@@ -3135,19 +3135,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/157",
+      "id": "http://localhost:8080/iiif/rotating/canvas/157",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/157/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/157/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/157/annotation-page/157",
+              "id": "http://localhost:8080/iiif/rotating/canvas/157/annotation-page/157",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/157",
+              "target": "http://localhost:8080/iiif/rotating/canvas/157",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/157/tiles/info.json",
@@ -3175,19 +3175,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/159",
+      "id": "http://localhost:8080/iiif/rotating/canvas/159",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/159/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/159/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/159/annotation-page/159",
+              "id": "http://localhost:8080/iiif/rotating/canvas/159/annotation-page/159",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/159",
+              "target": "http://localhost:8080/iiif/rotating/canvas/159",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/159/tiles/info.json",
@@ -3215,19 +3215,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/161",
+      "id": "http://localhost:8080/iiif/rotating/canvas/161",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/161/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/161/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/161/annotation-page/161",
+              "id": "http://localhost:8080/iiif/rotating/canvas/161/annotation-page/161",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/161",
+              "target": "http://localhost:8080/iiif/rotating/canvas/161",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/161/tiles/info.json",
@@ -3255,19 +3255,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/163",
+      "id": "http://localhost:8080/iiif/rotating/canvas/163",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/163/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/163/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/163/annotation-page/163",
+              "id": "http://localhost:8080/iiif/rotating/canvas/163/annotation-page/163",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/163",
+              "target": "http://localhost:8080/iiif/rotating/canvas/163",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/163/tiles/info.json",
@@ -3295,19 +3295,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/165",
+      "id": "http://localhost:8080/iiif/rotating/canvas/165",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/165/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/165/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/165/annotation-page/165",
+              "id": "http://localhost:8080/iiif/rotating/canvas/165/annotation-page/165",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/165",
+              "target": "http://localhost:8080/iiif/rotating/canvas/165",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/165/tiles/info.json",
@@ -3335,19 +3335,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/167",
+      "id": "http://localhost:8080/iiif/rotating/canvas/167",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/167/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/167/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/167/annotation-page/167",
+              "id": "http://localhost:8080/iiif/rotating/canvas/167/annotation-page/167",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/167",
+              "target": "http://localhost:8080/iiif/rotating/canvas/167",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/167/tiles/info.json",
@@ -3375,19 +3375,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/169",
+      "id": "http://localhost:8080/iiif/rotating/canvas/169",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/169/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/169/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/169/annotation-page/169",
+              "id": "http://localhost:8080/iiif/rotating/canvas/169/annotation-page/169",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/169",
+              "target": "http://localhost:8080/iiif/rotating/canvas/169",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/169/tiles/info.json",
@@ -3415,19 +3415,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/171",
+      "id": "http://localhost:8080/iiif/rotating/canvas/171",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/171/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/171/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/171/annotation-page/171",
+              "id": "http://localhost:8080/iiif/rotating/canvas/171/annotation-page/171",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/171",
+              "target": "http://localhost:8080/iiif/rotating/canvas/171",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/171/tiles/info.json",
@@ -3455,19 +3455,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/173",
+      "id": "http://localhost:8080/iiif/rotating/canvas/173",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/173/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/173/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/173/annotation-page/173",
+              "id": "http://localhost:8080/iiif/rotating/canvas/173/annotation-page/173",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/173",
+              "target": "http://localhost:8080/iiif/rotating/canvas/173",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/173/tiles/info.json",
@@ -3495,19 +3495,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/175",
+      "id": "http://localhost:8080/iiif/rotating/canvas/175",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/175/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/175/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/175/annotation-page/175",
+              "id": "http://localhost:8080/iiif/rotating/canvas/175/annotation-page/175",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/175",
+              "target": "http://localhost:8080/iiif/rotating/canvas/175",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/175/tiles/info.json",
@@ -3535,19 +3535,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/177",
+      "id": "http://localhost:8080/iiif/rotating/canvas/177",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/177/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/177/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/177/annotation-page/177",
+              "id": "http://localhost:8080/iiif/rotating/canvas/177/annotation-page/177",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/177",
+              "target": "http://localhost:8080/iiif/rotating/canvas/177",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/177/tiles/info.json",
@@ -3575,19 +3575,19 @@
       ]
     },
     {
-      "id": "http:/localhost:8080/iiif/rotating/canvas/179",
+      "id": "http://localhost:8080/iiif/rotating/canvas/179",
       "type": "Canvas",
       "height": 2160,
       "width": 1827,
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/179/annotation-page",
+          "id": "http://localhost:8080/iiif/rotating/canvas/179/annotation-page",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http:/localhost:8080/iiif/rotating/canvas/179/annotation-page/179",
+              "id": "http://localhost:8080/iiif/rotating/canvas/179/annotation-page/179",
               "motivation": "painting",
-              "target": "http:/localhost:8080/iiif/rotating/canvas/179",
+              "target": "http://localhost:8080/iiif/rotating/canvas/179",
               "type": "Annotation",
               "body": {
                 "id": "http://localhost:8080/iiif/rotating/179/tiles/info.json",
@@ -3617,366 +3617,366 @@
   ],
   "structures": [
     {
-      "id": "http:/localhost:8080/iiif/rotating/ranges/0",
+      "id": "http://localhost:8080/iiif/rotating/ranges/0",
       "items": [
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/001",
+          "id": "http://localhost:8080/iiif/rotating/canvas/001",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/003",
+          "id": "http://localhost:8080/iiif/rotating/canvas/003",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/005",
+          "id": "http://localhost:8080/iiif/rotating/canvas/005",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/007",
+          "id": "http://localhost:8080/iiif/rotating/canvas/007",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/009",
+          "id": "http://localhost:8080/iiif/rotating/canvas/009",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/011",
+          "id": "http://localhost:8080/iiif/rotating/canvas/011",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/013",
+          "id": "http://localhost:8080/iiif/rotating/canvas/013",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/015",
+          "id": "http://localhost:8080/iiif/rotating/canvas/015",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/017",
+          "id": "http://localhost:8080/iiif/rotating/canvas/017",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/019",
+          "id": "http://localhost:8080/iiif/rotating/canvas/019",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/021",
+          "id": "http://localhost:8080/iiif/rotating/canvas/021",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/023",
+          "id": "http://localhost:8080/iiif/rotating/canvas/023",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/025",
+          "id": "http://localhost:8080/iiif/rotating/canvas/025",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/027",
+          "id": "http://localhost:8080/iiif/rotating/canvas/027",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/029",
+          "id": "http://localhost:8080/iiif/rotating/canvas/029",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/031",
+          "id": "http://localhost:8080/iiif/rotating/canvas/031",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/033",
+          "id": "http://localhost:8080/iiif/rotating/canvas/033",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/035",
+          "id": "http://localhost:8080/iiif/rotating/canvas/035",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/037",
+          "id": "http://localhost:8080/iiif/rotating/canvas/037",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/039",
+          "id": "http://localhost:8080/iiif/rotating/canvas/039",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/041",
+          "id": "http://localhost:8080/iiif/rotating/canvas/041",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/043",
+          "id": "http://localhost:8080/iiif/rotating/canvas/043",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/045",
+          "id": "http://localhost:8080/iiif/rotating/canvas/045",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/047",
+          "id": "http://localhost:8080/iiif/rotating/canvas/047",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/049",
+          "id": "http://localhost:8080/iiif/rotating/canvas/049",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/051",
+          "id": "http://localhost:8080/iiif/rotating/canvas/051",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/053",
+          "id": "http://localhost:8080/iiif/rotating/canvas/053",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/055",
+          "id": "http://localhost:8080/iiif/rotating/canvas/055",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/057",
+          "id": "http://localhost:8080/iiif/rotating/canvas/057",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/059",
+          "id": "http://localhost:8080/iiif/rotating/canvas/059",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/061",
+          "id": "http://localhost:8080/iiif/rotating/canvas/061",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/063",
+          "id": "http://localhost:8080/iiif/rotating/canvas/063",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/065",
+          "id": "http://localhost:8080/iiif/rotating/canvas/065",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/067",
+          "id": "http://localhost:8080/iiif/rotating/canvas/067",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/069",
+          "id": "http://localhost:8080/iiif/rotating/canvas/069",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/071",
+          "id": "http://localhost:8080/iiif/rotating/canvas/071",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/073",
+          "id": "http://localhost:8080/iiif/rotating/canvas/073",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/075",
+          "id": "http://localhost:8080/iiif/rotating/canvas/075",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/077",
+          "id": "http://localhost:8080/iiif/rotating/canvas/077",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/079",
+          "id": "http://localhost:8080/iiif/rotating/canvas/079",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/081",
+          "id": "http://localhost:8080/iiif/rotating/canvas/081",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/083",
+          "id": "http://localhost:8080/iiif/rotating/canvas/083",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/085",
+          "id": "http://localhost:8080/iiif/rotating/canvas/085",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/087",
+          "id": "http://localhost:8080/iiif/rotating/canvas/087",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/089",
+          "id": "http://localhost:8080/iiif/rotating/canvas/089",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/091",
+          "id": "http://localhost:8080/iiif/rotating/canvas/091",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/093",
+          "id": "http://localhost:8080/iiif/rotating/canvas/093",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/095",
+          "id": "http://localhost:8080/iiif/rotating/canvas/095",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/097",
+          "id": "http://localhost:8080/iiif/rotating/canvas/097",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/099",
+          "id": "http://localhost:8080/iiif/rotating/canvas/099",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/101",
+          "id": "http://localhost:8080/iiif/rotating/canvas/101",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/103",
+          "id": "http://localhost:8080/iiif/rotating/canvas/103",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/105",
+          "id": "http://localhost:8080/iiif/rotating/canvas/105",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/107",
+          "id": "http://localhost:8080/iiif/rotating/canvas/107",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/109",
+          "id": "http://localhost:8080/iiif/rotating/canvas/109",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/111",
+          "id": "http://localhost:8080/iiif/rotating/canvas/111",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/113",
+          "id": "http://localhost:8080/iiif/rotating/canvas/113",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/115",
+          "id": "http://localhost:8080/iiif/rotating/canvas/115",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/117",
+          "id": "http://localhost:8080/iiif/rotating/canvas/117",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/119",
+          "id": "http://localhost:8080/iiif/rotating/canvas/119",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/121",
+          "id": "http://localhost:8080/iiif/rotating/canvas/121",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/123",
+          "id": "http://localhost:8080/iiif/rotating/canvas/123",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/125",
+          "id": "http://localhost:8080/iiif/rotating/canvas/125",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/127",
+          "id": "http://localhost:8080/iiif/rotating/canvas/127",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/129",
+          "id": "http://localhost:8080/iiif/rotating/canvas/129",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/131",
+          "id": "http://localhost:8080/iiif/rotating/canvas/131",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/133",
+          "id": "http://localhost:8080/iiif/rotating/canvas/133",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/135",
+          "id": "http://localhost:8080/iiif/rotating/canvas/135",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/137",
+          "id": "http://localhost:8080/iiif/rotating/canvas/137",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/139",
+          "id": "http://localhost:8080/iiif/rotating/canvas/139",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/141",
+          "id": "http://localhost:8080/iiif/rotating/canvas/141",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/143",
+          "id": "http://localhost:8080/iiif/rotating/canvas/143",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/145",
+          "id": "http://localhost:8080/iiif/rotating/canvas/145",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/147",
+          "id": "http://localhost:8080/iiif/rotating/canvas/147",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/149",
+          "id": "http://localhost:8080/iiif/rotating/canvas/149",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/151",
+          "id": "http://localhost:8080/iiif/rotating/canvas/151",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/153",
+          "id": "http://localhost:8080/iiif/rotating/canvas/153",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/155",
+          "id": "http://localhost:8080/iiif/rotating/canvas/155",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/157",
+          "id": "http://localhost:8080/iiif/rotating/canvas/157",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/159",
+          "id": "http://localhost:8080/iiif/rotating/canvas/159",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/161",
+          "id": "http://localhost:8080/iiif/rotating/canvas/161",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/163",
+          "id": "http://localhost:8080/iiif/rotating/canvas/163",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/165",
+          "id": "http://localhost:8080/iiif/rotating/canvas/165",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/167",
+          "id": "http://localhost:8080/iiif/rotating/canvas/167",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/169",
+          "id": "http://localhost:8080/iiif/rotating/canvas/169",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/171",
+          "id": "http://localhost:8080/iiif/rotating/canvas/171",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/173",
+          "id": "http://localhost:8080/iiif/rotating/canvas/173",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/175",
+          "id": "http://localhost:8080/iiif/rotating/canvas/175",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/177",
+          "id": "http://localhost:8080/iiif/rotating/canvas/177",
           "type": "Canvas"
         },
         {
-          "id": "http:/localhost:8080/iiif/rotating/canvas/179",
+          "id": "http://localhost:8080/iiif/rotating/canvas/179",
           "type": "Canvas"
         }
       ],

--- a/packages/11ty/_plugins/figures/test/figures.spec.js
+++ b/packages/11ty/_plugins/figures/test/figures.spec.js
@@ -48,33 +48,34 @@ const createManifestFromFigureFixture = async (figureFixtureName) => {
 describe('validating manifests via deepStrictEqual', () => {
   test('figure with checkbox annotations creates a valid manifest', async () => {
     const { manifestFixture, manifestJson } = await createManifestFromFigureFixture('annotationsCheckbox')
-    assert.deepStrictEqual(manifestFixture, manifestJson)
+    assert.deepStrictEqual(manifestJson, manifestFixture)
   })
 
   test('figure with radio annotations creates a valid manifest', async () => {
     const { manifestFixture, manifestJson } = await createManifestFromFigureFixture('annotationsRadio')
-    assert.deepStrictEqual(manifestFixture, manifestJson)
+    assert.deepStrictEqual(manifestJson, manifestFixture)
   })
 
   test('sequence figure creates a valid manifest', async () => {
     const { manifestFixture, manifestJson } = await createManifestFromFigureFixture('sequence')
-    assert.deepStrictEqual(manifestFixture, manifestJson)
+    assert.deepStrictEqual(manifestJson, manifestFixture)
   })
 
   test('sequence figure with annotations creates a valid manifest', async () => {
     const { manifestFixture, manifestJson } = await createManifestFromFigureFixture('sequenceWithAnnotations')
-    assert.deepStrictEqual(manifestFixture, manifestJson)
+    console.log(manifestJson.structures)
+    assert.deepStrictEqual(manifestJson, manifestFixture)
   })
 
   test('zoomable figure creates a valid manifest', async () => {
     const { manifestFixture, manifestJson } = await createManifestFromFigureFixture('zoomable')
-    assert.deepStrictEqual(manifestFixture, manifestJson)
+    assert.deepStrictEqual(manifestJson, manifestFixture)
   })
 
   /* Skipping this test, since we are currently overriding zoom on all sequence manifests */
   test('zoomable sequence figure creates a valid manifest', { skip: true }, async () => {
     const { manifestFixture, manifestJson } = await createManifestFromFigureFixture('zoomableSequence')
-    assert.deepStrictEqual(manifestFixture, manifestJson)
+    assert.deepStrictEqual(manifestJson, manifestFixture)
   })
 })
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "docs": "jsdoc2md --configure jsdoc.json --files src/**/*.js > docs/cli.md",
     "lint": "eslint src --ext .js",
     "lint:fix": "npm run lint -- --fix",
-    "postinstall": "cross-env patch-package --error-on-fail",
     "test": "echo \"No test specified\" && exit 0"
   },
   "imports": {
@@ -61,14 +60,12 @@
     "hosted-git-info": "^6.1.1",
     "i18next": "^22.4.9",
     "inquirer": "^9.1.4",
-    "install-npm-version": "^1.0.9",
     "js-yaml": "^4.1.0",
     "loglevel": "^1.8.1",
     "node-fetch": "^3.3.2",
     "open": "^8.4.0",
     "ora": "^6.1.2",
     "pagedjs-cli": "^0.4.3",
-    "patch-package": "^8.0.0",
     "read-package-up": "^11.0.0",
     "semver": "^7.3.8",
     "simple-git": "^3.16.0",

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -72,13 +72,7 @@ export default class CreateCommand extends Command {
         return
       }
 
-      options.eject = true
-
-      if (options.eject) {
-        await quire.installInProject(projectPath, quireVersion, options)
-      } else {
-        await quire.install(options)
-      }
+      await quire.installInProject(projectPath, quireVersion, options)
     }
   }
 }

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -148,51 +148,6 @@ async function initStarter (starter, projectPath, options) {
 }
 
 /**
- * Install quire-11ty (default to 'latest' version)
- *
- * @TODO refactor this to be callable by the installInProject method
- *
- * @param  {Object}  options  options passed from `quire new` command
- * @return  {Promise}
- */
-async function install(options = {}) {
-  const version = options.quireVersion || QUIRE_VERSION
-  console.debug(`[CLI:quire] installing quire-11ty@${version}`)
-  const absoluteInstallPath = path.join(__dirname, 'versions')
-  fs.ensureDirSync(absoluteInstallPath)
-  /**
-   * `Destination` is relative to `node_modules` of the working-directory
-   * so we have included a relative path to parent directory in order to
-   * install versions to a different local path.
-   * @see https://github.com/scott-lin/install-npm-version
-   */
-  const installOptions = {
-    Destination: path.join('..', version),
-    Debug: false,
-    Overwrite: options.force || options.overwrite || false,
-    Verbosity: options.debug ? 'Debug' : 'Silent',
-    WorkingDirectory: absoluteInstallPath
-  }
-  await inv.Install(`${PACKAGE_NAME}@${version}`, installOptions)
-
-  // delete empty `node_modules` directory that `install-npm-version` creates
-  const invNodeModulesDir = path.join(absoluteInstallPath, 'node_modules')
-  if (fs.existsSync(invNodeModulesDir)) fs.rmdir(invNodeModulesDir)
-
-  symlinkLatest()
-
-  console.debug('[CLI:quire] installing dev dependencies')
-  /**
-   * Manually install necessary dev dependencies to run 11ty;
-   * these must be `devDependencies` so that they are not bundled into
-   * the final `_site` package when running `quire build`
-   */
-  chdir(path.join(absoluteInstallPath, version))
-  await execaCommand('npm cache clean --force')
-  await execaCommand('npm install --save-dev')
-}
-
-/**
  * Install `quire-11ty` directly into a quire project
  *
  * @TODO refactor this to use the install method with pre and post-install hooks
@@ -375,19 +330,6 @@ function symlinkLatest() {
 }
 
 /**
- * Tests if a `quire-11ty` version is already installed
- * and installs the version if it is not already installed.
- *
- * @param  {String}  version  `quire-11ty` semantic version
- */
-function testVersion(version) {
-  version ||= getVersion()
-  if (!versions.includes(version)) {
-    install(version)
-  }
-}
-
-/**
  * Get an array of published `quire-11ty` package versions
  *
  * @return  {Array<String>}  published versions
@@ -400,12 +342,10 @@ export const quire = {
   getPath,
   getVersion,
   initStarter,
-  install,
   installInProject,
   latest,
   list,
   remove,
   setVersion,
-  testVersion,
   versions,
 }

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -220,12 +220,10 @@ async function installInProject(projectPath, quireVersion, options = {}) {
     .catch((error) => console.error('[CLI:error] ', error))
 
   const temp11tyDirectory = '.temp'
-  // TODO: What to do with options.force, options.overwrite?
-
   const tempDir = path.join(projectPath,temp11tyDirectory)
   fs.mkdirSync(tempDir)
 
-  // Copy the 11ty path or download the tarball from the package spec and unpack it 
+  // Copy if passed a path and it exists, otherwise attempt to download the tarball for this pathspec
   if (fs.existsSync(quirePath)) {
     fs.copySync(quirePath, tempDir)
   } else {


### PR DESCRIPTION
This PR corrects URIs in IIIF manifests, which had been failing on all platforms and had additional platform-specific failures for Windows.