### PR TITLE
Fix typo that was adding a duplicate fig caption instead of credit

### DIFF
--- a/packages/11ty/_includes/components/lightbox/data.js
+++ b/packages/11ty/_includes/components/lightbox/data.js
@@ -37,7 +37,7 @@ export default function (eleventyConfig) {
       const annotationsElementContent = !isSequence ? annotationsUI({ figure: fig, lightbox: true }) : undefined
       const labelHtml = label ? markdownify(label) : undefined
       const captionHtml = caption ? markdownify(caption) : undefined
-      const creditHtml = credit ? markdownify(caption) : undefined
+      const creditHtml = credit ? markdownify(credit) : undefined
       const sluggedId = slugify(id)
 
       const mapped = {


### PR DESCRIPTION
@cbutcosk, just a quick typo fix. let me know if I need to do anything here in terms of testing

