### PR TITLE
Bump `@11ty/eleventy` to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire",
-  "version": "1.0.0",
+  "version": "1.0.0-rc.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -45,49 +45,45 @@
       }
     },
     "node_modules/@11ty/eleventy": {
-      "version": "3.0.1-alpha.5",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.0.1-alpha.5.tgz",
-      "integrity": "sha512-a7x5CTsmsPdNUWslligOrprar0wahmGrQvYHF+9rSjEF6JEk5Rb6JNGEqdQcbNDur6pbt8sxlUt5az5dm71AEg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.0.tgz",
+      "integrity": "sha512-yR8zE+i5GKXTlR4I6Aj8dywI7f2/6uGhJPwgbH4vgh+XcZQ9zba9UMS/1Lyvkbl3UySRSAmlzeYiXi1ypV6oZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@11ty/dependency-tree": "^4.0.0",
         "@11ty/dependency-tree-esm": "^2.0.0",
-        "@11ty/eleventy-dev-server": "^2.0.7",
-        "@11ty/eleventy-plugin-bundle": "^3.0.1",
-        "@11ty/eleventy-utils": "^2.0.1",
+        "@11ty/eleventy-dev-server": "^2.0.8",
+        "@11ty/eleventy-plugin-bundle": "^3.0.6",
+        "@11ty/eleventy-utils": "^2.0.7",
         "@11ty/lodash-custom": "^4.17.21",
         "@11ty/posthtml-urls": "^1.0.1",
-        "@11ty/recursive-copy": "^4.0.0",
+        "@11ty/recursive-copy": "^4.0.1",
         "@sindresorhus/slugify": "^2.2.1",
         "bcp-47-normalize": "^2.3.0",
         "chokidar": "^3.6.0",
-        "cross-spawn": "^7.0.6",
         "debug": "^4.4.0",
         "dependency-graph": "^1.0.0",
         "entities": "^6.0.0",
-        "fast-glob": "^3.3.3",
         "filesize": "^10.1.6",
-        "graceful-fs": "^4.2.11",
         "gray-matter": "^4.0.3",
-        "is-glob": "^4.0.3",
         "iso-639-1": "^3.1.5",
         "js-yaml": "^4.1.0",
         "kleur": "^4.1.5",
         "liquidjs": "^10.21.0",
-        "luxon": "^3.5.0",
+        "luxon": "^3.6.1",
         "markdown-it": "^14.1.0",
-        "micromatch": "^4.0.8",
         "minimist": "^1.2.8",
         "moo": "^0.5.2",
-        "node-retrieve-globals": "^6.0.0",
+        "node-retrieve-globals": "^6.0.1",
         "nunjucks": "^3.2.4",
-        "p-map": "^7.0.3",
+        "picomatch": "^4.0.2",
         "please-upgrade-node": "^3.2.0",
         "posthtml": "^0.16.6",
         "posthtml-match-helper": "^2.0.3",
-        "semver": "^7.7.1",
-        "slugify": "^1.6.6"
+        "semver": "^7.7.2",
+        "slugify": "^1.6.6",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "eleventy": "cmd.cjs"
@@ -313,9 +309,9 @@
       }
     },
     "node_modules/@11ty/eleventy-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-2.0.2.tgz",
-      "integrity": "sha512-Lh/QxwoG10ElkO4WZlwlEqM/d58sreVfJ+I8bcL+QEwb5cGNHTuOlBnyZ2zcBKJohHINuo4zGMVrN83LBLIAaw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-2.0.7.tgz",
+      "integrity": "sha512-6QE+duqSQ0GY9rENXYb4iPR4AYGdrFpqnmi59tFp9VrleOl0QSh8VlBr2yd6dlhkdtj7904poZW5PvGr9cMiJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -324,6 +320,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@11ty/is-land": {
@@ -368,9 +377,9 @@
       }
     },
     "node_modules/@11ty/recursive-copy": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.1.tgz",
