### PR TITLE
Fix PDF building on CI / CD host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.5.3
+  browser-tools: circleci/browser-tools@2.1.2
   cypress: cypress-io/cypress@3.4.3
   mac: circleci/macos@2.5.2
   node: circleci/node@7.1.0
@@ -15,13 +15,20 @@ executors:
     docker:
       - image: cimg/base:current-22.04
         user: root
+    environment:
+        PUPPETEER_EXECUTABLE_PATH: '/usr/bin/google-chrome-stable'
+
   macos:
     macos:
       xcode: '16.2.0'
+    environment:
+        PUPPETEER_EXECUTABLE_PATH: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
   win: 
     machine:
       image: windows-server-2019-vs2019:current
       resource_class: windows.medium
+    environment:
+        PUPPETEER_EXECUTABLE_PATH: 'C:\Program Files\Google\Chrome\Application\chrome.exe'
 
 anchors:
 
@@ -55,17 +62,23 @@ commands:
     steps:
       - node/install:
           node-version: "22.14.0"
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install_chrome
+      # @TODO: Replace this hack that force-disables sandboxing
+      # 
+      # On linux chrome requires disabling sandboxing (or using deprecated suid containers) if run as root
+      # See https://pptr.dev/troubleshooting#setting-up-chrome-linux-sandbox
+      - run:
+          name: "Modify chrome app"
+          command: sudo sed -i 's|HERE/chrome"|HERE/chrome" --no-sandbox|g' /opt/google/chrome/google-chrome
+      - browser-tools/install_chromedriver
       - build_install_cli
 
   build_install_cli-macos:
     steps:
       - node/install:
           node-version: "22.14.0"
-      - browser-tools/install-chrome:
-          chrome-version: 115.0.5790.98
-      - browser-tools/install-chromedriver      
+      - browser-tools/install_chrome
+      - browser-tools/install_chromedriver      
       - build_install_cli
 
   build_install_cli-win:
@@ -133,10 +146,6 @@ commands:
 
   test-linux:
     steps:
-      # @TODO: This was the old cypress line, likely needs replicated or -browsers image used
-      # - run:
-      #     name: Install Cypress Dependencies
-      #     command: apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - run_tests
 
   test-macos:

--- a/_tests/integration-test.mjs
+++ b/_tests/integration-test.mjs
@@ -37,7 +37,20 @@ test.serial('Build the default publication', async (t) => {
 
 test.serial('Build the default publication\'s pdf', async (t) => {
   process.chdir( publicationPath )
-  const pdfCmd = await execa('quire', ['pdf'])
+  const {stdout, stderr} = await execa('quire', ['pdf'])
+
+  const downloadsDir = path.join('_site', '_assets', 'downloads')
+
+  const publicationPdf = path.join(downloadsDir, 'publication.pdf')
+  if (!fs.existsSync(publicationPdf)) {
+    t.fail(`No publication PDF generated! ${stdout} ${stderr}`)
+  }
+
+  const essayPdf = path.join(downloadsDir, 'publication-essay.pdf')
+  if (!fs.existsSync(essayPdf)) {
+    t.fail(`No essay PDF generated! ${stdout} ${stderr}`)
+  }
+
   t.pass()
 })
 


### PR DESCRIPTION
This PR fixes PDF building on circleCI by:
- Testing after the PDF build whether the default PDF files exist
- Updating the `browser-tools` orb used to pre-install Chrome and using its updated syntax
- Overriding the Puppeteer install locations with the `PUPPETEER_EXECUTABLE_PATH` env var
- Implementing a small workaround for sandboxing errors on CircleCI