### PR TITLE
Fix macos CI failures due to change in resource class default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ executors:
 
   macos:
     macos:
-      xcode: '16.2.0'
+      xcode: '16.3.0'
+    resource_class: m4pro.medium
     environment:
         PUPPETEER_EXECUTABLE_PATH: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
   win: 


### PR DESCRIPTION
This PR updates the CI configuration to work around an issue with macos VMs on circleCI. Circle is going to retire some of the macos VM tiers and the update appears to misconfigure new macos VMs by misname the new default resource class. This updates the circle CI configuration to manually select `m4pro.medium`, the new default.