### PR TITLE
Update `robots` meta tag to allow indexing + link following of publications (DEV-20375)

### DIFF
--- a/packages/11ty/_includes/components/head.js
+++ b/packages/11ty/_includes/components/head.js
@@ -46,7 +46,7 @@ export default function (eleventyConfig) {
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <meta name="robots" content="noindex, nofollow"/>
+        <meta name="robots" content="index, follow"/>
 
         <meta name="generator" content="${application.name} ${application.version}" />
 
@@ -73,15 +73,6 @@ export default function (eleventyConfig) {
         <script type="application/ld+json">${jsonld({ canonicalURL, page })}</script>
 
         <link rel="icon" href="/_assets/images/icons/favicon.ico" />
-        <!--
-          styles are already imported in _assets/javascript/application/index.js
-          and rendered as inline minified <style type="text/css">...</style> blocks,
-          not using these file links
-        -->
-        <!-- <link rel="stylesheet" href="/_assets/styles/application.scss" /> -->
-        <!-- <link rel="stylesheet" href="/_assets/styles/custom.css" /> -->
-
-        <!-- {% render 'polyfills/template.html' %} -->
 
         ${analytics()}
       </head>


### PR DESCRIPTION
This PR updates the default `<meta name="robots">` head tags to allow for page indexing and link following. It also removes deprecated template comments about style bootstrapping (re: async attributes) that are no longer applicable. 