### PR TITLE
Bump changelogs and lockfiles for 1.0.0-rc.33

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -12,6 +12,24 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.33]
+
+### Added
+
+- Added `iiif_image` property to Figure factory and schema. When passed an IIIF Image API URL (eg, `iiif_image: "https://media.getty.edu/iiif/image/aedba790-5d99-4eec-9453-103efd6a1429"`) the IIIF URL will be used to source image tiles and static-sized derivatives for this figure.
+
+### Changed 
+
+- Ensured that `isExternalResource` is passed through the Figure adapter to data consumers.
+
+### Bumped
+
+- Bumped minimum supported node engine version to v22.
+
+### Fixed
+
+- Fixed various pathing issues for image files used in the epub and pdf outputs.
+
 ## [1.0.0-rc.32]
 
 ### Bumped

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.32",
+  "version": "1.0.0-rc.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.32",
+  "version": "1.0.0-rc.33",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,12 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.33]
+
+### Bumped
+
+- Bumped minimum supported node engine verison to 22.
+
 ## [1.0.0-rc.31]
 
 ### Changed

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-cli",
-  "version": "1.0.0-rc.32",
+  "version": "1.0.0-rc.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.32",
+  "version": "1.0.0-rc.33",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {


### PR DESCRIPTION
This PR updates the CHANGELOGs for `@thegetty/quire-cli` and `@thegetty/quire-11ty` for version 1.0.0-rc33.