-      "integrity": "sha512-Zsg1xgfdVTMKNPj9o4FZeYa73dFZRX856CL4LsmqPMvDr0TuIK4cH9CVWJyf0OkNmM8GmlibGX18fF0B75Rn1w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.2.tgz",
+      "integrity": "sha512-174nFXxL/6KcYbLYpra+q3nDbfKxLxRTNVY1atq2M1pYYiPfHse++3IFNl8mjPFsd7y2qQjxLORzIjHMjL3NDQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5617,9 +5626,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6225,9 +6234,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10403,9 +10412,9 @@
       "license": "ISC"
     },
     "node_modules/liquidjs": {
-      "version": "10.21.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.0.tgz",
-      "integrity": "sha512-DouqxNU2jfoZzb1LinVjOc/f6ssitGIxiDJT+kEKyYqPSSSd+WmGOAhtWbVm1/n75svu4aQ+FyQ3ctd3wh1bbw==",
+      "version": "10.21.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.1.tgz",
+      "integrity": "sha512-NZXmCwv3RG5nire3fmIn9HsOyJX3vo+ptp0yaXUHAMzSNBhx74Hm+dAGJvscUA6lNqbLuYfXgNavRQ9UbUJhQQ==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
@@ -13638,9 +13647,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14943,9 +14952,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16310,7 +16319,7 @@
     },
     "packages/11ty": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0-rc.30",
+      "version": "1.0.0-rc.31",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "@iiif/helpers": "^1.3.1",
@@ -16323,7 +16332,7 @@
         "template-polyfill": "^2.0.0"
       },
       "devDependencies": {
-        "@11ty/eleventy": "^3.0.1-alpha.1",
+        "@11ty/eleventy": "<=3.1.0",
         "@11ty/eleventy-img": "^6.0.1",
         "@11ty/eleventy-navigation": "^1.0.1",
         "@11ty/eleventy-plugin-directory-output": "^1.0.1",
@@ -16433,7 +16442,7 @@
     },
     "packages/cli": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-rc.28",
+      "version": "1.0.0-rc.31",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "ajv": "^8.16.0",
@@ -16590,48 +16599,52 @@
       }
     },
     "@11ty/eleventy": {
-      "version": "3.0.1-alpha.5",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.0.1-alpha.5.tgz",
-      "integrity": "sha512-a7x5CTsmsPdNUWslligOrprar0wahmGrQvYHF+9rSjEF6JEk5Rb6JNGEqdQcbNDur6pbt8sxlUt5az5dm71AEg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.0.tgz",
+      "integrity": "sha512-yR8zE+i5GKXTlR4I6Aj8dywI7f2/6uGhJPwgbH4vgh+XcZQ9zba9UMS/1Lyvkbl3UySRSAmlzeYiXi1ypV6oZg==",
       "dev": true,
       "requires": {
         "@11ty/dependency-tree": "^4.0.0",
         "@11ty/dependency-tree-esm": "^2.0.0",
-        "@11ty/eleventy-dev-server": "^2.0.7",
-        "@11ty/eleventy-plugin-bundle": "^3.0.1",
-        "@11ty/eleventy-utils": "^2.0.1",
+        "@11ty/eleventy-dev-server": "^2.0.8",
+        "@11ty/eleventy-plugin-bundle": "^3.0.6",
+        "@11ty/eleventy-utils": "^2.0.7",
         "@11ty/lodash-custom": "^4.17.21",
         "@11ty/posthtml-urls": "^1.0.1",
-        "@11ty/recursive-copy": "^4.0.0",
+        "@11ty/recursive-copy": "^4.0.1",
         "@sindresorhus/slugify": "^2.2.1",
         "bcp-47-normalize": "^2.3.0",
         "chokidar": "^3.6.0",
-        "cross-spawn": "^7.0.6",
         "debug": "^4.4.0",
         "dependency-graph": "^1.0.0",
         "entities": "^6.0.0",
-        "fast-glob": "^3.3.3",
         "filesize": "^10.1.6",
-        "graceful-fs": "^4.2.11",
         "gray-matter": "^4.0.3",
-        "is-glob": "^4.0.3",
         "iso-639-1": "^3.1.5",
         "js-yaml": "^4.1.0",
         "kleur": "^4.1.5",
         "liquidjs": "^10.21.0",
-        "luxon": "^3.5.0",
+        "luxon": "^3.6.1",
         "markdown-it": "^14.1.0",
-        "micromatch": "^4.0.8",
         "minimist": "^1.2.8",
         "moo": "^0.5.2",
-        "node-retrieve-globals": "^6.0.0",
+        "node-retrieve-globals": "^6.0.1",
         "nunjucks": "^3.2.4",
-        "p-map": "^7.0.3",
+        "picomatch": "^4.0.2",
         "please-upgrade-node": "^3.2.0",
         "posthtml": "^0.16.6",
         "posthtml-match-helper": "^2.0.3",
-        "semver": "^7.7.1",
-        "slugify": "^1.6.6"
+        "semver": "^7.7.2",
+        "slugify": "^1.6.6",
+        "tinyglobby": "^0.2.13"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+          "dev": true
+        }
       }
     },
     "@11ty/eleventy-dev-server": {
@@ -16767,9 +16780,9 @@
       }
     },
     "@11ty/eleventy-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-2.0.2.tgz",
