### PR TITLE
Store figure image derivative dimensions and paths on `derivatives` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,7 +1298,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
       "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -1317,7 +1316,6 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1402,7 +1400,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
@@ -1417,7 +1414,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -1432,7 +1428,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@iiif/helpers": {
@@ -2128,9 +2123,9 @@
       }
     },
     "node_modules/@pagefind/darwin-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
-      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
       "cpu": [
         "arm64"
       ],
@@ -2142,9 +2137,9 @@
       ]
     },
     "node_modules/@pagefind/darwin-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
-      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
       "cpu": [
         "x64"
       ],
@@ -2156,9 +2151,9 @@
       ]
     },
     "node_modules/@pagefind/freebsd-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
-      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
       "cpu": [
         "x64"
       ],
@@ -2170,9 +2165,9 @@
       ]
     },
     "node_modules/@pagefind/linux-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
-      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
       "cpu": [
         "arm64"
       ],
@@ -2184,9 +2179,9 @@
       ]
     },
     "node_modules/@pagefind/linux-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
-      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
       "cpu": [
         "x64"
       ],
@@ -2197,24 +2192,10 @@
         "linux"
       ]
     },
-    "node_modules/@pagefind/windows-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
-      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@pagefind/windows-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
-      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
       "cpu": [
         "x64"
       ],
@@ -3020,27 +3001,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@simple-git/args-pathspec": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
-      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
-      "license": "MIT"
-    },
-    "node_modules/@simple-git/argv-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
-      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@simple-git/args-pathspec": "^1.0.3"
-      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3271,7 +3239,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vercel/nft": {
@@ -3420,7 +3387,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3451,7 +3417,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
       "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^4.0.0",
@@ -4176,7 +4141,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -4384,7 +4348,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4790,7 +4753,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
       "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "5.0.0"
@@ -5157,7 +5119,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concordance": {
@@ -5776,7 +5737,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/defaults": {
@@ -5854,7 +5814,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/del/-/del-7.1.0.tgz",
       "integrity": "sha512-v2KyNk7efxhlyHpjEvfyxaAihKKK0nWCuf6ZtqZcFFpQRG0bJ12Qsr0RpvsICMjAAZ8DOVCxrlqpxISlMHC4Kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "globby": "^13.1.2",
@@ -5990,7 +5949,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
       "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "aggregate-error": "^4.0.0"
@@ -6006,7 +5964,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
       "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6087,7 +6044,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -6127,7 +6083,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -6350,24 +6305,25 @@
       }
     },
     "node_modules/epubjs-cli": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/epubjs-cli/-/epubjs-cli-0.2.4.tgz",
-      "integrity": "sha512-7eW7wwohHCUOKpyMRQE5cJ7p3+Pu9SyYafL7/6jiKDxak5/QpLvT4EeAbrV+Vc74520KbAa3nmTiKlUb/PdYUQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/epubjs-cli/-/epubjs-cli-0.1.6.tgz",
+      "integrity": "sha512-DrmeG2e4RVzhvY1nGhzZ0SbxLUczfIzBA2QwZEpb9NEnkTpYn4o5QbWWXdiV81LVEemFiIa35lzREmbiplIxZg==",
       "license": "MIT",
       "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
         "commander": "^9.3.0",
         "epubjs": "^0.5.0-alpha.3",
+        "eslint": "^8.29.0",
+        "express": "^4.18.1",
         "jsdom": "^20.0.3",
         "jszip": "^3.10.1",
         "liquidjs": "^10.1.0",
         "mime-types": "^2.1.35",
+        "node-fetch": "^3.2.5",
         "ora": "^6.1.0"
       },
       "bin": {
         "epubjs-cli": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/epubjs-cli/node_modules/agent-base": {
@@ -6864,7 +6820,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6899,7 +6854,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -7214,7 +7168,6 @@
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -7231,7 +7184,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7244,7 +7196,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -7268,7 +7219,6 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7278,7 +7228,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -7295,7 +7244,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7311,7 +7259,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7328,7 +7275,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7341,7 +7287,6 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -7359,7 +7304,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -7372,7 +7316,6 @@
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -7388,7 +7331,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7398,14 +7340,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -7497,7 +7437,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -7510,7 +7449,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -7588,23 +7526,24 @@
       "license": "ISC"
     },
     "node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
+        "cross-spawn": "^7.0.3",
         "figures": "^6.1.0",
         "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
+        "human-signals": "^8.0.0",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
         "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
+        "pretty-ms": "^9.0.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
+        "yoctocolors": "^2.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.5.0"
@@ -7617,6 +7556,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7629,6 +7569,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7641,6 +7582,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7872,14 +7814,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -7999,6 +7939,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -8014,6 +7955,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8026,7 +7968,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -8039,7 +7980,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -8054,7 +7994,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -8166,7 +8105,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -8195,7 +8133,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -8283,7 +8220,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -8402,6 +8338,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -8473,7 +8410,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -8551,7 +8487,6 @@
       "version": "13.2.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
       "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dir-glob": "^3.0.1",
@@ -8571,7 +8506,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
       "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8602,7 +8536,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/gray-matter": {
@@ -8922,6 +8855,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -8996,7 +8930,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -9041,9 +8974,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -9067,7 +9000,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -9077,7 +9009,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9103,7 +9034,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9938,6 +9868,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10305,7 +10236,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -10330,7 +10260,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -10466,7 +10395,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -10599,7 +10527,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -10628,7 +10555,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.omit": {
@@ -11451,6 +11377,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -11516,6 +11448,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -11542,7 +11486,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11692,7 +11635,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -11882,6 +11824,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0",
@@ -11898,6 +11841,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11910,6 +11854,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12087,6 +12032,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -12108,7 +12068,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -12261,7 +12220,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -12277,7 +12235,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -12293,6 +12250,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12476,22 +12434,21 @@
       "license": "CC0-1.0"
     },
     "node_modules/pagefind": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
-      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "pagefind": "lib/runner/bin.cjs"
       },
       "optionalDependencies": {
-        "@pagefind/darwin-arm64": "1.5.2",
-        "@pagefind/darwin-x64": "1.5.2",
-        "@pagefind/freebsd-x64": "1.5.2",
-        "@pagefind/linux-arm64": "1.5.2",
-        "@pagefind/linux-x64": "1.5.2",
-        "@pagefind/windows-arm64": "1.5.2",
-        "@pagefind/windows-x64": "1.5.2"
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
       }
     },
     "node_modules/pako": {
@@ -12534,6 +12491,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12592,7 +12550,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12602,7 +12559,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12872,22 +12828,9 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/presentable-error": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/presentable-error/-/presentable-error-0.0.1.tgz",
-      "integrity": "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prettier": {
@@ -12910,6 +12853,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
       "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -13863,7 +13807,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -14152,13 +14095,13 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
-      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^5.0.0",
+        "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
@@ -14166,36 +14109,36 @@
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=14.0.0"
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sass/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^5.0.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
@@ -14635,16 +14578,14 @@
       "license": "ISC"
     },
     "node_modules/simple-git": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
-      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "@simple-git/args-pathspec": "^1.0.3",
-        "@simple-git/argv-parser": "^1.1.0",
-        "debug": "^4.4.0"
+        "debug": "^4.3.5"
       },
       "funding": {
         "type": "github",
@@ -15129,6 +15070,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15157,7 +15099,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15547,7 +15488,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through": {
@@ -15777,7 +15717,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -16218,7 +16157,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -16652,7 +16590,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16922,7 +16859,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -16935,6 +16871,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
       "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16957,7 +16894,7 @@
     },
     "packages/11ty": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0-rc.47",
+      "version": "1.0.0-rc.46",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "@iiif/helpers": "^1.3.1",
@@ -17019,14 +16956,14 @@
         "markdown-it-footnote": "^4.0.0",
         "mime-types": "^2.1.35",
         "module-alias": "^2.2.2",
-        "pagefind": "1.5.2",
+        "pagefind": "^1.4.0",
         "path": "^0.12.7",
         "prettier": "^3.2.5",
         "remove-markdown": "^0.5.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-scss": "^3.0.0",
         "sass": "^1.99.0",
-        "sharp": "^0.33.5",
+        "sharp": "^0.33.2",
         "sinon": "^21.0.0",
         "toml": "^3.0.0"
       },
@@ -17103,7 +17040,7 @@
     },
     "packages/cli": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-rc.55",
+      "version": "1.0.0-rc.53",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "ajv": "^8.16.0",
@@ -17112,21 +17049,22 @@
         "commander": "^12.1.0",
         "conf": "^13.1.0",
         "cross-env": "^7.0.3",
-        "del": "^8.0.1",
-        "epubjs-cli": "^0.2.4",
-        "execa": "^9.6.1",
+        "del": "^7.0.0",
+        "epubjs-cli": "^0.1.6",
+        "execa": "^6.1.0",
         "fs-extra": "^11.1.0",
         "hosted-git-info": "^6.1.1",
         "i18next": "^22.4.9",
         "inquirer": "^9.1.4",
         "js-yaml": "^4.1.0",
         "loglevel": "^1.8.1",
