### PR TITLE
Refine accordion epub compatibility / accessibility: set to open and remove non-zero tabIndex properties (DEV-21893)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "cross-env mkdir -p reports _site-test && ava --verbose --timeout 360s && playwright test && QUIRE_TEST_PUB_PATHNAME=1 playwright test",
     "test:browsers": "cross-env mkdir -p _site-test && playwright test && QUIRE_TEST_PUB_PATHNAME=1 playwright test",
     "test:browsers-circleci": "mkdir -p _site-test && SHARD=\"$((${CIRCLE_NODE_INDEX}+1))\" && npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL} && QUIRE_TEST_PUB_PATHNAME=1 npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL}",
-    "test:clean": "cross-env rm -rf test-publication* reports test-results publication.zip ava.xml packages/11ty/_site packages/11ty/_epub",
+    "test:clean": "cross-env rm -rf _site-test test-publication* reports test-results publication.zip ava.xml packages/11ty/_site packages/11ty/_epub packages/11ty/node_modules",
     "test:integration": "ava --tap --timeout 360s | tap-xunit > reports/publication-build.xml",
     "test:serve": "npx --yes http-server _site-test -a localhost -p 8080"
   },
@@ -36,7 +36,9 @@
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.29",
     "ava": "^6.2.0",
+    "cross-env": "^10.1.0",
     "execa": "^9.5.2",
+    "js-yaml": "^4.1.1",
     "jsdom": "^26.1.0",
     "playwright": "^1.52.0",
     "tap-xunit": "^2.4.1"

--- a/packages/11ty/_plugins/transforms/outputs/epub/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/transform.js
@@ -7,7 +7,7 @@ import writer from './writer.js'
 /**
  * Content transforms for EPUB output
  */
-export default function (eleventyConfig, collections, content) {
+export default function (eleventyConfig, collections, content, returnTransformed = false) {
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const removeHTML = eleventyConfig.getFilter('removeHTML')
   const slugify = eleventyConfig.getFilter('slugify')
@@ -171,6 +171,17 @@ export default function (eleventyConfig, collections, content) {
     linkElement.setAttribute('href', `${filename(index, collections.epub[index])}${hash}`)
   })
 
+  /**
+   * Set accordions to open and ensure they don't carry `tabindex` attributes
+   **/
+  body.querySelectorAll('details.accordion-section').forEach((details) => {
+    details.open = true
+  })
+
+  body.querySelectorAll('summary.accordion-section__heading').forEach((summary) => {
+    summary.removeAttribute('tabindex')
+  })
+
   transformPaths(body)
 
   /**
@@ -203,6 +214,10 @@ export default function (eleventyConfig, collections, content) {
   }
 
   readingOrder.push(item)
+
+  if (returnTransformed) {
+    return epubContent
+  }
 
   write(outputFilename, epubContent)
 


### PR DESCRIPTION
This PR updates the epub transform to improve the compatibility and accessibility of accordion components. Details:
- Adds an argument to the epub transform, `returnTransformed` that has the transform return the modified epub content instead of unmodified content.
- Adds a test of the epub transform output with an accordion, verifying that `details` elements are set to open and that `summary` elements do not have a tabindex (or it is set to 0).
- Adds a step to the epub transform that fixes the issue by setting `details[open=true]` and removing `tabindex` attributes from `summary` 
- Updates monorepo's `test:clean` script to remove other build assets (`_site-test` and `packages/11ty/node_modules`, which gets installed during package testing) and add some libraries missing for testing in monorepo root 