### PR TITLE
Fix: create command behavior on install failure

### DIFF
--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -2,7 +2,7 @@ import Command from '#src/Command.js'
 import { Option } from 'commander'
 import fs from 'fs-extra'
 import { installer } from '#lib/installer/index.js'
-import { ProjectCreateError } from '#src/errors/index.js'
+import { DirectoryNotEmptyError, ProjectCreateError } from '#src/errors/index.js'
 
 /**
  * Quire CLI `new` Command
@@ -69,16 +69,21 @@ export default class CreateCommand extends Command {
         quireVersion = await installer.initStarter(starter, projectPath, options)
       } catch (error) {
         this.logger.error(error.message)
-        // Only remove directory if it wasn't pre-existing user content
-        if (!error.message.includes('not empty')) {
-          fs.removeSync(projectPath)
-        }
+        /**
+         * Nota bene: Auto-deletion of projectPath is disabled to prevent accidental data loss.
+         * @TODO implement safe cleaup that either tracks whether quire created the directory,
+         * or prompt the user for confirmation before deleting any files.
+         */
+        // if (!(error instanceof DirectoryNotEmptyError)) {
+        //   fs.removeSync(projectPath)
+        // }
         throw new ProjectCreateError(projectPath, error.message)
       }
 
       // Check if initStarter returned without a version
       if (!quireVersion) {
-        fs.removeSync(projectPath)
+        // Nota bene: Auto-deletion disabled - see comment above
+        // fs.removeSync(projectPath)
         throw new ProjectCreateError(projectPath, 'Failed to determine Quire version')
       }
 

--- a/packages/cli/src/errors/index.js
+++ b/packages/cli/src/errors/index.js
@@ -38,6 +38,7 @@ export {
 // Install errors (exit code: 6)
 export {
   DependencyInstallError,
+  DirectoryNotEmptyError,
   VersionNotFoundError
 } from './install/index.js'
 

--- a/packages/cli/src/errors/install/directory-not-empty-error.js
+++ b/packages/cli/src/errors/install/directory-not-empty-error.js
@@ -1,0 +1,22 @@
+import QuireError from '../quire-error.js'
+
+/**
+ * Error thrown when attempting to create a project in a non-empty directory
+ *
+ * This error indicates the target directory contains existing files,
+ * which could be user content that should not be overwritten or deleted.
+ */
+export default class DirectoryNotEmptyError extends QuireError {
+  constructor(path) {
+    const location = path === '.' ? 'the current directory' : path
+    super(
+      `Cannot create project in a non-empty directory: ${location}`,
+      {
+        code: 'DIRECTORY_NOT_EMPTY',
+        exitCode: 2,
+        filePath: path,
+        suggestion: 'Choose an empty directory or create a new one'
+      }
+    )
+  }
+}

--- a/packages/cli/src/errors/install/index.js
+++ b/packages/cli/src/errors/install/index.js
@@ -6,4 +6,5 @@
  * @module errors/install
  */
 export { default as DependencyInstallError } from './dependency-install-error.js'
+export { default as DirectoryNotEmptyError } from './directory-not-empty-error.js'
 export { default as VersionNotFoundError } from './version-not-found-error.js'


### PR DESCRIPTION
Fixes a regression bug introduced by PR #1143

When creating a new project failure to install in a project directory tried to cleanup/delete the project directory based on fragile string matching in the error message!

### Changes

This pull-requests implements a `DirectoryNotEmpty` error yet still disables auto-delete/cleanup behavior for future implementation that either tracks wether quire created the directory or prompts the user for confirmation before destructive actions.

