### PR TITLE
Adjust sass deprecation warnings for current conditions

### DIFF
--- a/packages/11ty/_includes/components/lightbox/styles.js
+++ b/packages/11ty/_includes/components/lightbox/styles.js
@@ -26,8 +26,8 @@ export default function (eleventyConfig) {
       quietDeps: true,
       silenceDeprecations: [
         'color-functions',
-        'mixed-decls',
         'global-builtin',
+        'if-function',
         'import'
       ]
     }

--- a/packages/11ty/_plugins/transforms/outputs/epub/index.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/index.js
@@ -54,8 +54,8 @@ export default (eleventyConfig, collections) => {
       quietDeps: true,
       silenceDeprecations: [
         'color-functions',
-        'mixed-decls',
         'global-builtin',
+        'if-function',
         'import'
       ]
     }

--- a/packages/11ty/_plugins/transforms/outputs/pdf/write.js
+++ b/packages/11ty/_plugins/transforms/outputs/pdf/write.js
@@ -59,8 +59,8 @@ export default function (eleventyConfig) {
       quietDeps: true,
       silenceDeprecations: [
         'color-functions',
-        'mixed-decls',
         'global-builtin',
+        'if-function',
         'import'
       ]
     }

--- a/packages/11ty/_plugins/vite/index.js
+++ b/packages/11ty/_plugins/vite/index.js
@@ -88,8 +88,8 @@ export default function (eleventyConfig, { directoryConfig, publication }) {
             quietDeps: true,
             silenceDeprecations: [
               'color-functions',
-              'mixed-decls',
               'global-builtin',
+              'if-function',
               'import'
             ]
           }


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [existing issue](https://github.com/thegetty/quire/issues).*

**Before submitting your PR, make sure that you can run the following commands: `quire preview`, `quire build`, `quire pdf`, and `quire epub`. If any of those core quire commands throw errors/yield unexpected behavior, we will NOT review the PR!**

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?

See closed issue #1069 and merged PR #1120 

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

I was seeing the below deprecation messaging in `preview` and `build` when running a `quire-11ty@1.0.0-rc.44` project. I'm not sure how/if I missed it when reviewing the last PR we merged to address this, but now that the dust has settled following the repo reset, I can see it's definitely there. This PR addresses these warnings by removing the now uneccesary `mixed-decls` silencing and adding silencing for `if-function`.

```
WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.

DEPRECATION WARNING [if-function]: The Sass if() syntax is deprecated in favor of the modern CSS syntax.

Suggestion: if(sass($theme == classic): $black; else: $accent-color)

More info: https://sass-lang.com/d/if-function

    ╷
602 │   color: if($theme == classic,$black,$accent-color);
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    content/_assets/styles/components/quire-page.scss 602:10  @import
    content/_assets/styles/components/_all.scss 6:9           @import
    content/_assets/styles/application.scss 27:9              root stylesheet

DEPRECATION WARNING [if-function]: The Sass if() syntax is deprecated in favor of the modern CSS syntax.

Suggestion: if(sass($theme == classic): $black; else: $accent-color)

More info: https://sass-lang.com/d/if-function

    ╷
603 │   fill: if($theme == classic,$black,$accent-color);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    content/_assets/styles/components/quire-page.scss 603:9  @import
    content/_assets/styles/components/_all.scss 6:9          @import
    content/_assets/styles/application.scss 27:9             root stylesheet

DEPRECATION WARNING [if-function]: The Sass if() syntax is deprecated in favor of the modern CSS syntax.

Suggestion: if(sass($theme == classic): $accent-color; else: link-hover-color($secondary-background-color))

More info: https://sass-lang.com/d/if-function

    ╷
623 │       color: if($theme == classic,$accent-color,link-hover-color($secondary-background-color));
    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    content/_assets/styles/components/quire-page.scss 623:14  @import
    content/_assets/styles/components/_all.scss 6:9           @import
    content/_assets/styles/application.scss 27:9              root stylesheet

DEPRECATION WARNING [if-function]: The Sass if() syntax is deprecated in favor of the modern CSS syntax.

Suggestion: if(sass($theme == classic): $accent-color; else: link-hover-color($secondary-background-color))

More info: https://sass-lang.com/d/if-function

    ╷
624 │       fill: if($theme == classic,$accent-color,link-hover-color($secondary-background-color));
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    content/_assets/styles/components/quire-page.scss 624:13  @import
    content/_assets/styles/components/_all.scss 6:9           @import
    content/_assets/styles/application.scss 27:9              root stylesheet

DEPRECATION WARNING [if-function]: The Sass if() syntax is deprecated in favor of the modern CSS syntax.

Suggestion: if(sass($theme == classic): $accent-color; else: link-hover-color($content-background-color))

More info: https://sass-lang.com/d/if-function

    ╷
659 │         color: if($theme == classic,$accent-color,link-hover-color($content-background-color));
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    content/_assets/styles/components/quire-page.scss 659:16  @import
    content/_assets/styles/components/_all.scss 6:9           @import
    content/_assets/styles/application.scss 27:9              root stylesheet

WARNING: 1 repetitive deprecation warnings omitted.
Run in verbose mode to see all warnings.

WARNING: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.
```

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?

No

### Include screenshots of before/after if applicable.



### Additional Comments

