### PR TITLE
Fix: Sanitize a string for safe inclusion in XML/TAP output

### DIFF
--- a/_tests/e2e-test.mjs
+++ b/_tests/e2e-test.mjs
@@ -22,8 +22,8 @@ import test from 'ava'
  * Sanitize a string for safe inclusion in XML/TAP output;
  * removes ANSI escape codes and replaces control characters.
  *
- * Nota bene: Puppeteer and (headless) Chrome contain escape codes and/or
- * control characters, these must be cleaned before inclusion in XML output.
+ * Nota bene: Errors thrown by Puppeteer/Chrome may contain escape codes and/or
+ * control characters that must be removed before inclusion in XML output.
  */
 const sanitizeForXml = (str) => {
   if (!str) return ''


### PR DESCRIPTION
Implements a `sanitizeForXml` method that is used for standard error and output from end-to-end and safe inclusion in XML/TAP output.

Necessary to surface errors produced by Puppeteer and (headless) Chrome, which may contain escape codes and/or control characters.

