### PR TITLE
Bump `@thegetty/quire-11ty` version and update changelog

### DIFF
--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -12,6 +12,13 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.37]
+
+## Fixed
+
+- `contributors` shortcode insert unnecessary comma - https://github.com/thegetty/quire/issues/873
+
+
 ## [1.0.0-rc.36]
 
 ## Changed

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.36",
+  "version": "1.0.0-rc.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.36",
+  "version": "1.0.0-rc.37",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",


### PR DESCRIPTION
This PR bumps versions and the changelog for @thegetty/quire-11ty v1.0.0-rc.37