+        "node-fetch": "^3.3.2",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "pagedjs-cli": "^0.4.3",
         "read-package-up": "^11.0.0",
         "semver": "^7.3.8",
-        "simple-git": "^3.36.0",
+        "simple-git": "^3.16.0",
         "update-notifier": "^7.3.1"
       },
       "bin": {
@@ -17158,87 +17096,96 @@
         "yarn": ">=1"
       }
     },
-    "packages/cli/node_modules/del": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-8.0.1.tgz",
-      "integrity": "sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==",
+    "packages/cli/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
       "license": "MIT",
       "dependencies": {
-        "globby": "^14.0.2",
-        "is-glob": "^4.0.3",
-        "is-path-cwd": "^3.0.0",
-        "is-path-inside": "^4.0.0",
-        "p-map": "^7.0.2",
-        "presentable-error": "^0.0.1",
-        "slash": "^5.1.0"
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/cli/node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+    "packages/cli/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "packages/cli/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
+        "path-key": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/cli/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+    "packages/cli/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 4"
-      }
-    },
-    "packages/cli/node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/cli/node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+    "packages/cli/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17947,7 +17894,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
       "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
-      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^3.4.3"
       }
@@ -17955,8 +17901,7 @@
     "@eslint-community/regexpp": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="
     },
     "@eslint/eslintrc": {
       "version": "3.3.5",
@@ -18011,7 +17956,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -18021,14 +17965,12 @@
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
     },
     "@humanwhocodes/object-schema": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "dev": true
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
     },
     "@iiif/helpers": {
       "version": "1.3.1",
@@ -18435,51 +18377,44 @@
       }
     },
     "@pagefind/darwin-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
-      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
       "dev": true,
       "optional": true
     },
     "@pagefind/darwin-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
-      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
       "dev": true,
       "optional": true
     },
     "@pagefind/freebsd-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
-      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
       "dev": true,
       "optional": true
     },
     "@pagefind/linux-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
-      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
       "dev": true,
       "optional": true
     },
     "@pagefind/linux-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
-      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
-      "dev": true,
-      "optional": true
-    },
-    "@pagefind/windows-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
-      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
       "dev": true,
       "optional": true
     },
     "@pagefind/windows-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
-      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
       "dev": true,
       "optional": true
     },
@@ -18868,25 +18803,14 @@
     "@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
-    },
-    "@simple-git/args-pathspec": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
-      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="
-    },
-    "@simple-git/argv-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
-      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
-      "requires": {
-        "@simple-git/args-pathspec": "^1.0.3"
-      }
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true
     },
     "@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true
     },
     "@sindresorhus/slugify": {
       "version": "2.2.1",
@@ -19001,14 +18925,14 @@
         "markdown-it-footnote": "^4.0.0",
         "mime-types": "^2.1.35",
         "module-alias": "^2.2.2",
-        "pagefind": "1.5.2",
+        "pagefind": "^1.4.0",
         "path": "^0.12.7",
         "prettier": "^3.2.5",
         "remove-markdown": "^0.5.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-scss": "^3.0.0",
         "sass": "^1.99.0",
-        "sharp": "^0.33.5",
+        "sharp": "^0.33.2",
         "sinon": "^21.0.0",
         "template-polyfill": "^2.0.0",
         "toml": "^3.0.0",
@@ -19070,10 +18994,10 @@
         "commander": "^12.1.0",
         "conf": "^13.1.0",
         "cross-env": "^7.0.3",
-        "del": "^8.0.1",
-        "epubjs-cli": "^0.2.4",
+        "del": "^7.0.0",
+        "epubjs-cli": "^0.1.6",
         "eslint": "^8.57.1",
-        "execa": "^9.6.1",
+        "execa": "^6.1.0",
         "fs-extra": "^11.1.0",
         "hosted-git-info": "^6.1.1",
         "i18next": "^22.4.9",
@@ -19081,12 +19005,13 @@
         "js-yaml": "^4.1.0",
         "jsdoc-to-markdown": "^9.1.1",
         "loglevel": "^1.8.1",
+        "node-fetch": "^3.3.2",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "pagedjs-cli": "^0.4.3",
         "read-package-up": "^11.0.0",
         "semver": "^7.3.8",
-        "simple-git": "^3.36.0",
+        "simple-git": "^3.16.0",
         "update-notifier": "^7.3.1"
       },
       "dependencies": {
@@ -19098,52 +19023,54 @@
             "cross-spawn": "^7.0.1"
           }
         },
-        "del": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/del/-/del-8.0.1.tgz",
-          "integrity": "sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==",
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
           "requires": {
-            "globby": "^14.0.2",
-            "is-glob": "^4.0.3",
-            "is-path-cwd": "^3.0.0",
-            "is-path-inside": "^4.0.0",
-            "p-map": "^7.0.2",
-            "presentable-error": "^0.0.1",
-            "slash": "^5.1.0"
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
           }
         },
-        "globby": {
-          "version": "14.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-          "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        },
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+        },
+        "npm-run-path": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
           "requires": {
-            "@sindresorhus/merge-streams": "^2.1.0",
-            "fast-glob": "^3.3.3",
-            "ignore": "^7.0.3",
-            "path-type": "^6.0.0",
-            "slash": "^5.1.0",
-            "unicorn-magic": "^0.3.0"
+            "path-key": "^4.0.0"
           }
         },
-        "ignore": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-          "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
         },
-        "path-type": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-          "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="
-        },
-        "slash": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-          "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="
-        },
-        "unicorn-magic": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-          "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
         }
       }
     },
@@ -19266,8 +19193,7 @@
     "@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "@vercel/nft": {
       "version": "0.27.10",
@@ -19371,7 +19297,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "requires": {}
     },
     "acorn-walk": {
@@ -19391,7 +19316,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
       "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dev": true,
       "requires": {
         "clean-stack": "^4.0.0",
         "indent-string": "^5.0.0"
@@ -19863,8 +19787,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "bare-events": {
       "version": "2.5.4",
@@ -20011,7 +19934,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -20262,7 +20184,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
       "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "5.0.0"
       }
@@ -20495,8 +20416,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "concordance": {
       "version": "5.0.4",
@@ -20903,8 +20823,7 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "defaults": {
       "version": "1.0.4",
@@ -20955,7 +20874,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/del/-/del-7.1.0.tgz",
       "integrity": "sha512-v2KyNk7efxhlyHpjEvfyxaAihKKK0nWCuf6ZtqZcFFpQRG0bJ12Qsr0RpvsICMjAAZ8DOVCxrlqpxISlMHC4Kg==",
-      "dev": true,
       "requires": {
         "globby": "^13.1.2",
         "graceful-fs": "^4.2.10",
@@ -20971,7 +20889,6 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
           "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-          "dev": true,
           "requires": {
             "aggregate-error": "^4.0.0"
           }
@@ -20979,8 +20896,7 @@
         "slash": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-          "dev": true
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
         }
       }
     },
@@ -21101,7 +21017,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
       }
@@ -21125,7 +21040,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -21269,16 +21183,20 @@
       }
     },
     "epubjs-cli": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/epubjs-cli/-/epubjs-cli-0.2.4.tgz",
-      "integrity": "sha512-7eW7wwohHCUOKpyMRQE5cJ7p3+Pu9SyYafL7/6jiKDxak5/QpLvT4EeAbrV+Vc74520KbAa3nmTiKlUb/PdYUQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/epubjs-cli/-/epubjs-cli-0.1.6.tgz",
+      "integrity": "sha512-DrmeG2e4RVzhvY1nGhzZ0SbxLUczfIzBA2QwZEpb9NEnkTpYn4o5QbWWXdiV81LVEemFiIa35lzREmbiplIxZg==",
       "requires": {
+        "@xmldom/xmldom": "^0.8.6",
         "commander": "^9.3.0",
         "epubjs": "^0.5.0-alpha.3",
+        "eslint": "^8.29.0",
+        "express": "^4.18.1",
         "jsdom": "^20.0.3",
         "jszip": "^3.10.1",
         "liquidjs": "^10.1.0",
         "mime-types": "^2.1.35",
+        "node-fetch": "^3.2.5",
         "ora": "^6.1.0"
       },
       "dependencies": {
@@ -21641,8 +21559,7 @@
     "escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "escodegen": {
       "version": "2.1.0",
@@ -21659,7 +21576,6 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -21705,7 +21621,6 @@
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
           "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-          "dev": true,
           "requires": {
             "ajv": "^6.12.4",
             "debug": "^4.3.2",
@@ -21721,14 +21636,12 @@
         "@eslint/js": {
           "version": "8.57.1",
           "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-          "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-          "dev": true
+          "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="
         },
         "ajv": {
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -21740,7 +21653,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -21749,7 +21661,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -21758,14 +21669,12 @@
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "espree": {
           "version": "9.6.1",
           "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
           "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-          "dev": true,
           "requires": {
             "acorn": "^8.9.0",
             "acorn-jsx": "^5.3.2",
@@ -21776,7 +21685,6 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
@@ -21785,7 +21693,6 @@
           "version": "13.24.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
           "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -21793,20 +21700,17 @@
         "is-path-inside": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-          "dev": true
+          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "type-fest": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
     },
@@ -21979,7 +21883,6 @@
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -21988,8 +21891,7 @@
     "eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
     },
     "esm-import-transformer": {
       "version": "3.0.3",
@@ -22045,7 +21947,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       }
@@ -22054,7 +21955,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
       }
@@ -22108,38 +22008,42 @@
       "dev": true
     },
     "execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "dev": true,
       "requires": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
+        "cross-spawn": "^7.0.3",
         "figures": "^6.1.0",
         "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
+        "human-signals": "^8.0.0",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
         "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
+        "pretty-ms": "^9.0.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
+        "yoctocolors": "^2.0.0"
       },
       "dependencies": {
         "@sindresorhus/merge-streams": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-          "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
+          "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+          "dev": true
         },
         "is-plain-obj": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+          "dev": true
         },
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
         }
       }
     },
