### PR TITLE
Resolve issue with figure asset paths in lightbox when publication URL has a pathname (DEV-21513)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
   # Tests the output of the publication build -- must be separate for the playwright executor
   browser_test:
     executor: pw-noble-development
+    # NB: taken from https://playwright.dev/docs/ci#sharding-in-circleci
     parallelism: 4
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,15 +179,17 @@ jobs:
   # Tests the output of the publication build -- must be separate for the playwright executor
   browser_test:
     executor: pw-noble-development
+    parallelism: 4
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Install browser testing dependencies
           command: npm i && apt-get update && apt-get install -y zip && npx playwright install
+      # test:browsers-circleci follows https://playwright.dev/docs/ci#circleci to correct sharding
       - run: 
           name: Run browser testing on integration test artifacts
-          command: npm run test:browsers
+          command: npm run test:browsers-circleci
       - store_test_results:
           path: reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ commands:
             - package.json
             - reports
             - test-publication/_site
+            - test-publication-pathname/_site
             - _tests
 
       - store_test_results:

--- a/_tests/helpers/publication-setup.js
+++ b/_tests/helpers/publication-setup.js
@@ -1,0 +1,35 @@
+/**
+ * @script publication-setup.js
+ * 
+ * Stages publications in the site test directory
+ * 
+ **/ 
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Test publication type locations
+const publication = path.join('test-publication','_site')
+const pathnamePublication = path.join('test-publication-pathname', '_site')
+const pathnameSitemap = path.join(pathnamePublication, 'sitemap.xml')
+
+// Destination mounts
+const site = '_site-test'
+const pathnameSite = path.join(site, 'test-publication-pathname')
+const sitemap = path.join(site, 'sitemap.xml')
+
+if (fs.existsSync(site)) {
+  fs.rmSync(site, {recursive: true, force: true})  
+}
+fs.mkdirSync(site)
+
+// Copy with pathname if the env var is set
+if (!!process.env.QUIRE_TEST_PUB_PATHNAME) {
+  console.log("Pub pathing it",pathnamePublication, pathnameSite)
+  fs.cpSync(pathnamePublication, pathnameSite, {recursive: true})  
+  fs.cpSync(pathnameSitemap, sitemap)
+} else {
+  fs.cpSync(publication, site, {recursive: true})
+}
+
+

