### PR TITLE
Remove tarball after use in `quire new` command

### DIFF
--- a/packages/cli/src/commands/create.test.js
+++ b/packages/cli/src/commands/create.test.js
@@ -1,7 +1,8 @@
+import esmock from 'esmock'
+import path from 'node:path'
+import sinon from 'sinon'
 import test from 'ava'
 import { Volume, createFsFromVolume } from 'memfs'
-import sinon from 'sinon'
-import esmock from 'esmock'
 
 test.beforeEach((t) => {
   // Create sinon sandbox for mocking
@@ -291,4 +292,45 @@ test('create command should pass quire-path option to methods', async (t) => {
 
   t.true(initCall.args[2] === options, 'initStarter should receive options with quire-path')
   t.true(installCall.args[2] === options, 'installInProject should receive options with quire-path')
+})
+
+test('create command should remove temp dir and package artifacts', async (t) => {
+  const { sandbox, fs, projectRoot, vol } = t.context
+
+  // Setup project directory
+  fs.mkdirSync(projectRoot)
+
+  // Mock fs (adding copySync) and git (with mocked chainable stubs)
+  // NB: Passing `vol` here as fs because memfs only provides the cpSync there 
+  const { quire } = await esmock('../lib/quire/index.js', {
+    'fs-extra': vol,
+    '#lib/git/index.js': {
+      add: () => {
+        return {
+          commit: sandbox.stub()
+        }
+      },
+      cwd: () => {
+        return {
+          rm: () => {
+            return {
+              catch: sandbox.stub()
+            }
+          }
+        }
+      }
+    },
+    'execa': {
+      // Mock `npm pack` behvaior of creating a file in .temp
+      execaCommand: sandbox.stub().withArgs(/npm pack/).callsFake(() => {
+        fs.writeFileSync(path.join(projectRoot, '.temp', 'thegetty-quire-11ty-1.0.0.tgz'), '')
+      })
+    }
+  })
+
+  await quire.installInProject(projectRoot, '1.0.0')
+
+  // Check that neither the temp dir nor the tarball exist
+  t.false(fs.existsSync(path.join(projectRoot, '.temp')))
+  t.false(fs.existsSync(path.join(projectRoot, 'thegetty-quire-11ty-1.0.0.tgz')))
 })

--- a/packages/cli/src/lib/quire/index.js
+++ b/packages/cli/src/lib/quire/index.js
@@ -179,16 +179,19 @@ async function installInProject(projectPath, quireVersion, options = {}) {
 
   // Copy if passed a path and it exists, otherwise attempt to download the tarball for this pathspec
   if (fs.existsSync(quirePath)) {
-    fs.copySync(quirePath, tempDir)
+    fs.cpSync(quirePath, tempDir, {recursive: true})
   } else {
-    await execaCommand(`npm pack ${ options.debug ? '--debug' : '--quiet' } ${quire11tyPackage}`)
+    await execaCommand(`npm pack ${ options.debug ? '--debug' : '--quiet' } --pack-destination ${tempDir} ${quire11tyPackage}`)
 
     // Extract only the package dir from the tar bar and strip it from the extracted path
-    await execaCommand(`tar -xzf thegetty-quire-11ty-${quireVersion}.tgz -C ${tempDir} --strip-components=1 package/`)
+    const tarballPath = path.join(tempDir, `thegetty-quire-11ty-${quireVersion}.tgz`)
+    await execaCommand(`tar -xzf ${tarballPath} -C ${tempDir} --strip-components=1 package/`)
+
+    fs.rmSync(tarballPath)
   }
 
   // Copy `.temp` to projectPath
-  fs.copySync(tempDir, projectPath)
+  fs.cpSync(tempDir, projectPath, {recursive: true})
 
   console.debug('[CLI:quire] installing dev dependencies into quire project')
   /**
@@ -201,7 +204,7 @@ async function installInProject(projectPath, quireVersion, options = {}) {
     await execaCommand('npm install --save-dev', { cwd: projectPath })
   } catch(error) {
     console.warn(`[CLI:error]`, error)
-    fs.removeSync(projectPath)
+    fs.rmSync(projectPath, {recursive: true})
     return
   }
 
@@ -218,7 +221,7 @@ async function installInProject(projectPath, quireVersion, options = {}) {
   await git.add(eleventyFilesToCommit).commit('Adds `@thegetty/quire-11ty` files')
 
   // remove temporary 11ty install directory
-  fs.removeSync(path.join(projectPath, temp11tyDirectory))
+  fs.rmSync(path.join(projectPath, temp11tyDirectory), {recursive: true})
 }
 
 /**


### PR DESCRIPTION
This PR adds an integration test for https://github.com/thegetty/quire/issues/1068 , adjusts the `quire new` command to remove `@thegetty/quire-11ty` tarballs downloaded during publication install, and updates the underlying filesystem calls of `installInProject()` to use native node API calls for better testability.  