@@ -22315,14 +22219,12 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-uri": {
       "version": "3.0.6",
@@ -22400,6 +22302,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
       "requires": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -22407,7 +22310,8 @@
         "is-unicode-supported": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-          "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
+          "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+          "dev": true
         }
       }
     },
@@ -22415,7 +22319,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       },
@@ -22424,7 +22327,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
           "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-          "dev": true,
           "requires": {
             "flatted": "^3.2.9",
             "keyv": "^4.5.3",
@@ -22435,7 +22337,6 @@
           "version": "4.5.4",
           "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
           "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-          "dev": true,
           "requires": {
             "json-buffer": "3.0.1"
           }
@@ -22512,7 +22413,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -22526,8 +22426,7 @@
     "flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="
     },
     "for-each": {
       "version": "0.3.5",
@@ -22585,8 +22484,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.3",
@@ -22659,6 +22557,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
       "requires": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -22705,7 +22604,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -22751,7 +22649,6 @@
       "version": "13.2.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
       "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
       "requires": {
         "dir-glob": "^3.0.1",
         "fast-glob": "^3.3.0",
@@ -22763,8 +22660,7 @@
         "slash": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-          "dev": true
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
         }
       }
     },
@@ -22781,8 +22677,7 @@
     "graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -22989,7 +22884,8 @@
     "human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true
     },
     "hyperdyperid": {
       "version": "1.2.0",
@@ -23021,8 +22917,7 @@
     "ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
     "ignore-by-default": {
       "version": "2.1.0",
@@ -23058,9 +22953,9 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immutable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "devOptional": true
     },
     "import-fresh": {
@@ -23075,14 +22970,12 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
     },
     "indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
     },
     "index-to-position": {
       "version": "1.1.0",
@@ -23093,7 +22986,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -23591,7 +23483,8 @@
     "is-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true
     },
     "is-string": {
       "version": "1.1.1",
@@ -23827,8 +23720,7 @@
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -23848,8 +23740,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "json5": {
       "version": "2.2.3",
@@ -23936,7 +23827,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -24035,7 +23925,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -24054,8 +23943,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -24512,6 +24400,11 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -24550,6 +24443,11 @@
         "mime-db": "1.52.0"
       }
     },
+    "mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+    },
     "mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -24565,7 +24463,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -24662,8 +24559,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "negotiator": {
       "version": "0.6.3",
@@ -24787,6 +24683,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
       "requires": {
         "path-key": "^4.0.0",
         "unicorn-magic": "^0.3.0"
@@ -24795,12 +24692,14 @@
         "path-key": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
         },
         "unicorn-magic": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-          "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+          "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+          "dev": true
         }
       }
     },
@@ -24910,6 +24809,14 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "requires": {
+        "mimic-fn": "^4.0.0"
+      }
+    },
     "open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -24924,7 +24831,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -25020,7 +24926,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -25029,7 +24934,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -25037,7 +24941,8 @@
     "p-map": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA=="
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "dev": true
     },
     "p-queue": {
       "version": "6.6.2",
@@ -25166,18 +25071,17 @@
       }
     },
     "pagefind": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
-      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
       "dev": true,
       "requires": {
-        "@pagefind/darwin-arm64": "1.5.2",
-        "@pagefind/darwin-x64": "1.5.2",
-        "@pagefind/freebsd-x64": "1.5.2",
-        "@pagefind/linux-arm64": "1.5.2",
-        "@pagefind/linux-x64": "1.5.2",
-        "@pagefind/windows-arm64": "1.5.2",
-        "@pagefind/windows-x64": "1.5.2"
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
       }
     },
     "pako": {
@@ -25207,7 +25111,8 @@
     "parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true
     },
     "parse-srcset": {
       "version": "1.0.2",
@@ -25247,14 +25152,12 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -25413,13 +25316,7 @@
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "presentable-error": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/presentable-error/-/presentable-error-0.0.1.tgz",
-      "integrity": "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg=="
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prettier": {
       "version": "3.5.3",
@@ -25431,6 +25328,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
       "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "dev": true,
       "requires": {
         "parse-ms": "^4.0.0"
       }
@@ -26050,7 +25948,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -26244,30 +26141,30 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
-      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "devOptional": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
-        "chokidar": "^5.0.0",
+        "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "dependencies": {
         "chokidar": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-          "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+          "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
           "devOptional": true,
           "requires": {
-            "readdirp": "^5.0.0"
+            "readdirp": "^4.0.1"
           }
         },
         "readdirp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-          "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+          "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
           "devOptional": true
         }
       }