--- a/_tests/integration-test.mjs
+++ b/_tests/integration-test.mjs
@@ -90,7 +90,7 @@ test.serial('Create the default publication with a pathname and build the site, 
   const newCmd = await execa('quire', ['new', '--debug', '--quire-path', eleventyPath, pathedPub ])
 
   process.chdir(pathedPub)
-  changePubUrl(`http://localhost:8181/${ pathedPub }/`, t)
+  changePubUrl(`http://localhost:8080/${ pathedPub }/`, t)
 
   await buildSitePdfEpub()
   process.chdir(repoRoot)
@@ -99,6 +99,5 @@ test.serial('Create the default publication with a pathname and build the site, 
 
 // Package built site products for artifact storage and stage pathed publication
 test.after(async (t) => {
-  fs.renameSync(path.join(pathedPub, '_site'), path.join(pathedPub, pathedPub))
   await execa('zip', ['-r', publicationZip, path.join(publicationPath, '_site'), path.join(publicationPath, '_epub')])
 })

--- a/_tests/publication.spec.js
+++ b/_tests/publication.spec.js
@@ -72,6 +72,7 @@ const checkCanvasPanelCanvasDims = async (page) => {
  * 
  **/ 
 const checkAllImgsOK = async (page) => {
+  const pageUrl = page.url()
   const imgLoc = page.locator('img')
   const imgs = await imgLoc.all()  
 
@@ -79,10 +80,11 @@ const checkAllImgsOK = async (page) => {
   const imgHrefs = await Promise.all(imgs.map( async (img) => await img.getAttribute('src') ))
   const imgUrls = imgHrefs.map( (href) => {
     let url
+
     try {
-      url = new URL(href)
+      url = new URL(href, pageUrl)
     } catch {
-      url = new URL(href,'http://localhost:8080/')
+      test.fail(`${href} could not be parsed into a valid URL`)
     }
 
     return url
@@ -91,18 +93,64 @@ const checkAllImgsOK = async (page) => {
   await Promise.all( imgUrls.map( (u) => checkUrl(u,page) ) )
 }
 
+/**
+ * @function checkLightboxSlides
+ * 
+ * @argument {Page} page
+ * 
+ * Checks that src attrs of all lightbox slide images work
+ * 
+ **/ 
+const checkLightboxSlides = async (page) => {
+  // Find each figure image on the page, click it
+  // TODO: Drill shadowRoots
+  const modal = await page.locator('q-modal').first()
+  const lightbox = await modal.locator('q-lightbox').first()
+
+  for ( const slideImg of await lightbox.locator('.q-lightbox-slides__element--image > img').all() ) {
+    const src = await slideImg.getAttribute('src')
+
+    let url
+    try {
+      url = new URL(src)
+    } catch {
+      url = new URL(src,'http://localhost:8080/')
+    }
+    console.log(url.href)
+    await checkUrl(url.href, page)
+  }
+}
+
+/**
+ * @function loadSitemapUrls
+ * 
+ * @param {String} sitemapPath Path on disk to the sitemap
+ * 
+ * @returns {Array} All URLs from the sitemap
+ * 
+ * Loads a sitemap synchronously from disk (to mesh w/ playwright's declarative tests)
+ **/ 
+const loadSitemapUrls = (sitemapPath) => {  
+  // Use the JSDOM's potted DOMParser implementation for the XML
+  const dom = new JSDOM()
+  const parser = new dom.window.DOMParser()
+
+  let urls = []
+  const body = readFileSync(sitemapPath).toString()
+  const sitemap = parser.parseFromString(body, 'text/xml')
+
+  sitemap.querySelectorAll('urlset > url > loc').forEach( loc => {
+    if (!loc.textContent) return
+    urls.push(loc.textContent)
+  })
+
+  return urls
+}
+
+// Add the PDF, URLs from the prime publication, and URLs from the pathed publication
 let siteURLs = [ 'http://localhost:8080/pdf.html' ]
-
-const dom = new JSDOM()
-const parser = new dom.window.DOMParser()
-
-// Load the sitemap synchronously because playwright requires declarative tests
-const body = readFileSync(path.join('test-publication','_site','sitemap.xml')).toString()
-const sitemap = parser.parseFromString(body, 'text/xml')
-sitemap.querySelectorAll('urlset > url > loc').forEach( loc => {
-  if (!loc.textContent) return
-  siteURLs.push(loc.textContent)
-})
+siteURLs = siteURLs.concat(loadSitemapUrls(path.join('test-publication','_site','sitemap.xml')))
+siteURLs = siteURLs.concat(loadSitemapUrls(path.join('test-publication-pathname','test-publication-pathname','sitemap.xml')))
 
 for (const url of siteURLs) {
   if (!url) continue
@@ -113,5 +161,6 @@ for (const url of siteURLs) {
     await expect.soft(page).toHaveTitle(/.{1,}/)
     await checkAllImgsOK(page)
     await checkCanvasPanelCanvasDims(page)
+    // await checkLightboxSlides(page)
   })  
 }

--- a/_tests/publication.spec.js
+++ b/_tests/publication.spec.js
@@ -148,9 +148,8 @@ const loadSitemapUrls = (sitemapPath) => {
 }
 
 // Add the PDF, URLs from the prime publication, and URLs from the pathed publication
-let siteURLs = [ 'http://localhost:8080/pdf.html' ]
-siteURLs = siteURLs.concat(loadSitemapUrls(path.join('test-publication','_site','sitemap.xml')))
-siteURLs = siteURLs.concat(loadSitemapUrls(path.join('test-publication-pathname','test-publication-pathname','sitemap.xml')))
+let siteURLs = !!process.env.QUIRE_TEST_PUB_PATHNAME ? [] : [ 'http://localhost:8080/pdf.html' ]
+siteURLs = siteURLs.concat(loadSitemapUrls(path.join('_site-test','sitemap.xml')))
 
 for (const url of siteURLs) {
   if (!url) continue

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "workerThreads": false
   },
   "scripts": {
-    "test": "cross-env mkdir -p reports && ava --verbose --timeout 360s && playwright test",
-    "test:browsers": "npx playwright test",
+    "test": "cross-env mkdir -p reports _site-test && ava --verbose --timeout 360s && playwright test && QUIRE_TEST_PUB_PATHNAME=1 playwright test",
+    "test:browsers": "cross-env mkdir -p _site-test && playwright test && QUIRE_TEST_PUB_PATHNAME=1 playwright test",
+    "test:browsers-circleci": "mkdir -p _site-test && SHARD=\"$((${CIRCLE_NODE_INDEX}+1))\" && npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL} && QUIRE_TEST_PUB_PATHNAME=1 npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL}",
     "test:integration": "ava --tap --timeout 360s | tap-xunit > reports/publication-build.xml",
-    "test:serve": "npx --yes http-server test-publication/_site -a localhost -p 8080"
+    "test:serve": "npx --yes http-server _site-test -a localhost -p 8080"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -39,7 +39,7 @@ export default function (eleventyConfig) {
           return imageService(figure)
         }
       default:
-        return imageTag({...figure, lightbox})
+        return imageTag({ ...figure, lightbox })
     }
   }
 }

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -14,7 +14,7 @@ export default function (eleventyConfig) {
 
   return function (figure, options) {
     const { alt, isCanvas, isImageService, isSequence, staticInlineFigureImage, lazyLoading } = figure
-    const { interactive, preset } = options
+    const { interactive, preset, lightbox } = options
     if (preset) {
       figure.preset = preset
     }
@@ -22,24 +22,24 @@ export default function (eleventyConfig) {
     switch (true) {
       case isSequence:
         if (!interactive && staticInlineFigureImage) {
-          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive, lazyLoading })
+          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive, lazyLoading, lightbox })
         } else {
           return imageSequence(figure, options)
         }
       case isCanvas:
         if (!interactive && staticInlineFigureImage) {
-          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive, lazyLoading })
+          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive, lazyLoading, lightbox })
         } else {
           return canvasPanel(figure)
         }
       case isImageService:
         if (!interactive && staticInlineFigureImage) {
-          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive, lazyLoading })
+          return imageTag({ alt, src: staticInlineFigureImage, isStatic: !interactive, lazyLoading, lightbox })
         } else {
           return imageService(figure)
         }
       default:
