### PR TITLE
Replace css background images with html img elements

### DIFF
--- a/packages/11ty/_layouts/cover.liquid
+++ b/packages/11ty/_layouts/cover.liquid
@@ -5,17 +5,15 @@ description: Quire publication cover page
 layout: base.11ty.js
 ---
 
+{% if image %}
 {% assign coverImage = image %}
 {% assign imagePath = config.figures.imageDir | concat: coverImage | join: '/' %}
+{% endif %}
 
 <section class="quire-cover__hero hero is-fullheight">
-  <div
-    class="quire-cover__overlay"
-    style="background-image: url('{{ imagePath }}');"
-  >
-    {% comment %} This ensures background image asset gets copied into epub package {% endcomment %}
-    <img class="visually-hidden" src="{{ imagePath }}" alt="" data-outputs-include="epub" />
-  </div>
+  {% if image %}
+    <img class="quire-cover__hero-image hero-image" src="{{ imagePath }}" alt="" />
+  {% endif %}
   <div class="quire-cover__hero-body hero-body">
     <div class="container is-fluid">
       <h1 class="title" id="page-header-{{ page.filePathStem }}">

--- a/packages/11ty/_layouts/splash.liquid
+++ b/packages/11ty/_layouts/splash.liquid
@@ -4,15 +4,14 @@ classes:
 layout: base
 description: splash page layout
 ---
-{%- if image -%}
+{% if image %}
   {% assign imagePath = config.figures.imageDir | append: '/' | append: image %}
 {% endif %}
 {% assign labelDivider = config.pageTitle.labelDivider %}
 
-<section class="{% if title == "title page" or title == "half title page" %} is-screen-only {% endif %} quire-page__header hero {% if content %}{% else %}quire-page__header--full-height{% endif %} {% if image %}hero-image{% endif %}" {% if image %}style="background-image: url('{{ imagePath }}');"{% endif %}>
+<section class="{% if title == "title page" or title == "half title page" %} is-screen-only {% endif %} quire-page__header hero {% if content %}{% else %}quire-page__header--full-height{% endif %} {% if image %}quire-page__header--with-image{% endif %}">
   {% if image %}
-    {% comment %} This ensures background image asset gets copied into epub package {% endcomment %}
-    <img class="visually-hidden" src="{{ imagePath }}" alt="" data-outputs-include="epub" />
+    <img class="hero-image" src="{{ imagePath }}" alt="" />
   {% endif %}
   <div class="hero-body">
     <h1 class="quire-page__header__title" id="page-header-{{ page.filePathStem }}">


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [existing issue](https://github.com/thegetty/quire/issues).*

**Before submitting your PR, make sure that you can run the following commands: `quire preview`, `quire build`, `quire pdf`, and `quire epub`. If any of those core quire commands throw errors/yield unexpected behavior, we will NOT review the PR!**

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team

### Is this pull request related to an open issue? If so, what is the issue number?

Issue #1224 ("Cover and splash page background images are not displaying in PDF")

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.

This part of a fix for the issue. It is dependent on [PR #54](https://github.com/thegetty/quire-starter-default/pull/57) in the in the `quire-starter-default` repo to update the SCSS.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.

Replaces the use of CSS background images with HTML img elements.

### Does this pull request necessitate changes to Quire's documentation?

No

### Include screenshots of before/after if applicable.



### Additional Comments