-      "integrity": "sha512-Lh/QxwoG10ElkO4WZlwlEqM/d58sreVfJ+I8bcL+QEwb5cGNHTuOlBnyZ2zcBKJohHINuo4zGMVrN83LBLIAaw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-2.0.7.tgz",
+      "integrity": "sha512-6QE+duqSQ0GY9rENXYb4iPR4AYGdrFpqnmi59tFp9VrleOl0QSh8VlBr2yd6dlhkdtj7904poZW5PvGr9cMiJQ==",
       "dev": true
     },
     "@11ty/is-land": {
@@ -16797,9 +16810,9 @@
       }
     },
     "@11ty/recursive-copy": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.1.tgz",
-      "integrity": "sha512-Zsg1xgfdVTMKNPj9o4FZeYa73dFZRX856CL4LsmqPMvDr0TuIK4cH9CVWJyf0OkNmM8GmlibGX18fF0B75Rn1w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.2.tgz",
+      "integrity": "sha512-174nFXxL/6KcYbLYpra+q3nDbfKxLxRTNVY1atq2M1pYYiPfHse++3IFNl8mjPFsd7y2qQjxLORzIjHMjL3NDQ==",
       "dev": true,
       "requires": {
         "errno": "^1.0.0",
@@ -18247,7 +18260,7 @@
     "@thegetty/quire-11ty": {
       "version": "file:packages/11ty",
       "requires": {
-        "@11ty/eleventy": "^3.0.1-alpha.1",
+        "@11ty/eleventy": "<=3.1.0",
         "@11ty/eleventy-img": "^6.0.1",
         "@11ty/eleventy-navigation": "^1.0.1",
         "@11ty/eleventy-plugin-directory-output": "^1.0.1",
@@ -20145,9 +20158,9 @@
       }
     },
     "debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "requires": {
         "ms": "^2.1.3"
       }
@@ -20529,9 +20542,9 @@
       }
     },
     "entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
     },
     "env-paths": {
       "version": "3.0.0",
@@ -23243,9 +23256,9 @@
       "dev": true
     },
     "liquidjs": {
-      "version": "10.21.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.0.tgz",
-      "integrity": "sha512-DouqxNU2jfoZzb1LinVjOc/f6ssitGIxiDJT+kEKyYqPSSSd+WmGOAhtWbVm1/n75svu4aQ+FyQ3ctd3wh1bbw==",
+      "version": "10.21.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.1.tgz",
+      "integrity": "sha512-NZXmCwv3RG5nire3fmIn9HsOyJX3vo+ptp0yaXUHAMzSNBhx74Hm+dAGJvscUA6lNqbLuYfXgNavRQ9UbUJhQQ==",
       "requires": {
         "commander": "^10.0.0"
       },
@@ -25324,9 +25337,9 @@
       }
     },
     "semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -26227,9 +26240,9 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "requires": {
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire",
-  "version": "1.0.0",
+  "version": "1.0.0-rc.32",
   "private": true,
   "description": "a multi-format book publishing framework",
   "author": "Getty Digital",

--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -12,6 +12,12 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.32]
+
+### Bumped
+
+- Moved `@11ty/eleventy` to 3.1.0. Resolves issue in 1.0.0-rc.31 where new projects would fail to build.
+
 ## [1.0.0-rc.31]
 
 ### Added

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.31",
+  "version": "1.0.0-rc.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -58,7 +58,7 @@
     "template-polyfill": "^2.0.0"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^3.0.1-alpha.1",
+    "@11ty/eleventy": "<=3.1.0",
     "@11ty/eleventy-img": "^6.0.1",
     "@11ty/eleventy-navigation": "^1.0.1",
     "@11ty/eleventy-plugin-directory-output": "^1.0.1",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.31",
+  "version": "1.0.0-rc.32",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "1.0.0-rc.31",
+  "version": "1.0.0-rc.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.31",
+  "version": "1.0.0-rc.32",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {


### PR DESCRIPTION
This PR bumps `@11ty/eleventy` a version constraint of `<=3.1.0`. In addition to bumping to a full release version this change resolves an issue where the minor-version-changes-allowed constraint of `~3.0.1-alpha.1` allowed installs of 3.1.1+, leaving the resulting publication in an unbuildable state due to https://github.com/11ty/eleventy/issues/3860. 