### PR TITLE
Fix `Cannot read properties of undefined (reading 'citations')` error in @thegetty/quire-11ty@1.0.0-rc.38

### DIFF
--- a/_tests/integration-test.mjs
+++ b/_tests/integration-test.mjs
@@ -82,6 +82,14 @@ const buildSitePdfEpub = async (t) => {
   }
 }
 
+test.before('Mirror user package environment.', (t) => {
+  // Remove lockfile to ensure dependency resolution runs as from npm package
+  const lockfile = path.join('packages','11ty','package-lock.json')
+  if (fs.existsSync(lockfile)) {
+    fs.rmSync(lockfile)
+  }
+})
+
 test.serial('Create the default publication and build the site, epub, pdf', async (t) => {
   const newCmd = await execa('quire', ['new', '--debug', '--quire-path', eleventyPath, publicationName ])
 

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -220,10 +220,10 @@ export default async function (eleventyConfig) {
   /**
    * Load plugins for the Quire template shortcodes and filters
    */
-  eleventyConfig.addPlugin(componentsPlugin, collections)
+  eleventyConfig.addPlugin(componentsPlugin)
   eleventyConfig.addPlugin(filtersPlugin)
   eleventyConfig.addPlugin(frontmatterPlugin)
-  eleventyConfig.addPlugin(shortcodesPlugin, collections)
+  eleventyConfig.addPlugin(shortcodesPlugin)
 
   /**
    * Load additional plugins used for Quire projects

--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -12,6 +12,12 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0-rc.39]
+
+### Fixed
+
+- Fix issue where publications started via `quire new` against 1.0.0-rc.38 would not build with an error about `citations` - https://github.com/thegetty/quire/issues/1091
+
 ## [1.0.0-rc.38]
 
 ### Fixed

--- a/packages/11ty/_plugins/components/index.js
+++ b/packages/11ty/_plugins/components/index.js
@@ -10,8 +10,8 @@ import * as components from '../../_includes/components/index.js'
  * @param      {Object}  eleventyConfig  eleventy configuration
  * @param      {Object}  options         options
  */
-export default function (eleventyConfig, collections, options) {
-  const { addShortcode } = shortcodeFactory(eleventyConfig, collections)
+export default function (eleventyConfig, options) {
+  const { addShortcode } = shortcodeFactory(eleventyConfig)
 
   for (const component in components) {
     switch (component) {

--- a/packages/11ty/_plugins/components/shortcodeFactory.js
+++ b/packages/11ty/_plugins/components/shortcodeFactory.js
@@ -9,18 +9,22 @@
  * @param  {Object}  component       A JavaScript shortcode component
  * @param  {String}  tagName         A template tag name for the component
  */
-export default function (eleventyConfig, collections) {
+export default function (eleventyConfig) {
   return {
     addShortcode: function (tagName, component) {
       eleventyConfig.addShortcode(tagName, function (...args) {
+        // Pass access from the internal collections environment to shortcodes
+        const collections = this.ctx?.environments?.collections ?? {}
         const page = collections.all?.find(({ inputPath }) => inputPath === this.page.inputPath)
-        // console.log(tagName,page.inputPath)
+
         return component(eleventyConfig, { collections, page }).bind(this)(...args)
       })
     },
     addPairedShortcode: function (tagName, component) {
       eleventyConfig.addPairedShortcode(tagName, function (content, ...args) {
+        const collections = this.ctx?.environments?.collections ?? {}
         const page = collections.all?.find(({ inputPath }) => inputPath === this.page.inputPath)
+
         return component(eleventyConfig, { collections, page })(content, ...args)
       })
     }

--- a/packages/11ty/package-lock.json
+++ b/packages/11ty/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.38",
+  "version": "1.0.0-rc.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.38",
+  "version": "1.0.0-rc.39",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",


### PR DESCRIPTION
This PR fixes #1091 , where it was not possible to build publications based on `@thegetty/quire-11ty@1.0.0-rc.38` due to changes in the handling of collections in  `@11ty/eleventy@3.1.1` and above. Details:
- Updates integration testing so that it reliably reproduces the issue by removing the package lockfile before integration testing. Public users do not process new publications with a lockfile and so sometimes will get a different version of upstream dependencies than tested in CI / CD.
- Refactors `addShortcode` and `addPairedShortcode` functions to access collections via internal eleventy APIs rather than passed `collections` object. Also removes `collections` from `components` plugin function signature.