### PR TITLE
Add semantic release configuration

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,39 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+  
+jobs:
+  semantic-release:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+  
+  name: Semantic Release
+  runs-on: ubuntu-latest
+  permissions:
+    contents: write
+    issues: write
+    pull-requests: write
+  
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with: 
+        fetch-depth: 0
+        persist-credentials: false
+      
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "lts/*"
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Release
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npx semantic-release
+
+
+      

--- a/.releaserc.prerelease.yaml
+++ b/.releaserc.prerelease.yaml
@@ -1,0 +1,9 @@
+plugins: 
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/git"
+
+branches:
+  - main
+  

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,13 @@
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/npm"
+  - "@semantic-release/git"
+
+branches:
+  - main
+
+workspaces:
+  - path: packages/cli
+  - path: packages/11ty


### PR DESCRIPTION
### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [ ] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [ ] I have made my changes in a new branch and not directly in the main branch

- [ ] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
No

### Does this pull request necessitate changes to Quire's documentation?
No

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

Add a GHA  that runs on push to main and release branches. 
Versions in package.json will update automatically and committed. This elimnates manual version bumps. Supports keeping cli and 11ty packages in sync. 

Link to semantic-release [here](https://github.com/semantic-release/semantic-release/tree/master)