@@ -26583,15 +26480,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "simple-git": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
-      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "@simple-git/args-pathspec": "^1.0.3",
-        "@simple-git/argv-parser": "^1.1.0",
-        "debug": "^4.4.0"
+        "debug": "^4.3.5"
       }
     },
     "simple-swizzle": {
@@ -26916,7 +26811,8 @@
     "strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true
     },
     "strip-indent": {
       "version": "4.0.0",
@@ -26930,8 +26826,7 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "stubborn-fs": {
       "version": "1.2.5",
@@ -27203,8 +27098,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "through": {
       "version": "2.3.8",
@@ -27366,7 +27260,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -27632,7 +27525,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -27894,8 +27786,7 @@
     "word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -28066,13 +27957,13 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "yoctocolors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="
+      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "dev": true
     },
     "yoctocolors-cjs": {
       "version": "2.1.2",

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -15,7 +15,7 @@ export default function (eleventyConfig) {
   return function (figure, options) {
     const {
       alt,
-      transformations,
+      derivatives,
       isCanvas,
       isImageService,
       isSequence,
@@ -43,7 +43,7 @@ export default function (eleventyConfig) {
       case isCanvas && !interactive && staticInlineFigureImage:
       case isImageService && !interactive && staticInlineFigureImage:
       case !lightbox && Boolean(staticInlineFigureImage): {
-        const { paths, dimensions } = transformations.staticInlineFigureImage
+        const { paths, dimensions } = derivatives.staticInlineFigureImage
         const { height, width } = dimensions
 
         // Choose media path based on whether path will be loaded as-is or processed by 11ty
@@ -61,7 +61,7 @@ export default function (eleventyConfig) {
       }
 
       default: {
-        const { full } = transformations
+        const { full } = derivatives
         const { paths } = full
 
         return imageTag({ ...figure, lightbox, src: paths.absolute })

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -61,7 +61,10 @@ export default function (eleventyConfig) {
       }
 
       default:
-        return imageTag({ ...figure, lightbox })
+        const { full } = transformations
+        const { paths } = full
+
+        return imageTag({ ...figure, lightbox, src: paths.absolute })
     }
   }
 }

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -30,58 +30,36 @@ export default function (eleventyConfig) {
     }
 
     switch (true) {
-      case isSequence:
-        if (!interactive && staticInlineFigureImage) {
-          return imageTag({
-            alt,
-            height: transformations['static-inline-figure-image'].dimensions.height,
-            isStatic: !interactive,
-            lazyLoading,
-            lightbox,
-            src: staticInlineFigureImage,
-            width: transformations['static-inline-figure-image'].dimensions.width
-          })
-        } else {
-          return imageSequence(figure, options)
-        }
-      case isCanvas:
-        if (!interactive && staticInlineFigureImage) {
-          return imageTag({
-            alt,
-            height: transformations['static-inline-figure-image'].dimensions.height,
-            isStatic: !interactive,
-            lazyLoading,
-            lightbox,
-            src: staticInlineFigureImage,
-            width: transformations['static-inline-figure-image'].dimensions.width
-          })
-        } else {
-          return canvasPanel(figure)
-        }
-      case isImageService:
-        if (!interactive && staticInlineFigureImage) {
-          return imageTag({
-            alt,
-            height: transformations['static-inline-figure-image'].dimensions.height,
-            isStatic: !interactive,
-            lazyLoading,
-            lightbox,
-            src: staticInlineFigureImage,
-            width: transformations['static-inline-figure-image'].dimensions.width
-          })
-        } else {
-          return imageService(figure)
-        }
-      case !lightbox && Boolean(staticInlineFigureImage):
+      case isSequence && interactive:
+        return imageSequence(figure, options)
+
+      case isCanvas && interactive:
+        return canvasPanel(figure)
+
+      case isImageService && interactive:
+        return imageService(figure)
+
+      case isSequence && !interactive && staticInlineFigureImage:
+      case isCanvas && !interactive && staticInlineFigureImage:
+      case isImageService && !interactive && staticInlineFigureImage:
+      case !lightbox && Boolean(staticInlineFigureImage): {
+        const { paths, dimensions } = transformations.staticInlineFigureImage
+        const { height, width } = dimensions
+
+        // Choose media path based on whether path will be loaded as-is or processed by 11ty
+        const src = lightbox ? paths.absolute : paths.internal
+
         return imageTag({
           alt,
-          height: transformations['static-inline-figure-image'].dimensions.height,
-          isStatic: true,
+          height,
+          isStatic: lightbox ? !interactive : true,
           lazyLoading,
           lightbox,
-          src: staticInlineFigureImage,
-          width: transformations['static-inline-figure-image'].dimensions.width
+          src,
+          width
         })
+      }
+
       default:
         return imageTag({ ...figure, lightbox })
     }

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -60,11 +60,12 @@ export default function (eleventyConfig) {
         })
       }
 
-      default:
+      default: {
         const { full } = transformations
         const { paths } = full
 
         return imageTag({ ...figure, lightbox, src: paths.absolute })
+      }
     }
   }
 }

--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -15,7 +15,7 @@ export default function (eleventyConfig) {
   return function (figure, options) {
     const {
       alt,
-      dimensions,
+      transformations,
       isCanvas,
       isImageService,
       isSequence,
@@ -34,12 +34,12 @@ export default function (eleventyConfig) {
         if (!interactive && staticInlineFigureImage) {
           return imageTag({
             alt,
-            height: dimensions['static-inline-figure-image'].height,
+            height: transformations['static-inline-figure-image'].dimensions.height,
             isStatic: !interactive,
             lazyLoading,
             lightbox,
             src: staticInlineFigureImage,
-            width: dimensions['static-inline-figure-image'].width
+            width: transformations['static-inline-figure-image'].dimensions.width
           })
         } else {
           return imageSequence(figure, options)
@@ -48,12 +48,12 @@ export default function (eleventyConfig) {
         if (!interactive && staticInlineFigureImage) {
           return imageTag({
             alt,
-            height: dimensions['static-inline-figure-image'].height,
+            height: transformations['static-inline-figure-image'].dimensions.height,
             isStatic: !interactive,
             lazyLoading,
             lightbox,
             src: staticInlineFigureImage,
-            width: dimensions['static-inline-figure-image'].width
+            width: transformations['static-inline-figure-image'].dimensions.width
           })
         } else {
           return canvasPanel(figure)
@@ -62,12 +62,12 @@ export default function (eleventyConfig) {
         if (!interactive && staticInlineFigureImage) {
           return imageTag({
             alt,
-            height: dimensions['static-inline-figure-image'].height,
+            height: transformations['static-inline-figure-image'].dimensions.height,
             isStatic: !interactive,
             lazyLoading,
             lightbox,
             src: staticInlineFigureImage,
-            width: dimensions['static-inline-figure-image'].width
+            width: transformations['static-inline-figure-image'].dimensions.width
           })
         } else {
           return imageService(figure)
@@ -75,12 +75,12 @@ export default function (eleventyConfig) {
       case !lightbox && Boolean(staticInlineFigureImage):
         return imageTag({
           alt,
-          height: dimensions['static-inline-figure-image'].height,
+          height: transformations['static-inline-figure-image'].dimensions.height,
           isStatic: true,
           lazyLoading,
           lightbox,
           src: staticInlineFigureImage,
-          width: dimensions['static-inline-figure-image'].width
+          width: transformations['static-inline-figure-image'].dimensions.width
         })
       default:
         return imageTag({ ...figure, lightbox })

--- a/packages/11ty/_includes/components/figure/image/image-tag.js
+++ b/packages/11ty/_includes/components/figure/image/image-tag.js
@@ -1,6 +1,5 @@
 import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
-import path from 'node:path'
 
 /**
  * Image Tag for figures that are static images
@@ -12,20 +11,7 @@ import path from 'node:path'
  * @return     {String}  An <img> element
  */
 export default function (eleventyConfig) {
-  const { imageDir } = eleventyConfig.globalData.config.figures
-  const { pathname } = eleventyConfig.globalData.publication
-
   return function ({ height, width, alt = '', src = '', isStatic = false, lazyLoading = 'lazy', lightbox = false }) {
-    // Lightbox loads in-browser so urls must have pathname, rest are prepended by 11ty
-    const extOrIiifRegex = /^(https?:\/\/|\/iiif\/|\\iiif\\)/
-    const assetRoot = lightbox && pathname !== '/' ? path.posix.join(pathname, imageDir) : imageDir
-    let imageSrc = extOrIiifRegex.test(src) || isStatic ? src : path.posix.join(assetRoot, src)
-
-    // HACK: If an URL-unsafe path separator has made it this far, remove it
-    if (path.sep !== '/') {
-      imageSrc = imageSrc.replaceAll(path.sep, '/')
-    }
-
     // Apply height/ width attributes if they exist
     const heightAttribute = height > 0 ? `height=${height}` : ''
     const widthAttribute = width > 0 ? `width=${width}` : ''
@@ -36,7 +22,7 @@ export default function (eleventyConfig) {
         class="q-figure__image"
         decoding="async"
         loading="${lazyLoading}"
-        src="${imageSrc}"
+        src="${src}"
         ${heightAttribute}
         ${widthAttribute}
       />

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -1,6 +1,5 @@
 import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
-import path from 'node:path'
 
 /**
  * Renders an image with a caption in print output
@@ -14,8 +13,6 @@ export default function (eleventyConfig) {
   const figureCaption = eleventyConfig.getFilter('figureCaption')
   const figureLabel = eleventyConfig.getFilter('figureLabel')
 
-  const { imageDir } = eleventyConfig.globalData.config.figures
-
   return function (figure) {
     const {
       alt,
@@ -23,10 +20,7 @@ export default function (eleventyConfig) {
       credit,
       derivatives,
       id,
-      isExternalResource,
-      label,
-      src,
-      staticInlineFigureImage
+      label
     } = figure
 
     const { printImage } = derivatives

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -21,6 +21,7 @@ export default function (eleventyConfig) {
       alt,
       caption,
       credit,
+      derivatives,
       id,
       isExternalResource,
       label,
@@ -28,30 +29,23 @@ export default function (eleventyConfig) {
       staticInlineFigureImage
     } = figure
 
-    if (!src && !staticInlineFigureImage) return ''
+    const { printImage } = derivatives
+
+    if (printImage === undefined) return ''
+
+    const { paths, dimensions } = printImage
+    const { height, width } = dimensions
+
+    if (!paths.internal) return ''
 
     const labelElement = figureLabel({ caption, id, label })
 
-    /**
-     * NB: Image assets can be: external, in the asset dir, or in the IIIF directory
-     **/
-    let imageSrc
-    switch (true) {
-      case figure.isSequence:
-        imageSrc = figure.staticInlineFigureImage
-        break
-      case figure.isCanvas || figure.isImageService:
-        imageSrc = figure.printImage
-        break
-      case isExternalResource && src:
-        imageSrc = src
-        break
-      default:
-        imageSrc = path.posix.join(imageDir, src)
-    }
-
     return html`
-      <img alt="${escape(alt)}" class="q-figure__image" src="${imageSrc}"/>
+      <img alt="${escape(alt)}"
+           class="q-figure__image"
+           height="${height}"
+           src="${paths.internal}"
+           width="${width}"/>
       ${figureCaption({ caption, content: labelElement, credit })}
     `
   }

--- a/packages/11ty/_lib/snakeToCamelCase/index.js
+++ b/packages/11ty/_lib/snakeToCamelCase/index.js
@@ -1,0 +1,20 @@
+/**
+ * @function snakeToCamelCase
+ *
+ * @param {string} content
+ *
+ * @returns {string}
+ *
+ * Converts a string in snake-case to camelCase
+ *
+ **/
+export default function snakeToCamelCase (content) {
+  const parts = content.split('-')
+  const capitalized = parts.map((part, i) => {
+    const first = i > 0 ? part.charAt(0).toUpperCase() : part.charAt(0)
+
+    return (first + part.substring(1))
+  })
+
+  return capitalized.join('')
+}

--- a/packages/11ty/_plugins/figures/figureMedia/README.md
+++ b/packages/11ty/_plugins/figures/figureMedia/README.md
@@ -1,16 +1,25 @@
-# Figures
+# FiguresMedia
+Data model that handles figure media assets and provides normalized asset path data for figures.
 
 ## `FigureMediaFactory`
-Creates `FigureMedia` instances and calls `Figure.processFiles()` to generate assets for consumption by shortcodes.
+A mostly-abstract factory that creates `FigureMedia` instances via the `create` method. `create` calls the new instance's `processFiles` to start the generation of site media assets and model data for use by components.
 
 ## `FigureMedia`
-Stores `figures.yaml` data and wraps media creation methods like `processFiles`.
+Stores `figures.yaml` data, wraps the injection of media creation methods like `processFiles`, and generates new modelled figure media data with the `media` method.
 
 ### `processFiles`
 Files are written to `<iiifConfig.dirs.outputRoot>/<iiifConfig.dirs.output>/<figure.id>` (default: `/_site/iiif/<figure.id>`).
 
+### `Tiler`
+Injectable class providing an abstraction over the `sharp` incantations for generating tiles.
+
+### `Transformer`
+Injectable class providing an abstraction over `sharp`'s `resize` method. Options for individual derivative transformations (eg, thumbnail images) are instantiated are configured in the IIIF configuration (see ["Image processing"](#image-processing) below).
+
 #### Image processing 
-Processes image files in `figure.src` and `annotation.src`. Image processing includes creating tiles if the resource is an image service and performing image transformations.
+Processes image files in `figure.src`, `figure.iiif_image`, and `annotation.src`.
+
+Tiles are only created for figure images with `zoom` set to `true`. Transformed derivative images are created for all figure images, see `_plugins/figures/iiif/config.js` for details. Transform `resize` options are largely pass-through to the `sharp` method. 
 
 #### Manifest generation
-Generates a IIIF manifest for figures with annotations and figures with a single image and `zoom=true`.
+Generates a IIIF manifest for figures with annotations and figures with a single image and `zoom` set to `true`.

--- a/packages/11ty/_plugins/figures/figureMedia/README.md
+++ b/packages/11ty/_plugins/figures/figureMedia/README.md
@@ -16,6 +16,8 @@ Injectable class providing an abstraction over the `sharp` incantations for gene
 ### `Transformer`
 Injectable class providing an abstraction over `sharp`'s `resize` method. Options for individual derivative transformations (eg, thumbnail images) are instantiated are configured in the IIIF configuration (see ["Image processing"](#image-processing) below).
 
+Metadata about asset derivatives' paths and dimensions are stored in the `derivatives` property in the object returned by `FigureMedia`'s `media()` method, with each derivative's metadata stored under its transformation and "full" for the complete image.  
+
 #### Image processing 
 Processes image files in `figure.src`, `figure.iiif_image`, and `annotation.src`.
 

--- a/packages/11ty/_plugins/figures/figureMedia/README.md
+++ b/packages/11ty/_plugins/figures/figureMedia/README.md
@@ -1,5 +1,5 @@
 # FiguresMedia
-Data model that handles figure media assets and provides normalized asset path data for figures.
+Data model that handles figure media assets and provides normalized asset path data and dimensions for figures.
 
 ## `FigureMediaFactory`
 A mostly-abstract factory that creates `FigureMedia` instances via the `create` method. `create` calls the new instance's `processFiles` to start the generation of site media assets and model data for use by components.

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -485,7 +485,7 @@ export default class FigureMedia {
       filename ??= `${name}.jpg`
       const { name: directory } = path.parse(this.src)
 
-      // NB: Internal must absolute relative to publication root! 
+      // NB: Internal must absolute relative to publication root!
       const internal = path.join('/', this.outputPathname, directory, filename)
       const absolute = path.join(pathname, internal)
       const uri = urlPathJoin(baseURI, internal)

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -435,6 +435,53 @@ export default class FigureMedia {
   }
 
   /**
+   * @function storeTransformResult
+   *
+   * @param {string} name
+   * @param {Object} metadata
+   * @param {null|string} filename
+   *
+   * Stores image paths + metadata for a transformation under the key `name`.
+   * Uses `filename` in paths if non-null.
+   *
+   **/
+  storeTransformResult (name, metadata, filename = null) {
+    if (typeof this.transformations !== 'object') {
+      this.transformations = {}
+    }
+
+    const { baseURI } = this.iiifConfig
+    const { pathname } = new URL(baseURI)
+
+    const { height, width } = metadata
+
+    // TODO: Path should be unmutated src if an URL
+    let paths = {}
+    if (this.isExternalResource) {
+      paths = { absolute: this.src, internal: this.src, uri: this.src }
+    } else {
+      filename ??= `${name}.jpg`
+      const internal = path.join(this.outputPathname, this.id, filename)
+      const absolute = path.join(pathname, internal)
+      const uri = urlPathJoin(baseURI, internal)
+
+      paths = {
+        absolute,
+        internal,
+        uri
+      }
+    }
+
+    this.transformations[name] = {
+      dimensions: {
+        height,
+        width
+      },
+      paths
+    }
+  }
+
+  /**
    * @function processFigureImage
    *
    * Tiles and transforms `src` asset
@@ -444,8 +491,7 @@ export default class FigureMedia {
     if (!(this.src || this.iiifImage)) return
     if (this.isExternalResource) return
 
-    const { baseURI, transformations } = this.iiifConfig
-    const { pathname } = new URL(baseURI)
+    const { transformations } = this.iiifConfig
 
     const options = {
       transformations
@@ -463,42 +509,12 @@ export default class FigureMedia {
 
     if (errors) this.errors = this.errors.concat(errors)
 
+    // Store path and dimensions data for the full resolution and all transformations
     const { base: filename } = path.parse(this.src)
-    const internal = path.posix.join(this.outputPathname, filename)
+    this.storeTransformResult('full', { height: this.height, width: this.width }, filename)
 
-    // Store path and dimensions data for the full resolution transformation
-    this.transformations = {
-      full: {
-        dimensions: {
-          height: this.height,
-          width: this.width
-        },
-        paths: {
-          absolute: path.posix.join(pathname, internal),
-          internal,
-          uri: urlPathJoin(this.iiifConfig.baseURI, internal)
-        }
-      }
-    }
-
-    // Store path and dimensions data for each transformation
-    for (const [name, data] of Object.entries(metadata ?? {})) {
-      const { height, width } = data
-
-      const filename = `${name}.jpg`
-      const internal = path.join(this.outputPathname, this.id, filename)
-
-      this.transformations[name] = {
-        dimensions: {
-          height,
-          width
-        },
-        paths: {
-          absolute: path.join(pathname, internal),
-          internal,
-          uri: urlPathJoin(baseURI, internal)
-        }
-      }
+    for (const [name, result] of Object.entries(metadata ?? {})) {
+      this.storeTransformResult(name, result)
     }
   }
 

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -462,11 +462,9 @@ export default class FigureMedia {
     if (this.isExternalResource) {
       paths = { absolute: this.src, internal: this.src, uri: this.src }
     } else {
+      // NB: Transformed derivatives are stored in a directory with the name of the transform and a filename of <name>.<format>
       filename ??= `${name}.jpg`
-
-      // NB: Full resources are (currently) stored without a nested destination directory
-      const { name: srcName } = path.parse(this.src)
-      const directory = name === 'full' ? '' : srcName
+      const directory = this.iiifImage ? slugify(this.iiifImage) : path.parse(this.src).name
 
       // `internal` is used without a leading slash for path math
       // then made absolutely internal, relative to the publication root
@@ -523,15 +521,11 @@ export default class FigureMedia {
       options.tile = true
     }
 
-    const processSrc = this.src ?? this.iiifImage
-    const { errors, metadata } = await this.processImage(processSrc, this.outputDir, options)
+    const { errors, metadata } = await this.processImage(this.src ?? this.iiifImage, this.outputDir, options)
 
     if (errors) this.errors = this.errors.concat(errors)
 
-    // Store path and dimensions data for the full resolution and all transformations
-    const { base: filename } = path.parse(this.src)
-    this.storeTransformResult('full', { height: this.height, width: this.width }, filename)
-
+    // Store path and dimensions data for each transformation
     for (const [name, result] of Object.entries(metadata ?? {})) {
       this.storeTransformResult(name, result)
     }

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -122,6 +122,7 @@ export default class FigureMedia {
     this.canvasId = canvasId()
     this.data = data
     this.debugLog = debugLog
+    this.derivatives = {}
     this.id = id
     this.iiifConfig = iiifConfig
     this.iiifImage = iiifImage
@@ -346,6 +347,8 @@ export default class FigureMedia {
       src: this.src,
       staticInlineFigureImage: this.staticInlineFigureImage,
       thumbnail: this.staticInlineFigureImage,
+
+      // NB: sequence and annotation figures do not get processed
       derivatives: this.derivatives
     }
   }
@@ -436,7 +439,7 @@ export default class FigureMedia {
   }
 
   /**
-   * @function storeTransformResult
+   * @function storeTransformedDerivative
    *
    * @param {string} name
    * @param {Object} metadata
@@ -446,11 +449,7 @@ export default class FigureMedia {
    * Uses `filename` in paths if non-null.
    *
    **/
-  storeTransformResult (name, metadata, filename = null) {
-    if (typeof this.derivatives !== 'object') {
-      this.derivatives = {}
-    }
-
+  storeTransformedDerivative (name, metadata, filename = null) {
     const { baseURI } = this.iiifConfig
     const { pathname } = new URL(baseURI)
 
@@ -508,7 +507,7 @@ export default class FigureMedia {
     if (this.isExternalResource) {
       for (const transformation of transformations) {
         const name = snakeToCamelCase(transformation.name)
-        this.storeTransformResult(name, { height: this.height, width: this.width })
+        this.storeTransformedDerivative(name, { height: this.height, width: this.width })
       }
 
       return
@@ -527,7 +526,7 @@ export default class FigureMedia {
 
     // Store path and dimensions data for each transformation
     for (const [name, result] of Object.entries(metadata ?? {})) {
-      this.storeTransformResult(name, result)
+      this.storeTransformedDerivative(name, result)
     }
   }
 

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -346,7 +346,7 @@ export default class FigureMedia {
       src: this.src,
       staticInlineFigureImage: this.staticInlineFigureImage,
       thumbnail: this.staticInlineFigureImage,
-      transformations: this.transformations
+      derivatives: this.derivatives
     }
   }
 
@@ -447,8 +447,8 @@ export default class FigureMedia {
    *
    **/
   storeTransformResult (name, metadata, filename = null) {
-    if (typeof this.transformations !== 'object') {
-      this.transformations = {}
+    if (typeof this.derivatives !== 'object') {
+      this.derivatives = {}
     }
 
     const { baseURI } = this.iiifConfig
@@ -480,7 +480,7 @@ export default class FigureMedia {
     }
 
     const property = snakeToCamelCase(name)
-    this.transformations[property] = {
+    this.derivatives[property] = {
       dimensions: {
         height,
         width

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -490,8 +490,8 @@ export default class FigureMedia {
 
       // `internal` is used without a leading slash for path math
       // then made absolutely internal, relative to the publication root
-      const internal = path.join(this.outputPathname, directory, filename)
-      const absolute = path.join(pathname, internal)
+      const internal = path.posix.join(this.outputPathname, directory, filename)
+      const absolute = path.posix.join(pathname, internal)
       const uri = urlPathJoin(baseURI, internal)
 
       paths = {

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -496,7 +496,7 @@ export default class FigureMedia {
 
       paths = {
         absolute,
-        internal: path.join('/', internal),
+        internal: path.posix.join('/', internal),
         uri
       }
     }

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -217,7 +217,8 @@ export default class FigureMedia {
   }
 
   /**
-   * Test if the `src` is an external resource
+   * Returns true if `src` is a URL resource and should be served that way
+   *
    * @return {Boolean}
    */
   get isExternalResource () {
@@ -398,7 +399,6 @@ export default class FigureMedia {
     this.errors = []
 
     if (this.mediaType !== 'image') return {}
-    if (this.isExternalResource && !this.iiifImage) return {}
 
     await this.calculateDimensions()
 
@@ -499,12 +499,21 @@ export default class FigureMedia {
    */
   async processFigureImage () {
     if (!(this.src || this.iiifImage)) return
-    if (this.isExternalResource) return
 
     const { transformations } = this.iiifConfig
 
     const options = {
       transformations
+    }
+
+    // Add passthrough paths for absolute, etc on external image URLs
+    if (this.isExternalResource) {
+      for (const transformation of transformations) {
+        const name = snakeToCamelCase(transformation.name)
+        this.storeTransformResult(name, { height: this.height, width: this.width })
+      }
+
+      return
     }
 
     if (this.isCanvas) {

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -183,10 +183,9 @@ export default class FigureMedia {
   }
 
   /**
-   * Path to the image file that represents the canvas
-   * Used to define canvas properties `width` and `height`
+   * Path to the image file on disk, or the image of the first choice or sequence image.
    */
-  get canvasImagePath () {
+  get imageFilePath () {
     if (this.iiifImage) return this.iiifImage
 
     const firstChoiceSrc = () => {
@@ -344,14 +343,15 @@ export default class FigureMedia {
       startCanvasIndex,
       src: this.src,
       staticInlineFigureImage: this.staticInlineFigureImage,
-      thumbnail: this.staticInlineFigureImage
+      thumbnail: this.staticInlineFigureImage,
+      transformations: this.transformations
     }
   }
 
   /**
    * @function calculateDimensions
    *
-   * Fetches and stores figure height and width
+   * Reads and stores this figure's height and width
    *
    **/
   async calculateDimensions () {
@@ -367,13 +367,17 @@ export default class FigureMedia {
 
         height = info.height
         width = info.width
-      } catch (err) {
-        logger.error(`Could not fetch metadata for figure ${this.id} with error ${err}!`)
+      } catch (error) {
+        logger.error(`Could not fetch metadata for figure ${this.id} with error ${error}!`)
         return
       }
     } else {
-      // TODO: Use `try / catch` here! sharp().metadata() can also throw
-      ({ height, width } = await sharp(this.canvasImagePath).metadata())
+      try {
+        ({ height, width } = await sharp(this.imageFilePath).metadata())
+      } catch (error) {
+        logger.error(`Could not read metadata for figure ${this.id}: ${error}!`)
+        return
+      }
     }
 
     this.height = height
@@ -440,7 +444,8 @@ export default class FigureMedia {
     if (!(this.src || this.iiifImage)) return
     if (this.isExternalResource) return
 
-    const { transformations } = this.iiifConfig
+    const { baseURI, transformations } = this.iiifConfig
+    const { pathname } = new URL(baseURI)
 
     const options = {
       transformations
@@ -458,12 +463,42 @@ export default class FigureMedia {
 
     if (errors) this.errors = this.errors.concat(errors)
 
-    // Store dimensions from transform metadata for downstream use
-    this.dimensions = {}
+    const { base: filename } = path.parse(this.src)
+    const internal = path.posix.join(this.outputPathname, filename)
+
+    // Store path and dimensions data for the full resolution transformation
+    this.transformations = {
+      full: {
+        dimensions: {
+          height: this.height,
+          width: this.width
+        },
+        paths: {
+          absolute: path.posix.join(pathname, internal),
+          internal,
+          uri: urlPathJoin(this.iiifConfig.baseURI, internal)
+        }
+      }
+    }
+
+    // Store path and dimensions data for each transformation
     for (const [name, data] of Object.entries(metadata ?? {})) {
       const { height, width } = data
 
-      this.dimensions[name] = { height, width }
+      const filename = `${name}.jpg`
+      const internal = path.join(this.outputPathname, this.id, filename)
+
+      this.transformations[name] = {
+        dimensions: {
+          height,
+          width
+        },
+        paths: {
+          absolute: path.join(pathname, internal),
+          internal,
+          uri: urlPathJoin(baseURI, internal)
+        }
+      }
     }
   }
 

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -483,16 +483,20 @@ export default class FigureMedia {
       paths = { absolute: this.src, internal: this.src, uri: this.src }
     } else {
       filename ??= `${name}.jpg`
-      const { name: directory } = path.parse(this.src)
 
-      // NB: Internal must absolute relative to publication root!
-      const internal = path.join('/', this.outputPathname, directory, filename)
+      // NB: Full resources are (currently) stored without a nested destination directory
+      const { name: srcName } = path.parse(this.src)
+      const directory = name === 'full' ? '' : srcName
+
+      // `internal` is used without a leading slash for path math
+      // then made absolutely internal, relative to the publication root
+      const internal = path.join(this.outputPathname, directory, filename)
       const absolute = path.join(pathname, internal)
       const uri = urlPathJoin(baseURI, internal)
 
       paths = {
         absolute,
-        internal,
+        internal: path.join('/', internal),
         uri
       }
     }

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -5,6 +5,7 @@ import Fetch from '@11ty/eleventy-fetch'
 import Manifest from '../iiif/manifest/index.js'
 import SequenceFactory from '../sequence/factory.js'
 import chalkFactory from '#lib/chalk/index.js'
+import snakeToCamelCase from '#lib/snakeToCamelCase/index.js'
 import path from 'node:path'
 import sharp from 'sharp'
 import slugify from '@sindresorhus/slugify'
@@ -435,27 +436,6 @@ export default class FigureMedia {
   }
 
   /**
-   * @function convertSnakeCase
-   *
-   * @param {string} content
-   *
-   * @returns {string}
-   *
-   * Converts a string in snake-case to camelCase
-   *
-   **/
-  convertSnakeCase (content) {
-    const parts = content.split('-')
-    const capitalized = parts.map((part, i) => {
-      const first = i > 0 ? part.charAt(0).toUpperCase() : part.charAt(0)
-
-      return (first + part.substring(1))
-    })
-
-    return capitalized.join('')
-  }
-
-  /**
    * @function storeTransformResult
    *
    * @param {string} name
@@ -501,7 +481,7 @@ export default class FigureMedia {
       }
     }
 
-    const property = this.convertSnakeCase(name)
+    const property = snakeToCamelCase(name)
     this.transformations[property] = {
       dimensions: {
         height,

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -435,6 +435,27 @@ export default class FigureMedia {
   }
 
   /**
+   * @function convertSnakeCase
+   *
+   * @param {string} content
+   *
+   * @returns {string}
+   *
+   * Converts a string in snake-case to camelCase
+   *
+   **/
+  convertSnakeCase (content) {
+    const parts = content.split('-')
+    const capitalized = parts.map((part, i) => {
+      const first = i > 0 ? part.charAt(0).toUpperCase() : part.charAt(0)
+
+      return (first + part.substring(1))
+    })
+
+    return capitalized.join('')
+  }
+
+  /**
    * @function storeTransformResult
    *
    * @param {string} name
@@ -455,13 +476,17 @@ export default class FigureMedia {
 
     const { height, width } = metadata
 
-    // TODO: Path should be unmutated src if an URL
     let paths = {}
+
+    // Ensure the path is passed unmutated if a URL
     if (this.isExternalResource) {
       paths = { absolute: this.src, internal: this.src, uri: this.src }
     } else {
       filename ??= `${name}.jpg`
-      const internal = path.join(this.outputPathname, this.id, filename)
+      const { name: directory } = path.parse(this.src)
+
+      // NB: Internal must absolute relative to publication root! 
+      const internal = path.join('/', this.outputPathname, directory, filename)
       const absolute = path.join(pathname, internal)
       const uri = urlPathJoin(baseURI, internal)
 
@@ -472,7 +497,8 @@ export default class FigureMedia {
       }
     }
 
-    this.transformations[name] = {
+    const property = this.convertSnakeCase(name)
+    this.transformations[property] = {
       dimensions: {
         height,
         width

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -94,18 +94,23 @@ export default (eleventyConfig) => {
      */
     tileSize: 256,
     /**
-     * All transformations are applied to each image and output a separate file.
+     * Each figure image is generates an output file from the configured transformations.
      *
      * @type {Array<Object>}
      * @property {String} name  Output file name
      * @property {Object} resize  Options passed to the `sharp.resize()` method
      * @see {@link https://sharp.pixelplumbing.com/api-resize}
+     *
      */
     transformations: [
       {
+        name: 'full',
+        resize: {}
+      },
+      {
         name: 'thumbnail',
         resize: {
-          width: 50
+          width: 280
         }
       },
       /**

--- a/packages/11ty/_plugins/figures/image/processor.js
+++ b/packages/11ty/_plugins/figures/image/processor.js
@@ -82,18 +82,16 @@ export default class ImageProcessor {
       } catch (error) {
         errors.push(`Failed to generate tiles from source ${imagePath} ${error}`)
       }
-    } else {
-      /**
-       * Copy file to output directory since vite removes images
-       * not directly referenced by the templates
-       */
+    }
 
-      const { base } = path.parse(imagePath)
-      try {
-        fs.copySync(inputPath, path.join(this.outputRoot, outputPath, base))
-      } catch (error) {
-        errors.push(`Failed to copy source image ${imagePath} ${error}`)
-      }
+    /**
+     * Copy full file for use by downstream components
+     */
+    const { base } = path.parse(imagePath)
+    try {
+      fs.copySync(inputPath, path.join(this.outputRoot, outputPath, base))
+    } catch (error) {
+      errors.push(`Failed to copy source image ${imagePath} ${error}`)
     }
 
     return { errors, metadata }

--- a/packages/11ty/_plugins/figures/image/transformer.js
+++ b/packages/11ty/_plugins/figures/image/transformer.js
@@ -18,8 +18,8 @@ const iiifSize = (resize, imgInfo) => {
   const { width } = imgInfo
   const { width: xformWidth, withoutEnlargement } = resize
 
-  let reqWidth = xformWidth
-  if (xformWidth > width && withoutEnlargement || xformWidth === undefined) {
+  let reqWidth = xformWidth ?? width
+  if (xformWidth > width && withoutEnlargement) {
     reqWidth = width
   }
 

--- a/packages/11ty/_plugins/figures/image/transformer.js
+++ b/packages/11ty/_plugins/figures/image/transformer.js
@@ -19,7 +19,7 @@ const iiifSize = (resize, imgInfo) => {
   const { width: xformWidth, withoutEnlargement } = resize
 
   let reqWidth = xformWidth
-  if (xformWidth > width && withoutEnlargement) {
+  if (xformWidth > width && withoutEnlargement || xformWidth === undefined) {
     reqWidth = width
   }
 
@@ -41,14 +41,14 @@ export default class Transformer {
    * Creates a `sharp/transform` that writes the image file to the output directory.
    * Nota bene: this `transform` is distinct form `11ty/transform`
    *
-   * @property {String} inputPath The path to the image file to transform
+   * @property {String} inputSource The image file path or IIIF endpoint URL to transform
    * @property  {Object} transformation A transformation item from `iiif/config.js#transformations`
    * @param  {Object} options
    * @property  {Object} resize Resize options for `sharp`
    * @return {Promise}
    */
-  async transform (inputPath, outputDir, transformation, options = {}) {
-    if (!inputPath) return {}
+  async transform (inputSource, outputDir, transformation, options = {}) {
+    if (!inputSource) return {}
 
     const { region, iiifEndpoint } = options
     const { resize } = transformation
@@ -56,9 +56,9 @@ export default class Transformer {
     let ext, name
     if (iiifEndpoint) {
       ext = '.jpg'
-      name = slugify(inputPath)
+      name = slugify(inputSource)
     } else {
-      ({ ext, name } = path.parse(inputPath))
+      ({ ext, name } = path.parse(inputSource))
     }
 
     const format = this.formats.find(({ input }) => input.includes(ext))
@@ -67,13 +67,13 @@ export default class Transformer {
     fs.ensureDirSync(path.parse(outputPath).dir)
 
     if (fs.pathExistsSync(outputPath)) {
-      logger.debug(`skipping previously transformed image '${inputPath}'`)
+      logger.debug(`skipping previously transformed image '${inputSource}'`)
       return
     }
 
-    // If this is an IIIF endpoint, download with the appropriate size params
+    // Download from the IIIF endpoint (if exists) with the appropriate size params
     if (iiifEndpoint) {
-      const iiifUrl = inputPath.endsWith('/') ? inputPath : inputPath + '/'
+      const iiifUrl = inputSource.endsWith('/') ? inputSource : inputSource + '/'
 
       // Will need info for profile detection (v2/v3) and dimensions
       const infoUrl = new URL('info.json', iiifUrl)
@@ -98,7 +98,7 @@ export default class Transformer {
      * Declare a `sharp` service with a `crop` method that is callable
      * without a `region`, which the sharp API `extract` method does not allow
      */
-    const service = sharp(inputPath)
+    const service = sharp(inputSource)
     service.crop = function (region) {
       if (!region) return this
       const [top, left, width, height] = region.split(',').map((item) => parseFloat(item.trim()))

--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -1,4 +1,4 @@
-import FigureFactory from './figureMedia/factory.js'
+import FigureMediaFactory from './figureMedia/factory.js'
 import chalkFactory from '#lib/chalk/index.js'
 import iiifConfig from './iiif/config.js'
 
@@ -12,7 +12,7 @@ const logger = chalkFactory('Figures', 'DEBUG')
 export default function (eleventyConfig, options) {
   eleventyConfig.on('eleventy.before', async () => {
     const config = iiifConfig(eleventyConfig)
-    const figureFactory = new FigureFactory({ ...config, ...options })
+    const figureFactory = new FigureMediaFactory({ ...config, ...options })
 
     const { figure_list: figureList } = eleventyConfig.globalData.figures
 

--- a/packages/11ty/_tests/plugins/figures.spec.js
+++ b/packages/11ty/_tests/plugins/figures.spec.js
@@ -68,11 +68,11 @@ test('FigureMediaFactory should use unmutated `src` properties for figure images
   const { figure: figureModel } = await factory.create(figure)
   const figureMedia = figureModel.media()
 
-  const { transformations } = figureMedia
+  const { derivatives } = figureMedia
 
   // Check that the paths of each transformation are unmutated
-  for (const [name, transformation] of Object.entries(transformations)) {
-    const { paths } = transformation
+  for (const [name, derivative] of Object.entries(derivatives)) {
+    const { paths } = derivative
 
     if (paths.absolute !== figure.src || paths.internal !== figure.src || paths.uri !== figure.src) {
       t.fail(`The transformation ${name} should not mutate external resource URLs`)
@@ -134,7 +134,7 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
   const factorySubpath = await MockFigureMediaFactory(sandbox, iiifConfig, transformedNotTiled)
   const { figure: subpathFigureMedia } = await factorySubpath.create(figure)
 
-  const { paths, dimensions } = subpathFigureMedia.transformations.full
+  const { paths, dimensions } = subpathFigureMedia.derivatives.full
   const { absolute, internal, uri } = paths
   const { height, width } = dimensions
 

--- a/packages/11ty/_tests/plugins/figures.spec.js
+++ b/packages/11ty/_tests/plugins/figures.spec.js
@@ -51,6 +51,37 @@ test.before('', async (t) => {
   t.context.sandbox = sandbox
 })
 
+test('FigureMediaFactory should use unmutated `src` properties for figure images from URLs', async (t) => {
+  const { iiifConfig, sandbox } = t.context
+
+  const figure = {
+    id: 'https-figure',
+    src: 'https://example.org/test.jpg'
+  }
+
+  // Test that src will be passed unmutated to the paths on figureMedia
+  const noopProcessor = async (path, _, options) => {
+    return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
+  }
+
+  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, noopProcessor)
+  const { figure: figureModel } = await factory.create(figure)
+  const figureMedia = figureModel.media()
+
+  const { transformations } = figureMedia
+
+  // Check that the paths of each transformation are unmutated
+  for (const [name, transformation] of Object.entries(transformations)) {
+    const { paths } = transformation
+
+    if (paths.absolute !== figure.src || paths.internal !== figure.src || paths.uri !== figure.src) {
+      t.fail(`The transformation ${name} should not mutate external resource URLs`)
+    }
+  }
+
+  t.pass()
+})
+
 test('FigureMediaFactory should create a staticInlineFigureImage for zoomable figures', async (t) => {
   const { iiifConfig, sandbox } = t.context
 
@@ -60,14 +91,14 @@ test('FigureMediaFactory should create a staticInlineFigureImage for zoomable fi
     zoom: true
   }
 
-  // Check the options passed to the processor, if they are correct it passes
+  // Check whether the figure will be processed as zoomed and tiled
   let passed = false
-  const isTransformedZoomedAndIIIF = async (path, _, options) => {
+  const zoomedAndTiled = async (path, _, options) => {
     passed = options.transformations?.length > 0 && options.tile && !options.iiifEndpoint
     return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
   }
 
-  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedZoomedAndIIIF)
+  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, zoomedAndTiled)
   await factory.create(figure)
 
   if (passed) {
@@ -78,20 +109,21 @@ test('FigureMediaFactory should create a staticInlineFigureImage for zoomable fi
 })
 
 test('FigureMediaFactory should create a staticInlineFigureImage for static figures', async (t) => {
+  // Set up a figure to be transformed
   const { iiifConfig, sandbox } = t.context
-
   const figure = {
     id: 'static-figure',
     src: 'static-figure.jpg'
   }
 
+  // Set up a mock processor that checks whether the right options are passed in
   let passed = false
-  const isTransformedOnly = async (path, _, options) => {
+  const transformedNotTiled = async (path, _, options) => {
     passed = options.transformations?.length > 0 && !options.tile && !options.iiifEndpoint
     return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
   }
 
-  const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedOnly)
+  const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, transformedNotTiled)
   await factoryRoot.create(figure)
 
   if (!passed) {
@@ -99,7 +131,7 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
   }
 
   iiifConfig.baseURI = new URL('subpath', iiifConfig.baseURI).href
-  const factorySubpath = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedOnly)
+  const factorySubpath = await MockFigureMediaFactory(sandbox, iiifConfig, transformedNotTiled)
   const { figure: subpathFigureMedia } = await factorySubpath.create(figure)
 
   const { paths, dimensions } = subpathFigureMedia.transformations.full

--- a/packages/11ty/_tests/plugins/figures.spec.js
+++ b/packages/11ty/_tests/plugins/figures.spec.js
@@ -60,10 +60,11 @@ test('FigureMediaFactory should create a staticInlineFigureImage for zoomable fi
     zoom: true
   }
 
+  // Check the options passed to the processor, if they are correct it passes
   let passed = false
   const isTransformedZoomedAndIIIF = async (path, _, options) => {
     passed = options.transformations?.length > 0 && options.tile && !options.iiifEndpoint
-    return { errors: [] }
+    return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
   }
 
   const factory = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedZoomedAndIIIF)
@@ -87,15 +88,40 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
   let passed = false
   const isTransformedOnly = async (path, _, options) => {
     passed = options.transformations?.length > 0 && !options.tile && !options.iiifEndpoint
-    return { errors: [] }
+    return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
   }
 
-  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedOnly)
-  await factory.create(figure)
+  const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedOnly)
+  await factoryRoot.create(figure)
 
-  if (passed) {
-    t.pass()
-  } else {
+  if (!passed) {
     t.fail()
   }
+
+  iiifConfig.baseURI = new URL('subpath', iiifConfig.baseURI).href
+  const factorySubpath = await MockFigureMediaFactory(sandbox, iiifConfig, isTransformedOnly)
+  const { figure: subpathFigureMedia } = await factorySubpath.create(figure)
+
+  const { paths, dimensions } = subpathFigureMedia.transformations.full
+  const { absolute, internal, uri } = paths
+  const { height, width } = dimensions
+
+  // Test that:
+  // - Absolute and internal paths begin with '/'
+  // - Absolute and uri contain the subpath but internal does not
+  t.is(absolute.at(0), '/')
+  const absoluteComponents = absolute.split('/')
+  t.is(absoluteComponents.at(1), 'subpath')
+
+  t.is(internal.at(0), '/')
+  const internalComponents = internal.split('/')
+  t.not(internalComponents.at(1), 'subpath')
+
+  const mediaUrl = new URL(uri)
+  const mediaComponents = mediaUrl.pathname.split('/')
+  t.is(mediaComponents.at(1), 'subpath')
+
+  // Test that dimensions exist
+  t.is(height, 1000)
+  t.is(width, 1000)
 })

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.47",
+  "version": "1.0.0-rc.46",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",
@@ -107,14 +107,14 @@
     "markdown-it-footnote": "^4.0.0",
     "mime-types": "^2.1.35",
     "module-alias": "^2.2.2",
-    "pagefind": "1.5.2",
+    "pagefind": "^1.4.0",
     "path": "^0.12.7",
     "prettier": "^3.2.5",
     "remove-markdown": "^0.5.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-scss": "^3.0.0",
     "sass": "^1.99.0",
-    "sharp": "^0.33.5",
+    "sharp": "^0.33.2",
     "sinon": "^21.0.0",
     "toml": "^3.0.0"
   },


### PR DESCRIPTION
This PR refactors the figure media model to make it easier to use image derivatives generated during publication builds. It moves path and dimension metadata handling into the higher-order `FigureMedia` class, allowing for more correct re-use of the paths in components and adding long-missing `height` and `width` attributes to quire's figure `img` tags, improving page responsiveness.

## Overview of changes:
- Adds a `derivatives` property to the `media()` data shim on `FigureMedia` class. `derivatives` contains an object with derivative transformation names as keys (full, thumbnail, etc) and result metadata (height, width, and asset paths) objects. A full list of transforms is in `packages/11ty/_plugins/figures/iiif/config.js`.
- This is the shape of the additional data on `FigureMedia` instances serialized as JSON:
```json
{
  "derivatives": {
    "full": {
      "dimensions": {
        "height": 1000,
        "width": 1000
      }
      "paths": {
        "absolute": "/_assets/images/XXX.jpg",
        "internal": "/subpath/_assets/images/XXX.jpg",
        "uri": "https://example.org/subpath/_assets/images/XXX.jpg"
      }
    }
  }
}
```
- `paths` contains asset paths for derivatives:
  - `absolute` - relative to the the root of the publication hostname
  - `internal` - relative to the root of the publication (ie, paths that are safe to use in fragments that will be processed by the asset bundling plugin)
  - `uri` - with scheme, hostname, and port
- `dimensions` contains the `height` and `width` for the derived image
- Moves path calculations out of components and into `FigureMedia` methods. The switching dispatch of the `figureElement` component is also refactored so that control flow branches within the static figure tag are reduced from several branches to one branch with a varying argument.
- Deletes now-redundant path calculations from `imageTag` and the print output mode of `figureImage` components.
- Adds a helper function, `snakeCaseToCamel`, for converting transformation names within in the IIIF configuration that are in snake case to the camel case used by quire's data APIs (and enforced by linting, etc). 
- Adds tests for image asset paths to ensure correct behavior with and without a publication pathname.
- Adds test ensuring that figure images with an HTTP URL as `src` but not an internally-served IIIF URL (eg, images on a CDN) use the src URL for all paths.

## Affected Issues:
- These changes address the images side of #1171, transformed derivatives are generated for all images and in this PR their paths and metadata are made available at `globalData.figuresMedia[].derivatives.thumbnail.paths`, etc.
- Also addressed is the images part of #1197: this PR hoists pathing logic out of the html figure image component and into the class.
- Still to be addressed in future PRs are video and audio asset paths, poster paths, and other asset-encumbered figure media types.
