### PR TITLE
Fix inclusion of SVG icons in PDF output

### DIFF
--- a/packages/11ty/_layouts/pdf.liquid
+++ b/packages/11ty/_layouts/pdf.liquid
@@ -17,10 +17,10 @@
   `pages` is an array of `section` elements from each PDF-having page in the publication.
   {% endcomment %}
 
+  {% icons %}
+  {% iconscc %}
+
   {% for page in pages %}
-    {% if forloop.first == true %}
-      {{ page.svgElements }}
-    {% endif %}
     {{ page.sectionElement }}
   {% endfor %}
 

--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -219,7 +219,6 @@ export default function (eleventyConfig, collections, content) {
 
   const { document } = new JSDOM(content).window
   const mainElement = document.querySelector('main[data-output-path]')
-  const svgSymbolElements = document.querySelectorAll('body > svg')
   const pageIndex = pdfPages.findIndex((path) => path === this.outputPath)
 
   // Returning content allows subsequent transforms to process it unmodified
@@ -254,7 +253,6 @@ export default function (eleventyConfig, collections, content) {
   trimLeadingSeparator(sectionElement)
   slugifyIds(sectionElement)
 
-  collections.pdf[pageIndex].svgSymbolElements = Array.from(svgSymbolElements).map(el => el.outerHTML)
   collections.pdf[pageIndex].sectionElement = sectionElement.outerHTML
 
   if (hasPagePDF && hasCoverPage) {

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -30,9 +30,7 @@ export default function (eleventyConfig) {
    * Render the PDF pages in a liquid layout that merges them into one file
    * Do the same for covers of the PDF pages.
    *
-   * NB: layout will only add SVG symbols once
-   *
-   * @param  {Object} collection collections.pdf with `sectionElement`,`svgElements`, and `coverPageData`
+   * @param  {Object} collection collections.pdf with `sectionElement` and `coverPageData`
    */
   return async (collection) => {
     const publicationHtml = await eleventyConfig.javascript.shortcodes.renderFile(pdfTemplatePath, { pages: collection }, 'liquid')


### PR DESCRIPTION
SVG icons were not being included properly in the PDF output due to a naming issue: Quire was creating `svgSymbolElements` in `_plugins/transforms/outputs/pdf/transform.js` but then calling for `svgElements` in `_layouts/pdf.liquid`. Rather than fixing the naming though, SVG icons can simply be added to the PDF layout directly, without need of the extra logic. This PR does that.