### PR TITLE
Fix page data contributor regression in 1.0.0-rc.39

### DIFF
--- a/packages/11ty/_plugins/shortcodes/contributors.js
+++ b/packages/11ty/_plugins/shortcodes/contributors.js
@@ -95,6 +95,8 @@ export default function (eleventyConfig) {
       case 'name-title-block': {
         const separator = (format === 'name-title') ? ', ' : ''
         const listItems = contributorList.map((contributor) => {
+          const { first_name: firstName, id, last_name: lastName } = contributor
+
           const contributorParts = [
             `<span class="quire-contributor__name">${fullname(contributor)}</span>`
           ]
@@ -110,8 +112,9 @@ export default function (eleventyConfig) {
             )
           }
 
+          const contributorId = slugify(id ?? `${firstName} ${lastName}`)
           return `
-            <li class="quire-contributor" id="${slugify(contributor.id)}">${contributorParts.join(separator)}</li>
+            <li class="quire-contributor" id="${contributorId}">${contributorParts.join(separator)}</li>
           `
         })
         contributorsElement = `

--- a/packages/11ty/_tests/shortcodes/contributors.spec.js
+++ b/packages/11ty/_tests/shortcodes/contributors.spec.js
@@ -129,7 +129,8 @@ test.serial('contributors from page data behave properly on content=pageContribu
   // - A page with no contributor
   // - Page contributors by Contributor One, Contributor Three
 
-  // NB: Including a page without a contributor element to track https://github.com/thegetty/quire/issues/853#issuecomment-3534338465
+  // NB: Page without a contributor element to tracks https://github.com/thegetty/quire/issues/853#issuecomment-3534338465
+  // Page with multiple contributors tracks https://github.com/thegetty/quire/issues/853#issuecomment-3577118911
   const environment = new Eleventy('.', '_site', {
     config: stubGlobalData(data, (eleventyConfig) => {
       eleventyConfig.addTemplate('publication-contributors.md', '# A Page\n{% contributors context=publicationContributors format="bio" %}', { abstract: '', contributor: [{ first_name: 'Contributor', last_name: 'One' }], title: 'A Page', layout: 'base.11ty.js', order: 0, outputs: ['html'] })

--- a/packages/11ty/content/_computed/eleventyComputed.js
+++ b/packages/11ty/content/_computed/eleventyComputed.js
@@ -225,12 +225,18 @@ export default {
     let contributors = publication.contributor.filter(Boolean)
     const inPubData = (contrib) => !!contributors.find((c) => c.id === contrib.id || (!contrib.id && contrib.first_name === c.first_name && contrib.last_name === c.last_name))
 
-    // Add any contributors that are only present in page headmatter
-    const headmatterOnly = collections.allSorted.flatMap((page) => {
+    // Add unique'd contributors that are present in page headmatter only
+    const headmatterOnly = new Map()
+    collections.allSorted.flatMap((page) => {
       return (page.data.contributor ?? []).filter((c) => !inPubData(c))
+    }).forEach((contributor) => {
+      const { id, first_name, last_name } = contributor
+      const key = id ?? `${first_name} ${last_name}`
+
+      headmatterOnly.set(key, contributor)
     })
 
-    contributors = contributors.concat(headmatterOnly)
+    contributors = contributors.concat(Array.from(headmatterOnly.values()))
       .map((c) => addPages(c, collections))
 
     return contributors


### PR DESCRIPTION
This PR fixes regressions in quire-11ty@1.0.0-rc.39 where publications with a page with no `contributor` propery in page headmatter would crash builds, multiple contributors without ids would trigger duplicate element id errors (on `id='undefined'`), and contributors from page data with the same first_name + last_name pairs were not being properly deduplicated. Details:
- Adjusts `contributors` shortcode test cases to better cover state + error space
- Uses slugged first_name-last_name string as fallback id for contributors without one
- Corrects contributor coalescing across pages in `publicationContributors`
 
These issues are tracked by https://github.com/thegetty/quire/issues/853#issuecomment-3534338465 and https://github.com/thegetty/quire/issues/853#issuecomment-3577118911 