### PR TITLE
Fix recent CI failures: update xcode pin and limit playwright worker count in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
 
   macos:
     macos:
-      xcode: '16.3.0'
+      xcode: '16.4.0'
     resource_class: m4pro.medium
     environment:
         PUPPETEER_EXECUTABLE_PATH: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: undefined, //process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['junit', {printSteps: true, outputFile: pathnameTesting ? 'reports/publication-browser-pathname.xml' :  'reports/publication-browser.xml' }]


### PR DESCRIPTION
This PR collates fixes to quire's CI configuration from recent branches:
- Updates the macos workflow's xcode pin to 16.4.0, which should immediate failures of the macos job.
- Restores the single browser process setting to the playwright configuration when it runs in CI, which should restore the browser testing job's to known good. We had been applying this manually to branches under review but better to nip the common failures in the bud once.