### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/11ty/_includes/components/figure/table/element.js
+++ b/packages/11ty/_includes/components/figure/table/element.js
@@ -21,7 +21,18 @@ export default function (eleventyConfig) {
    * @return  {String}  Text content of the referenced template file
    */
   return async function ({ src }) {
-    const filePath = path.join(eleventyConfig.directoryAssignments.input, assetDir, src)
+    const assetRoot = path.resolve(eleventyConfig.directoryAssignments.input, assetDir)
+
+    if (typeof src !== 'string' || path.isAbsolute(src)) {
+      throw new Error('Invalid figure table source path')
+    }
+
+    const filePath = path.resolve(assetRoot, src)
+    const relativePath = path.relative(assetRoot, filePath)
+
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+      throw new Error('Invalid figure table source path')
+    }
 
     return await eleventyConfig.javascript.shortcodes.renderFile(filePath, {}, 'html')
   }

--- a/packages/11ty/_plugins/figures/iiif/manifest/writer.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/writer.js
@@ -14,8 +14,13 @@ export default class ManifestWriter {
    */
   write (manifest) {
     if (!manifest) return { errors: ['Error writing manifest. Manifest is undefined.'] }
+    if (typeof manifest.id !== 'string') return { errors: ['Error writing manifest. Manifest id is invalid.'] }
     const uriPathname = manifest.id.replace(this.baseURI, '')
-    const outputPath = path.join(this.outputRoot, uriPathname)
+    const outputRootPath = path.resolve(this.outputRoot)
+    const outputPath = path.resolve(this.outputRoot, uriPathname)
+    if (outputPath !== outputRootPath && !outputPath.startsWith(`${outputRootPath}${path.sep}`)) {
+      return { errors: ['Failed to write manifest. Manifest id resolves outside output directory.'] }
+    }
     try {
       fs.ensureDirSync(path.parse(outputPath).dir)
       fs.writeJsonSync(outputPath, manifest, { spaces: 2 })


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `packages/11ty/_includes/components/figure/table/element.js:L25`

The table element shortcode builds a filesystem path from untrusted `src` (`path.join(input, assetDir, src)`) and immediately renders that file. If `src` contains traversal segments (e.g., `../../...`), an attacker controlling figure data could read and render arbitrary files from the build host.

## Solution

Normalize and validate `src` before use. Resolve the final path and enforce that it stays within the intended asset root directory (e.g., compare `resolvedPath.startsWith(resolvedAssetRoot)`). Reject absolute paths and `..` traversal.

## Changes

- `packages/11ty/_includes/components/figure/table/element.js` (modified)
- `packages/11ty/_plugins/figures/iiif/manifest/writer.js` (modified)