### PR TITLE
Fix duplicate ID error in accordion shortcode (DEV-21555)

### DIFF
--- a/packages/11ty/_plugins/components/shortcodeFactory.js
+++ b/packages/11ty/_plugins/components/shortcodeFactory.js
@@ -13,14 +13,14 @@ export default function (eleventyConfig, collections) {
   return {
     addShortcode: function (tagName, component) {
       eleventyConfig.addShortcode(tagName, function (...args) {
-        const page = collections.all.find(({ inputPath }) => inputPath === this.page.inputPath)
+        const page = collections.all?.find(({ inputPath }) => inputPath === this.page.inputPath)
         // console.log(tagName,page.inputPath)
         return component(eleventyConfig, { collections, page }).bind(this)(...args)
       })
     },
     addPairedShortcode: function (tagName, component) {
       eleventyConfig.addPairedShortcode(tagName, function (content, ...args) {
-        const page = collections.all.find(({ inputPath }) => inputPath === this.page.inputPath)
+        const page = collections.all?.find(({ inputPath }) => inputPath === this.page.inputPath)
         return component(eleventyConfig, { collections, page })(content, ...args)
       })
     }

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -51,7 +51,12 @@ const checkForDuplicateIds = function (data, filename) {
  */
 export default function (eleventyConfig, directoryConfig) {
   const dir = path.resolve(directoryConfig.inputDir, '_data')
-  // console.debug(`[plugins:globalData] ${dir}`)
+
+  // Add directory config to globalData so that it is available to other plugins
+  eleventyConfig.addGlobalData('directoryConfig', directoryConfig)
+
+  if (!fs.existsSync(dir)) return eleventyConfig.globalData
+
   const files = fs.readdirSync(dir)
     .filter((file) => path.extname(file) !== '.md')
   const parse = parser(eleventyConfig)
@@ -74,9 +79,6 @@ export default function (eleventyConfig, directoryConfig) {
     checkForDuplicateIds(value, file)
     eleventyConfig.addGlobalData(key, value)
   }
-
-  // Add directory config to globalData so that it is available to other plugins
-  eleventyConfig.globalData.directoryConfig = directoryConfig
 
   return eleventyConfig.globalData
 }

--- a/packages/11ty/_plugins/shortcodes/accordion.js
+++ b/packages/11ty/_plugins/shortcodes/accordion.js
@@ -41,15 +41,8 @@ export default function (eleventyConfig, { page }) {
       'accordion-section__heading', headingLevelClass, 'accordion-section__controls', controlsClass
     ].filter((x) => x)
 
-    const printComponent = `
-      <section id="${sectionId}-print" class="accordion-section" data-outputs-include="epub,pdf">
-        ${markdownify(heading, { inline: false })}
-        ${markdownify(content, { inline: false })}
-      </section>
-    `
-
-    const htmlComponent = `
-      <details class="accordion-section" id="${sectionId}" ${open ? 'open' : ''} data-outputs-include="html">
+    const component = `
+      <details class="accordion-section" id="${sectionId}-accordion" ${open ? 'open' : ''} >
         <summary class="${summaryClasses.join(' ')}" tabindex="1">
           <button
             aria-label="${copyButton.ariaLabel}"
@@ -74,8 +67,7 @@ export default function (eleventyConfig, { page }) {
     `
 
     return oneLine`
-      ${printComponent}
-      ${htmlComponent}
+      ${component}
     `
   }
 }

--- a/packages/11ty/_plugins/shortcodes/accordion.js
+++ b/packages/11ty/_plugins/shortcodes/accordion.js
@@ -42,7 +42,7 @@ export default function (eleventyConfig, { page }) {
     ].filter((x) => x)
 
     const printComponent = `
-      <section id="${sectionId}" class="accordion-section" data-outputs-include="epub,pdf">
+      <section id="${sectionId}-print" class="accordion-section" data-outputs-include="epub,pdf">
         ${markdownify(heading, { inline: false })}
         ${markdownify(content, { inline: false })}
       </section>

--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -212,6 +212,10 @@ export default function (eleventyConfig, collections, content) {
     }
   }
 
+  function openAccordions (document) {
+    document.querySelectorAll('details.accordion-section').forEach((sect) => { sect.open = true })
+  }
+
   const pdfPages = collections.pdf.map(({ outputPath }) => outputPath)
 
   // Returning content allows subsequent transforms to process it unmodified
@@ -252,6 +256,7 @@ export default function (eleventyConfig, collections, content) {
   filterOutputs(sectionElement, 'pdf')
   trimLeadingSeparator(sectionElement)
   slugifyIds(sectionElement)
+  openAccordions(sectionElement)
 
   collections.pdf[pageIndex].sectionElement = sectionElement.outerHTML
 

--- a/packages/11ty/_tests/helpers/index.js
+++ b/packages/11ty/_tests/helpers/index.js
@@ -1,3 +1,5 @@
+import Eleventy from '@11ty/eleventy'
+
 /**
  * @function stubGlobalData
  *

--- a/packages/11ty/_tests/helpers/index.js
+++ b/packages/11ty/_tests/helpers/index.js
@@ -1,0 +1,38 @@
+/**
+ * @function stubGlobalData
+ *
+ * @param {Object} eleventyConfig
+ *
+ * Inserts keys / values into globalData suitable to make Eleventy() init
+ *
+ **/
+const stubGlobalData = (eleventyConfig) => {
+  eleventyConfig.addGlobalData('publication', {})
+
+  const config = {
+    accordion: {
+      copyButton: {}
+    },
+    epub: {},
+    figures: {}
+  }
+  eleventyConfig.addGlobalData('config', config)
+
+  const figures = { figure_list: [] }
+  eleventyConfig.addGlobalData('figures', figures)
+}
+
+/**
+ * @function initEleventyEnvironment
+ *
+ * Initializes an Eleventy object suitable for rendering out shortcodes
+ *
+ **/
+const initEleventyEnvironment = async () => {
+  const elev = new Eleventy('../', '_site', { config: stubGlobalData })
+  await elev.init()
+
+  return elev
+}
+
+export { initEleventyEnvironment }

--- a/packages/11ty/_tests/shortcodes.spec.js
+++ b/packages/11ty/_tests/shortcodes.spec.js
@@ -1,7 +1,7 @@
-import Eleventy from '@11ty/eleventy'
 import { JSDOM } from 'jsdom'
 import test from 'ava'
-import { initEleventyEnvironment } from './helpers'
+import { initEleventyEnvironment } from './helpers/index.js'
+
 /**
  * @function renderAndTestIds
  *

--- a/packages/11ty/_tests/shortcodes.spec.js
+++ b/packages/11ty/_tests/shortcodes.spec.js
@@ -1,44 +1,7 @@
 import Eleventy from '@11ty/eleventy'
 import { JSDOM } from 'jsdom'
 import test from 'ava'
-
-/**
- * @function stubGlobalData
- *
- * @param {Object} eleventyConfig
- *
- * Inserts keys / values into globalData suitable to make Eleventy() init
- *
- **/
-const stubGlobalData = (eleventyConfig) => {
-  eleventyConfig.addGlobalData('publication', {})
-
-  const config = {
-    accordion: {
-      copyButton: {}
-    },
-    epub: {},
-    figures: {}
-  }
-  eleventyConfig.addGlobalData('config', config)
-
-  const figures = { figure_list: [] }
-  eleventyConfig.addGlobalData('figures', figures)
-}
-
-/**
- * @function stubEleventy
- *
- * Initializes an Eleventy object suitable for rendering out shortcodes
- *
- **/
-const stubEleventy = async () => {
-  const elev = new Eleventy('../', '_site', { config: stubGlobalData })
-  await elev.init()
-
-  return elev
-}
-
+import { initEleventyEnvironment } from './helpers'
 /**
  * @function renderAndTestIds
  *
@@ -59,8 +22,8 @@ const renderAndTestIds = async (content, eleventy, t) => {
 }
 
 // Initialize Eleventy and pass into test context
-test.before('Stub eleventyConfig', async (t) => {
-  const elev = await stubEleventy()
+test.before('Stub the eleventy environment', async (t) => {
+  const elev = await initEleventyEnvironment()
 
   t.context.eleventy = elev
 })

--- a/packages/11ty/_tests/shortcodes.spec.js
+++ b/packages/11ty/_tests/shortcodes.spec.js
@@ -1,0 +1,88 @@
+import Eleventy from '@11ty/eleventy'
+import { JSDOM } from 'jsdom'
+import test from 'ava'
+
+/**
+ * @function stubGlobalData
+ *
+ * @param {Object} eleventyConfig
+ *
+ * Inserts keys / values into globalData suitable to make Eleventy() init
+ *
+ **/
+const stubGlobalData = (eleventyConfig) => {
+  eleventyConfig.addGlobalData('publication', {})
+
+  const config = {
+    accordion: {
+      copyButton: {}
+    },
+    epub: {},
+    figures: {}
+  }
+  eleventyConfig.addGlobalData('config', config)
+
+  const figures = { figure_list: [] }
+  eleventyConfig.addGlobalData('figures', figures)
+}
+
+/**
+ * @function stubEleventy
+ *
+ * Initializes an Eleventy object suitable for rendering out shortcodes
+ *
+ **/
+const stubEleventy = async () => {
+  const elev = new Eleventy('../', '_site', { config: stubGlobalData })
+  await elev.init()
+
+  return elev
+}
+
+// Initialize Eleventy and pass into test context
+test.before('Stub eleventyConfig', async (t) => {
+  const elev = await stubEleventy()
+
+  t.context.eleventy = elev
+})
+
+test('Accordion sections should never produce duplicate ids', async (t) => {
+  const { eleventy } = t.context
+
+  const content = `{% accordion '## Test Section' %}
+  Test content.
+  {% endaccordion %}`
+
+  const contentWithFootnote = `{% accordion '## Test Section' %}
+  Test content.[^1]
+  {% endaccordion %}`
+
+  const testContent = [content, contentWithFootnote]
+  testContent.forEach(async (c) => {
+    const rendered = await eleventy.eleventyConfig.config.javascriptFunctions.renderTemplate(contentWithFootnote, 'liquid,md', {})
+    const markup = JSDOM.fragment(rendered)
+
+    const ids = Array.from(markup.querySelectorAll('[id]')).map((el) => el.id)
+    const uniques = new Set(ids)
+
+    if (ids.length !== uniques.length) t.fail('Accordion shortcode should not emit duplicate ids.')
+  })
+
+  t.pass()
+})
+
+test('Accordion sections should not produce duplicate ids in the markup with a footnote', async (t) => {
+  const { eleventy } = t.context
+
+  const contentWithFootnote = `{% accordion '## Test Section' %}
+  Test content.[^1]
+  {% endaccordion %}`
+
+  const rendered = await eleventy.eleventyConfig.config.javascriptFunctions.renderTemplate(contentWithFootnote, 'liquid,md', {})
+  const markup = JSDOM.fragment(rendered)
+
+  const ids = Array.from(markup.querySelectorAll('[id]')).map((el) => el.id)
+  const uniques = new Set(ids)
+
+  if (ids.length !== uniques.length) t.fail('Accordion shortcode should not emit duplicate ids.')
+})

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "npm run test",
     "preserve": "npm run clean",
     "serve": "cross-env ELEVENTY_ENV=production eleventy --serve",
-    "test": "npm run lint && node --test"
+    "test": "npm run lint && ava --verbose --timeout 360s && node --test '_plugins/figures/test/*.spec.js'"
   },
   "imports": {
     "#root/*": "./*",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "npm run test",
     "preserve": "npm run clean",
     "serve": "cross-env ELEVENTY_ENV=production eleventy --serve",
-    "test": "npm run lint && ava --verbose --timeout 360s && node --test '_plugins/figures/test/*.spec.js'"
+    "test": "npm run lint && ava --verbose --timeout 360s _tests/* && node --test '_plugins/figures/test/figures.spec.js'"
   },
   "imports": {
     "#root/*": "./*",

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "npm run test",
     "preserve": "npm run clean",
     "serve": "cross-env ELEVENTY_ENV=production eleventy --serve",
-    "test": "npm run lint && ava --verbose --timeout 360s _tests/* && node --test '_plugins/figures/test/figures.spec.js'"
+    "test": "npm run lint && ava --verbose --timeout 360s _tests/* && node --test _plugins/figures/test/*.spec.js"
   },
   "imports": {
     "#root/*": "./*",


### PR DESCRIPTION
This PR addresses an issue (DEV-21555) where projects that use the accordion shortcode will not build without disabling ID checking in the configuration for the IdAttributePlugin in the project's `.eleventy.js`. The patch:
- Adds a test helper function that initializes the `Eleventy()` object and passes it on to later tests (helper in `packages/11ty/_tests/helpers/index.js`.
- Adds a test for duplicate IDs in the accordion shortcode when used with and without a footnote.
- Refactors `accordion` shortcode to remove duplicate markup and use `summary`/`details` tags in all outputs and sets details to open in PDF