### PR TITLE
Workaround for improperly installed arch binaries

### DIFF
--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.35",
+  "version": "1.0.0-rc.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.35",
+  "version": "1.0.0-rc.36",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",
@@ -55,7 +55,8 @@
     "iiif-builder": "^1.0.7",
     "lit": "^3.1.2",
     "lunr": "^2.3.9",
-    "template-polyfill": "^2.0.0"
+    "template-polyfill": "^2.0.0",
+    "vite": "^6.3.6"
   },
   "devDependencies": {
     "@11ty/eleventy": "<=3.1.0",
@@ -84,6 +85,7 @@
     "cpy-cli": "^5.0.0",
     "cross-env": "^7.0.3",
     "del-cli": "^5.1.0",
+    "esbuild": "<=0.25.9",
     "eslint": "^8.57.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
This PR contains a workaround for issue #1066 , where users were unable to create publications, or in some cases could create but not build publications, due to an issue with npm and esbuild.

This PR:
- Pins `esbuild<=0.25.9` as a direct dependency of `@thegetty/quire-11ty`, which from testing affected machines appears durably works around for the issue.
- Adds `vite` as a direct dependency to `@thegetty/quire-11ty` to avoid intermediate dependency issues like the one in the issue.
- Updates the changelog for `@thegety/quire-11ty`