-        return imageTag(figure)
+        return imageTag({...figure, lightbox})
     }
   }
 }

--- a/packages/11ty/_includes/components/figure/image/image-tag.js
+++ b/packages/11ty/_includes/components/figure/image/image-tag.js
@@ -12,11 +12,15 @@ import path from 'node:path'
  * @return     {String}  An <img> element
  */
 export default function (eleventyConfig) {
+  const { publicDir } = eleventyConfig.globalData.directoryConfig
   const { imageDir } = eleventyConfig.globalData.config.figures
+  const { pathname } = eleventyConfig.globalData.publication
 
-  return function ({ alt = '', src = '', isStatic = false, lazyLoading = 'lazy' }) {
+  return function ({ alt = '', src = '', isStatic = false, lazyLoading = 'lazy', lightbox = false }) {
+    // Lightbox loads in-browser so urls must have pathname, rest are prepended by 11ty
     const extOrIiifRegex = /^(https?:\/\/|\/iiif\/|\\iiif\\)/
-    let imageSrc = extOrIiifRegex.test(src) || isStatic ? src : path.posix.join(imageDir, src)
+    const assetRoot = lightbox && pathname !== '/' ? path.posix.join(pathname, imageDir) : imageDir
+    const imageSrc = extOrIiifRegex.test(src) || isStatic ? src : path.posix.join(assetRoot, src)
 
     // HACK: If an URL-unsafe path separator has made it this far, remove it
     if (path.sep !== '/') {

--- a/packages/11ty/_includes/components/figure/image/image-tag.js
+++ b/packages/11ty/_includes/components/figure/image/image-tag.js
@@ -12,7 +12,6 @@ import path from 'node:path'
  * @return     {String}  An <img> element
  */
 export default function (eleventyConfig) {
-  const { publicDir } = eleventyConfig.globalData.directoryConfig
   const { imageDir } = eleventyConfig.globalData.config.figures
   const { pathname } = eleventyConfig.globalData.publication
 
@@ -20,7 +19,7 @@ export default function (eleventyConfig) {
     // Lightbox loads in-browser so urls must have pathname, rest are prepended by 11ty
     const extOrIiifRegex = /^(https?:\/\/|\/iiif\/|\\iiif\\)/
     const assetRoot = lightbox && pathname !== '/' ? path.posix.join(pathname, imageDir) : imageDir
-    const imageSrc = extOrIiifRegex.test(src) || isStatic ? src : path.posix.join(assetRoot, src)
+    let imageSrc = extOrIiifRegex.test(src) || isStatic ? src : path.posix.join(assetRoot, src)
 
     // HACK: If an URL-unsafe path separator has made it this far, remove it
     if (path.sep !== '/') {

--- a/packages/11ty/_includes/components/figure/video/element.js
+++ b/packages/11ty/_includes/components/figure/video/element.js
@@ -19,6 +19,7 @@ const logger = chalkFactory('Figure Video')
  * @return     {String}  An HTML <video> element
  */
 export default function (eleventyConfig) {
+  const { pathname } = eleventyConfig.globalData.publication
   const { imageDir } = eleventyConfig.globalData.config.figures
   const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
   const videoElements = {
@@ -90,13 +91,16 @@ export default function (eleventyConfig) {
     mediaType,
     poster,
     lazyLoading,
+    lightbox,
     src
   }) {
+    const assetRoot = lightbox && pathname !== '/' ? path.posix.join(pathname, imageDir) : imageDir
+
     if (poster) {
-      poster = path.join(imageDir, poster)
+      poster = path.join(assetRoot, poster)
     }
     if (src) {
-      src = src.startsWith('http') ? src : path.join(imageDir, src)
+      src = src.startsWith('http') ? src : path.join(assetRoot, src)
     }
 
     return videoElements[mediaType]({ id, mediaId, mediaType, poster, lazyLoading, src })

--- a/packages/11ty/_includes/components/lightbox/data.js
+++ b/packages/11ty/_includes/components/lightbox/data.js
@@ -59,7 +59,7 @@ export default function (eleventyConfig) {
           case mediaType === 'table':
             return `<div class="overflow-container">${await figureTableElement(figure)}</div>`
           case isVideo:
-            return figureVideoElement({...figure, lightbox: true})
+            return figureVideoElement({ ...figure, lightbox: true })
           case mediaType === 'image':
           default:
             return figureImageElement(figure, { preset: 'zoom', interactive: true, lightbox: true })

--- a/packages/11ty/_includes/components/lightbox/data.js
+++ b/packages/11ty/_includes/components/lightbox/data.js
@@ -59,10 +59,10 @@ export default function (eleventyConfig) {
           case mediaType === 'table':
             return `<div class="overflow-container">${await figureTableElement(figure)}</div>`
           case isVideo:
-            return figureVideoElement(figure)
+            return figureVideoElement({...figure, lightbox: true})
           case mediaType === 'image':
           default:
-            return figureImageElement(figure, { preset: 'zoom', interactive: true })
+            return figureImageElement(figure, { preset: 'zoom', interactive: true, lightbox: true })
         }
       }
 

--- a/packages/11ty/_plugins/sitemap/index.js
+++ b/packages/11ty/_plugins/sitemap/index.js
@@ -17,7 +17,11 @@ export default async function (eleventyConfig, collections) {
   })
 
   eleventyConfig.on('eleventy.after', async () => {
-    const sitemap = await eleventyConfig.javascript.functions.renderTemplate('{% sitemap collections.html %}', 'liquid,md', { collections })
+    // Ensure the page's canonical URL is used so pub pathname is preserved
+    const urls = collections.html.map( p => {
+      return {...p, url: p.data.canonicalURL}
+    })
+    const sitemap = await eleventyConfig.javascript.functions.renderTemplate('{% sitemap urls %}', 'liquid,md', { urls })
     const outputPath = path.join(publicDir || outputDir, 'sitemap.xml')
 
     fs.writeFileSync(outputPath, sitemap)

--- a/packages/11ty/_plugins/sitemap/index.js
+++ b/packages/11ty/_plugins/sitemap/index.js
@@ -18,8 +18,8 @@ export default async function (eleventyConfig, collections) {
 
   eleventyConfig.on('eleventy.after', async () => {
     // Ensure the page's canonical URL is used so pub pathname is preserved
-    const urls = collections.html.map( p => {
-      return {...p, url: p.data.canonicalURL}
+    const urls = collections.html.map(p => {
+      return { ...p, url: p.data.canonicalURL }
     })
     const sitemap = await eleventyConfig.javascript.functions.renderTemplate('{% sitemap urls %}', 'liquid,md', { urls })
     const outputPath = path.join(publicDir || outputDir, 'sitemap.xml')

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -67,10 +67,14 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
+  webServer: [{
     command: 'npm run test:serve',
     url: 'http://localhost:8080',
     reuseExistingServer: !process.env.CI,
-  },
+  },{
+    command: 'npx --yes http-server -a localhost -p 8181 test-publication-pathname',
+    url: 'http://localhost:8181',
+    reuseExistingServer: !process.env.CI,
+  }]
 });
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,8 @@
 // @ts-check
 import { defineConfig, devices } from '@playwright/test';
 
+const pathnameTesting = !!process.env.QUIRE_TEST_PUB_PATHNAME
+
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -14,10 +16,10 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: undefined, //process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
-    ['junit', {printSteps: true, outputFile: 'reports/publication-browser.xml'}]
+    ['junit', {printSteps: true, outputFile: pathnameTesting ? 'reports/publication-browser-pathname.xml' :  'reports/publication-browser.xml' }]
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
@@ -31,50 +33,33 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
+      name: 'setup',
+      testMatch: /publication-setup\.js/
+    },
+    {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup']
     },
 
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
+      dependencies: ['setup']
     },
-
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
+      dependencies: ['setup']
     },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
 
   /* Run your local dev server before starting the tests */
   webServer: [{
     command: 'npm run test:serve',
     url: 'http://localhost:8080',
-    reuseExistingServer: !process.env.CI,
-  },{
-    command: 'npx --yes http-server -a localhost -p 8181 test-publication-pathname',
-    url: 'http://localhost:8181',
-    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    // reuseExistingServer: !process.env.CI,
   }]
 });
 


### PR DESCRIPTION
This PR resolves an issue where lightbox assets would not load when the publication URL was set to something with a pathname (eg, `https://example.org/publication/`). An overview of the changes:
- Adds an integration test that builds a second publication at `test-publication-pathname` with the URL `http://localhost:8181/test-publication-pathname/` and persists it in CI to the browser testing stage.
- Creates a few helper functions to modify publication configuration and walk a publication sitemap.
- Fixes an issue where sitemap URLs did not include a pathname when present.
- Passes a `lightbox` argument to ImageElement and VideoElement render functions and prepends publication `pathname` when rendering for lightbox usage and pathname is not `/`