### PR TITLE
Bump changelog and package versions for @thegetty/quire-cli and @thegetty/quire-11ty 1.0.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16942,7 +16942,7 @@
     },
     "packages/11ty": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0-rc.49",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "@iiif/helpers": "^1.3.1",
@@ -17088,7 +17088,7 @@
     },
     "packages/cli": {
       "name": "@thegetty/quire-cli",
-      "version": "1.0.0-rc.55",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "ajv": "^8.16.0",

--- a/packages/11ty/CHANGELOG.md
+++ b/packages/11ty/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0]
+
+- No changes -- first 1.0.0 release!
+
 ## [1.0.0-rc.49]
 
 ### Fixed

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0-rc.49",
+  "version": "1.0.0",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog entries are classified using the following labels:
 - `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [1.0.0]
+
+- No changes -- first 1.0.0 release!
+
 ## [1.0.0-rc.55]
 
 ### Bumped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thegetty/quire-cli",
   "description": "Quire command-line interface",
-  "version": "1.0.0-rc.55",
+  "version": "1.0.0",
   "author": "Getty Digital",
   "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
   "bugs": {


### PR DESCRIPTION
This PR bumps the package versions for @thegetty/quire-cli and @thegetty/quire-11ty to 1.0.0. It also updates the changelog for 1.0.0 on both.