### PR TITLE
Refine radio annotations: set default, selected choice on canvas-panel

### DIFF
--- a/packages/11ty/_includes/components/figure/image/canvas-panel.js
+++ b/packages/11ty/_includes/components/figure/image/canvas-panel.js
@@ -22,8 +22,9 @@ export default function (eleventyConfig) {
    */
   return function (data) {
     const {
+      annotations,
       canvasId,
-      choiceId,
+      choiceId: choice,
       height = '',
       id,
       iiifContent,
@@ -37,6 +38,15 @@ export default function (eleventyConfig) {
     if (!manifestId && !iiifContent) {
       logger.error(`Invalid params for figure "${id}": `, data)
       return ''
+    }
+
+    let choiceId = choice
+    const allAnnotations = (annotations ?? []).flatMap(anno => anno.items)
+    if (allAnnotations.some(a => a.type === 'choice') && !choice) {
+      const defaultAnnotation = allAnnotations.at(0)
+      const selectedAnnotation = allAnnotations.find(item => item.selected)
+
+      choiceId = selectedAnnotation ? selectedAnnotation.uri : defaultAnnotation.uri
     }
 
     return html`

--- a/packages/11ty/_tests/shortcodes/figure.spec.js
+++ b/packages/11ty/_tests/shortcodes/figure.spec.js
@@ -1,0 +1,106 @@
+/**
+ * figure.spec.js
+ *
+ * Tests for the `figure` shortcode
+ *
+ **/
+import Figure from '../../_plugins/figures/figure/index.js'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { initEleventyEnvironment } from '../helpers/index.js'
+import { JSDOM } from 'jsdom'
+import path from 'path'
+import test from 'ava'
+
+const iiifConfigPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../_plugins/figures/test/__fixtures__/iiif-config.json')
+
+// Initialize an 11ty environment with figures and other minimal props for figures
+test.before('', async (t) => {
+  const iiifConfig = JSON.parse(fs.readFileSync(iiifConfigPath))
+  const eleventy = await initEleventyEnvironment({})
+
+  t.context.eleventy = eleventy
+  t.context.iiifConfig = iiifConfig
+})
+
+test('figures with choice annotations should render a canavs-panel element with a choice-id', async (t) => {
+  const { eleventy, iiifConfig } = t.context
+
+  const data = {
+    id: 'test-choice-annotations',
+    label: 'Figure T.C.A',
+    caption: 'Figure Test Choice Annotations.',
+    credit: '',
+    annotations: [
+      {
+        input: 'radio',
+        items: [
+          {
+            src: 'figures/variant-a.jpg',
+            label: 'Variant #1'
+          },
+          {
+            src: 'figures/variant-b.jpg',
+            label: 'Variant #2'
+          }
+        ]
+      }
+    ]
+  }
+
+  // Get the component off the eleventyConfig so intermediate `getFilter()`s resolve
+  const figureImage = eleventy.eleventyConfig.config.javascriptFunctions.figureImage
+
+  const figure = new Figure(iiifConfig, null, data)
+  const rendered = await figureImage(figure)
+
+  const dom = JSDOM.fragment(rendered)
+
+  const canvasPanel = dom.querySelector('canvas-panel')
+
+  t.truthy(canvasPanel, 'Image should render a canvas-panel element')
+  t.truthy(canvasPanel.getAttribute('choice-id'), 'canvas-panel element should have choice-id set')
+})
+
+test('figures with choice annotations that are `selected: true` should set the choice-id of the selected annotation', async (t) => {
+  const { eleventy, iiifConfig } = t.context
+
+  const data = {
+    id: 'test-choice-annotations',
+    label: 'Figure T.C.A',
+    caption: 'Figure Test Choice Annotations.',
+    credit: '',
+    annotations: [
+      {
+        input: 'radio',
+        items: [
+          {
+            src: 'figures/variant-a.jpg',
+            label: 'Variant #1'
+          },
+          {
+            src: 'figures/variant-b.jpg',
+            label: 'Variant #2',
+            selected: true
+          }
+        ]
+      }
+    ]
+  }
+
+  // Get the component off the eleventyConfig
+  const figureImage = eleventy.eleventyConfig.config.javascriptFunctions.figureImage
+
+  // Use the annotation for matching on the test
+  const figure = new Figure(iiifConfig, null, data)
+  const selected = figure.annotations.flatMap(annotation => annotation.items).find(item => item.selected)
+  const rendered = await figureImage(figure)
+
+  const dom = JSDOM.fragment(rendered)
+
+  const canvasPanel = dom.querySelector('canvas-panel')
+
+  t.truthy(canvasPanel, 'Image should render a canvas-panel element')
+  t.truthy(canvasPanel.getAttribute('choice-id'), 'canvas-panel element should have choice-id set')
+  t.is(canvasPanel.getAttribute('choice-id'), selected.uri)
+})

--- a/packages/11ty/content/_assets/javascript/application/canvas-panel.js
+++ b/packages/11ty/content/_assets/javascript/application/canvas-panel.js
@@ -273,10 +273,15 @@ const setUpUIEventHandlers = () => {
 
   /**
    * Add click handlers to UI inputs
+   *
+   * Note: checkboxes need initializing but radio buttons use `canvas-panel[choice-id]`
    */
   const inputs = document.querySelectorAll('.annotations-ui__input')
   for (const input of inputs) {
-    handleSelect(input)
+    if (input.type === 'checkbox') {
+      handleSelect(input)
+    }
+
     input.addEventListener('click', ({ target }) => handleSelect(target))
   }
 }


### PR DESCRIPTION
This PR restages #1137 against the rewound branch history

Original description
-------------------
This PR addresses https://github.com/thegetty/quire/issues/1111 , where figure choice annotations show the incorrect image at first page load. An overview:

Adds a basic test for the figureImage component (_includes/components/figure/image/index.js) that ensures the nested canvas-panel element has any choice-id set.
Adjusts client application javascript to only select annotation checkboxes at page load to synchronize annotation state
Mirrors client-side behavior of selecting the first annotation choice by setting first annotation as default choice-id on the canvas-panel element.