### PR TITLE
Fix accordions leaking default "Details" content from captive browser in PDFs (DEV-21892)

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/transform.js
@@ -216,8 +216,29 @@ export default function (eleventyConfig, collections, content) {
     }
   }
 
-  function openAccordions (document) {
-    document.querySelectorAll('details.accordion-section').forEach((sect) => { sect.open = true })
+  /**
+   * @function replaceAccordions
+   *
+   * @param {Element} element
+   *
+   * Replaces accordions in `Document` with section elements.
+   *
+   * Primarily this is a workaround for an issue where accordions that span PDF pages
+   * trigger browser-internal summary default text to appear in PDFs.
+   **/
+  function replaceAccordions (element) {
+    element.querySelectorAll('details.accordion-section').forEach((accordionSection) => {
+      // Transfer accordion section's heading, content to a new `section` element
+      const summary = accordionSection.querySelector('summary')
+      const headingContent = summary.innerHTML
+      summary.remove()
+
+      const section = element.ownerDocument.createElement('section')
+      section.classList.add('accordion-section')
+      section.innerHTML = headingContent + accordionSection.innerHTML
+
+      accordionSection.replaceWith(section)
+    })
   }
 
   const pdfPages = collections.pdf.map(({ outputPath }) => outputPath)
@@ -260,7 +281,7 @@ export default function (eleventyConfig, collections, content) {
   filterOutputs(sectionElement, 'pdf')
   trimLeadingSeparator(sectionElement)
   slugifyIds(sectionElement)
-  openAccordions(sectionElement)
+  replaceAccordions(sectionElement)
 
   collections.pdf[pageIndex].sectionElement = sectionElement.outerHTML
 


### PR DESCRIPTION
This PR fixes DEV-21892, where `accordion` elements that span PDF pages could sometimes contain browser-default content (a "Details" label and disclosure triangle) when printing with pagedjs. Details:
- Adds a test ensuring that the PDF transform turns accordion `details` into `section` elements
- Modifies the PDF transform to ensure that accordions are replaced with `section` elements