### PR TITLE
fix/build error handling

### DIFF
--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -11,7 +11,7 @@ import sharp from 'sharp'
 import slugify from '@sindresorhus/slugify'
 import urlPathJoin from '#lib/urlPathJoin/index.js'
 
-const logger = chalkFactory('Figures:FigureMedia', 'DEBUG')
+const logger = chalkFactory('Figures:FigureMedia', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 /**
  * @param {Object} iiifConfig

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -2,7 +2,7 @@ import chalkFactory from '#lib/chalk/index.js'
 import path from 'node:path'
 
 // eslint-disable-next-line no-unused-vars
-const logger = chalkFactory('Figures:IIIF:Config', 'DEBUG')
+const logger = chalkFactory('Figures:IIIF:Config', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 export default (eleventyConfig) => {
   const { url } = eleventyConfig.globalData.publication

--- a/packages/11ty/_plugins/figures/iiif/manifest/index.js
+++ b/packages/11ty/_plugins/figures/iiif/manifest/index.js
@@ -6,7 +6,7 @@ import Writer from './writer.js'
 import chalkFactory from '#lib/chalk/index.js'
 import urlPathJoin from '#lib/urlPathJoin/index.js'
 
-const logger = chalkFactory('Figures:IIIF:Manifest', 'DEBUG')
+const logger = chalkFactory('Figures:IIIF:Manifest', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 const vault = globalVault()
 const builder = new IIIFBuilder(vault)

--- a/packages/11ty/_plugins/figures/image/processor.js
+++ b/packages/11ty/_plugins/figures/image/processor.js
@@ -4,7 +4,7 @@ import chalkFactory from '#lib/chalk/index.js'
 import fs from 'fs-extra'
 import path from 'node:path'
 
-const logger = chalkFactory('Figures:ImageProcessor', 'DEBUG')
+const logger = chalkFactory('Figures:ImageProcessor', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 /**
  * The Quire Image Processor handles file system changes for IIIF images

--- a/packages/11ty/_plugins/figures/image/tiler.js
+++ b/packages/11ty/_plugins/figures/image/tiler.js
@@ -5,7 +5,7 @@ import path from 'node:path'
 import sharp from 'sharp'
 import slugify from '@sindresorhus/slugify'
 
-const logger = chalkFactory('Figures:ImageTiler', 'DEBUG')
+const logger = chalkFactory('Figures:ImageTiler', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 /**
  * Tiler

--- a/packages/11ty/_plugins/figures/image/transformer.js
+++ b/packages/11ty/_plugins/figures/image/transformer.js
@@ -5,7 +5,7 @@ import path from 'node:path'
 import sharp from 'sharp'
 import slugify from '@sindresorhus/slugify'
 
-const logger = chalkFactory('Figures:ImageTransformer', 'DEBUG')
+const logger = chalkFactory('Figures:ImageTransformer', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 /**
  * @function iiifSize

--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -2,7 +2,7 @@ import FigureMediaFactory from './figureMedia/factory.js'
 import chalkFactory from '#lib/chalk/index.js'
 import iiifConfig from './iiif/config.js'
 
-const logger = chalkFactory('Figures', 'DEBUG')
+const logger = chalkFactory('Figures', process.env.QUIRE_DEBUG_LOG ?? 'info')
 
 /**
  * Figures Plugin

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -10,28 +10,36 @@ const logger = chalkFactory('[plugins:globalData]')
  * Throws an error if data contains duplicate ids
  * @param  {Object|Array} data
  */
-const checkForDuplicateIds = function (data, filename) {
+const checkForDuplicateIds = function (data, filename, key = '') {
   if (!data) return
 
-  if (Array.isArray(data)) {
-    if (data.every((item) => Object.hasOwn(item, 'id'))) {
-      const duplicates = data.filter((a, index) => {
+  if(Array.isArray(data)) {
+    const isObject = data.length > 0 
+      && data.some((item) => typeof item === 'object' 
+      && Object.hasOwn(item, 'id'))
+     
+    if(isObject) {
+      const isMissingId = data.some((item) => !item?.id)
+      if(isMissingId) {
+        throw new Error(`${filename}: "${key}" contains an entry with no "id".`)
+      }
+
+      const duplicates = data.filter((a,index) => {
         return index !== data.findIndex((b) => b.id === a.id)
       })
+
       if (duplicates.length) {
         const ids = duplicates.map(({ id }) => id)
-        throw new Error(`Duplicates ids: ${ids.join(', ')}`)
+        throw new Error(`${filename}: "${key}" contains duplicate ids: ${ids.join(', ')}.`)
       }
     }
+
+    return 
   }
 
   if (typeof data === 'object') {
     Object.keys(data).forEach((key) => {
-      try {
-        checkForDuplicateIds(data[key], filename)
-      } catch (error) {
-        logger.error(`${filename} ${key} contains multiple entries with the same id.\nEach entry in ${key} must have a unique id. ${error.message}`)
-      }
+      checkForDuplicateIds(data[key], filename, key)
     })
   }
 }
@@ -68,6 +76,7 @@ export default function (eleventyConfig, directoryConfig) {
     let value
     try {
       value = validateUserConfig(key, parsed)
+      checkForDuplicateIds(value, file)
     } catch (err) {
       logger.error(err)
       process.exit(1)
@@ -76,7 +85,6 @@ export default function (eleventyConfig, directoryConfig) {
     if (!key || !value) {
       continue
     }
-    checkForDuplicateIds(value, file)
     eleventyConfig.addGlobalData(key, value)
   }
 

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -13,18 +13,15 @@ const logger = chalkFactory('[plugins:globalData]')
 const validateObjectIds = function (data, filename, key = '') {
   if (!data) return
 
-  if(Array.isArray(data)) {
-    const isObject = data.length > 0 
-      && data.some((item) => typeof item === 'object' 
-      && Object.hasOwn(item, 'id'))
-     
-    if(isObject) {
+  if (Array.isArray(data)) {
+    const isObject = data.length > 0 && data.some((item) => typeof item === 'object' && Object.hasOwn(item, 'id'))
+    if (isObject) {
       const isMissingId = data.some((item) => !item?.id)
-      if(isMissingId) {
+      if (isMissingId) {
         throw new Error(`${filename}: "${key}" contains an entry with no "id".`)
       }
 
-      const duplicates = data.filter((a,index) => {
+      const duplicates = data.filter((a, index) => {
         return index !== data.findIndex((b) => b.id === a.id)
       })
 
@@ -76,7 +73,8 @@ export default function (eleventyConfig, directoryConfig) {
       value = validateUserConfig(key, parsed)
       validateObjectIds(value, file, key)
     } catch (err) {
-      throw err
+      logger.error(err.message)
+      process.exit(1)
     }
 
     if (!key || !value) {

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -33,8 +33,6 @@ const validateObjectIds = function (data, filename, key = '') {
         throw new Error(`${filename}: "${key}" contains duplicate ids: ${ids.join(', ')}.`)
       }
     }
-
-    return 
   }
 
   if (typeof data === 'object') {

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -78,8 +78,7 @@ export default function (eleventyConfig, directoryConfig) {
       value = validateUserConfig(key, parsed)
       validateObjectIds(value, file, key)
     } catch (err) {
-      logger.error(err)
-      process.exit(1)
+      throw err
     }
 
     if (!key || !value) {

--- a/packages/11ty/_plugins/globalData/index.js
+++ b/packages/11ty/_plugins/globalData/index.js
@@ -10,7 +10,7 @@ const logger = chalkFactory('[plugins:globalData]')
  * Throws an error if data contains duplicate ids
  * @param  {Object|Array} data
  */
-const checkForDuplicateIds = function (data, filename, key = '') {
+const validateObjectIds = function (data, filename, key = '') {
   if (!data) return
 
   if(Array.isArray(data)) {
@@ -39,7 +39,7 @@ const checkForDuplicateIds = function (data, filename, key = '') {
 
   if (typeof data === 'object') {
     Object.keys(data).forEach((key) => {
-      checkForDuplicateIds(data[key], filename, key)
+      validateObjectIds(data[key], filename, key)
     })
   }
 }
@@ -76,7 +76,7 @@ export default function (eleventyConfig, directoryConfig) {
     let value
     try {
       value = validateUserConfig(key, parsed)
-      checkForDuplicateIds(value, file)
+      validateObjectIds(value, file, key)
     } catch (err) {
       logger.error(err)
       process.exit(1)

--- a/packages/11ty/_tests/plugins/globalData.spec.js
+++ b/packages/11ty/_tests/plugins/globalData.spec.js
@@ -1,0 +1,106 @@
+/**
+ * globalData.spec.js
+ * 
+ * Tests for `globalData` plugin
+ */
+import esmock from 'esmock'
+import test from 'ava'
+import sinon from 'sinon'
+import { initEleventyEnvironment } from '../helpers/index.js'
+
+const fakeFs = {
+    existsSync: () => true,
+    readdirSync: () => ['figures.yaml'],
+    readFileSync: () => ''
+}
+const fakeParser = () => (filepath) => ({ figure_list: eleventyStub.config.figure_list })
+const fakeValidator = { validateUserConfig: (k, v) => v }
+const fakeChalk = () => ({ error: console.error, warn: console.warn })
+
+const eleventyStub = {
+    config: {
+        figure_list: [
+            {
+                id: 'lange',
+                src: 'figures/lange.jpg',
+                caption: '*Dorothea Lange, Resettlement Administration photographer, in California*, 1936.',
+                credit: 'Library of Congress Prints and Photographs Division',
+                alt: 'Shot low and looking up at an old model car on a dirt row with a hill behind. A woman sits on the roof of the car holding a large camera and smiling.'
+            },
+            {
+                id: 'evans',
+                src: 'figures/evans.jpg',
+                caption: '*Walker Evans, profile, hand up to face*, 1937.',
+                credit: 'Library of Congress Prints and Photographs Division',
+                alt: 'A seated man looking away to the left, his hand at his cheek, his hair mussed, a slight worried expression on his face.'
+            }
+        ]
+    },
+    globalData: {
+        directoryConfig: { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
+    }
+}
+
+test.before('Load plugin with mocks', async (t) => {
+    t.context.GlobalData = await esmock(
+        '../../_plugins/globalData/index.js',
+        {
+            'fs-extra': fakeFs,
+            '../../_plugins/globalData/parser.js': fakeParser,
+            '../../_plugins/globalData/validator.js': fakeValidator,
+            '#lib/chalk/index.js': { default: fakeChalk }
+        }
+    )
+})
+
+test('Validate Figures added to eleventyConfig.globalData', async (t) => {
+    const { GlobalData } = t.context
+
+    const eleventyConfig = {
+        addGlobalData: sinon.stub().callsFake((key, value) => {
+            eleventyConfig.globalData[key] = value
+        }),
+        globalData: {}
+    }   
+
+    const directoryConfig = { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
+
+    GlobalData(eleventyConfig, directoryConfig)
+    
+    t.true(eleventyConfig.addGlobalData.calledWith('figures', sinon.match.any))
+    t.deepEqual(eleventyConfig.globalData.figures.figure_list, eleventyStub.config.figure_list);
+})
+
+test('Validate Figures throws missing id error', async (t) => {
+    const { GlobalData } = t.context
+
+    const missingIdParser = () => (filepath) => ({ 
+        figure_list: [
+            { id: 'lange', src: 'figures/lange.jpg', caption: 'Test' },
+            { id: '', src: 'figures/missing-id.jpg', caption: 'Test 2' }
+        ]
+    })
+    
+    const badGlobalData = await esmock(
+        '../../_plugins/globalData/index.js',
+        {
+            'fs-extra': fakeFs,
+            '../../_plugins/globalData/parser.js': missingIdParser,
+            '../../_plugins/globalData/validator.js': fakeValidator,
+            '#lib/chalk/index.js': { default: fakeChalk }
+        }
+    )
+
+    const eleventyConfig = {
+        addGlobalData: sinon.stub().callsFake((key, value) => {
+            eleventyConfig.globalData[key] = value
+        }),
+        globalData: {}
+    }   
+
+    const directoryConfig = { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
+    const error = t.throws(() => {
+        badGlobalData(eleventyConfig, directoryConfig)
+    })
+    t.is(error.message, 'figures.yaml: "figure_list" contains an entry with no "id".');
+})

--- a/packages/11ty/_tests/plugins/globalData.spec.js
+++ b/packages/11ty/_tests/plugins/globalData.spec.js
@@ -1,106 +1,104 @@
 /**
  * globalData.spec.js
- * 
  * Tests for `globalData` plugin
  */
 import esmock from 'esmock'
 import test from 'ava'
 import sinon from 'sinon'
-import { initEleventyEnvironment } from '../helpers/index.js'
 
 const fakeFs = {
-    existsSync: () => true,
-    readdirSync: () => ['figures.yaml'],
-    readFileSync: () => ''
+  existsSync: () => true,
+  readdirSync: () => ['figures.yaml'],
+  readFileSync: () => ''
 }
 const fakeParser = () => (filepath) => ({ figure_list: eleventyStub.config.figure_list })
 const fakeValidator = { validateUserConfig: (k, v) => v }
 const fakeChalk = () => ({ error: console.error, warn: console.warn })
+const fakeExit = sinon.stub(process, 'exit').callsFake(() => {
+  throw new Error('exited with a non-zero exit code: 1')
+})
 
 const eleventyStub = {
-    config: {
-        figure_list: [
-            {
-                id: 'lange',
-                src: 'figures/lange.jpg',
-                caption: '*Dorothea Lange, Resettlement Administration photographer, in California*, 1936.',
-                credit: 'Library of Congress Prints and Photographs Division',
-                alt: 'Shot low and looking up at an old model car on a dirt row with a hill behind. A woman sits on the roof of the car holding a large camera and smiling.'
-            },
-            {
-                id: 'evans',
-                src: 'figures/evans.jpg',
-                caption: '*Walker Evans, profile, hand up to face*, 1937.',
-                credit: 'Library of Congress Prints and Photographs Division',
-                alt: 'A seated man looking away to the left, his hand at his cheek, his hair mussed, a slight worried expression on his face.'
-            }
-        ]
-    },
-    globalData: {
-        directoryConfig: { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
-    }
+  config: {
+    figure_list: [
+      {
+        id: 'lange',
+        src: 'figures/lange.jpg',
+        caption: '*Dorothea Lange, Resettlement Administration photographer, in California*, 1936.',
+        credit: 'Library of Congress Prints and Photographs Division',
+        alt: 'Shot low and looking up at an old model car on a dirt row with a hill behind. A woman sits on the roof of the car holding a large camera and smiling.'
+      },
+      {
+        id: 'evans',
+        src: 'figures/evans.jpg',
+        caption: '*Walker Evans, profile, hand up to face*, 1937.',
+        credit: 'Library of Congress Prints and Photographs Division',
+        alt: 'A seated man looking away to the left, his hand at his cheek, his hair mussed, a slight worried expression on his face.'
+      }
+    ]
+  },
+  globalData: {
+    directoryConfig: { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
+  }
 }
 
 test.before('Load plugin with mocks', async (t) => {
-    t.context.GlobalData = await esmock(
-        '../../_plugins/globalData/index.js',
-        {
-            'fs-extra': fakeFs,
-            '../../_plugins/globalData/parser.js': fakeParser,
-            '../../_plugins/globalData/validator.js': fakeValidator,
-            '#lib/chalk/index.js': { default: fakeChalk }
-        }
-    )
+  t.context.GlobalData = await esmock(
+    '../../_plugins/globalData/index.js',
+    {
+      'fs-extra': fakeFs,
+      '../../_plugins/globalData/parser.js': fakeParser,
+      '../../_plugins/globalData/validator.js': fakeValidator,
+      '#lib/chalk/index.js': { default: fakeChalk }
+    }
+  )
 })
 
 test('Validate Figures added to eleventyConfig.globalData', async (t) => {
-    const { GlobalData } = t.context
+  const { GlobalData } = t.context
 
-    const eleventyConfig = {
-        addGlobalData: sinon.stub().callsFake((key, value) => {
-            eleventyConfig.globalData[key] = value
-        }),
-        globalData: {}
-    }   
+  const eleventyConfig = {
+    addGlobalData: sinon.stub().callsFake((key, value) => {
+      eleventyConfig.globalData[key] = value
+    }),
+    globalData: {}
+  }
 
-    const directoryConfig = { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
+  const directoryConfig = { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
 
-    GlobalData(eleventyConfig, directoryConfig)
-    
-    t.true(eleventyConfig.addGlobalData.calledWith('figures', sinon.match.any))
-    t.deepEqual(eleventyConfig.globalData.figures.figure_list, eleventyStub.config.figure_list);
+  GlobalData(eleventyConfig, directoryConfig)
+  t.true(eleventyConfig.addGlobalData.calledWith('figures', sinon.match.any))
+  t.deepEqual(eleventyConfig.globalData.figures.figure_list, eleventyStub.config.figure_list)
 })
 
 test('Validate Figures throws missing id error', async (t) => {
-    const { GlobalData } = t.context
+  const missingIdParser = () => (filepath) => ({
+    figure_list: [
+      { id: 'lange', src: 'figures/lange.jpg', caption: 'Test' },
+      { id: '', src: 'figures/missing-id.jpg', caption: 'Test 2' }
+    ]
+  })
+  const badGlobalData = await esmock(
+    '../../_plugins/globalData/index.js',
+    {
+      'fs-extra': fakeFs,
+      '../../_plugins/globalData/parser.js': missingIdParser,
+      '../../_plugins/globalData/validator.js': fakeValidator,
+      '#lib/chalk/index.js': { default: fakeChalk }
+    }
+  )
 
-    const missingIdParser = () => (filepath) => ({ 
-        figure_list: [
-            { id: 'lange', src: 'figures/lange.jpg', caption: 'Test' },
-            { id: '', src: 'figures/missing-id.jpg', caption: 'Test 2' }
-        ]
-    })
-    
-    const badGlobalData = await esmock(
-        '../../_plugins/globalData/index.js',
-        {
-            'fs-extra': fakeFs,
-            '../../_plugins/globalData/parser.js': missingIdParser,
-            '../../_plugins/globalData/validator.js': fakeValidator,
-            '#lib/chalk/index.js': { default: fakeChalk }
-        }
-    )
+  const eleventyConfig = {
+    addGlobalData: sinon.stub().callsFake((key, value) => {
+      eleventyConfig.globalData[key] = value
+    }),
+    globalData: {}
+  }
+  const directoryConfig = { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
+  const error = t.throws(() => {
+    badGlobalData(eleventyConfig, directoryConfig)
+  })
 
-    const eleventyConfig = {
-        addGlobalData: sinon.stub().callsFake((key, value) => {
-            eleventyConfig.globalData[key] = value
-        }),
-        globalData: {}
-    }   
-
-    const directoryConfig = { inputDir: 'content', outputDir: '_site', publicDir: 'public' }
-    const error = t.throws(() => {
-        badGlobalData(eleventyConfig, directoryConfig)
-    })
-    t.is(error.message, 'figures.yaml: "figure_list" contains an entry with no "id".');
+  t.is(error.message, 'exited with a non-zero exit code: 1')
+  fakeExit.restore()
 })

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -56,7 +56,6 @@ export default class BuildCommand extends Command {
       }
     } catch (err) {
       console.error(err.message);
-      process.exit(1);
     }
 
   }

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -41,18 +41,24 @@ export default class BuildCommand extends Command {
     super(BuildCommand.definition)
   }
 
-  action(options, command) {
+  async action(options, command) {
     if (options.debug) {
       console.debug('[CLI] Command \'%s\' called with options %o', this.name(), options)
     }
 
-    if (options['11ty'] === 'cli') {
-      console.debug('[CLI] running eleventy using lib/11ty cli')
-      cli.build(options)
-    } else {
-      console.debug('[CLI] running eleventy using lib/11ty api')
-      api.build(options)
+    try {
+      if (options['11ty'] === 'cli') {
+        console.debug('[CLI] running eleventy using lib/11ty cli')
+        await cli.build(options)
+      } else {
+        console.debug('[CLI] running eleventy using lib/11ty api')
+        await api.build(options)
+      }
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
     }
+
   }
 
   preAction(command) {

--- a/packages/cli/src/commands/preview.js
+++ b/packages/cli/src/commands/preview.js
@@ -54,7 +54,7 @@ export default class PreviewCommand extends Command {
         await api.serve(options)
       }
     } catch (err) {
-      console.error(err)
+      console.error(err.message);
     }
   }
 

--- a/packages/cli/src/commands/preview.js
+++ b/packages/cli/src/commands/preview.js
@@ -45,12 +45,16 @@ export default class PreviewCommand extends Command {
       console.debug('[CLI] Command \'%s\' called with arguments [%o] and options %o', this.name(), options)
     }
 
-    if (options['11ty'] === 'cli') {
-      console.debug('[CLI] running eleventy using lib/11ty cli')
-      cli.serve(options)
-    } else {
-      console.debug('[CLI] running eleventy using lib/11ty api')
-      api.serve(options)
+    try {
+      if (options['11ty'] === 'cli') {
+        console.debug('[CLI] running eleventy using lib/11ty cli')
+        await cli.serve(options)
+      } else {
+        console.debug('[CLI] running eleventy using lib/11ty api')
+        await api.serve(options)
+      }
+    } catch (err) {
+      console.error(err)
     }
   }
 

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -84,9 +84,14 @@ export default {
     if (options.debug) env.CHALK_LEVEL_LOG = 'DEBUG'
     env.ELEVENTY_ENV = 'production'
 
-    const build = execa('node', command, { all: true, cwd: projectRoot, env })
-    build.all.pipe(process.stdout)
-    await build
+    try {
+      const build = execa('node', command, { all: true, cwd: projectRoot, env })
+      build.all.pipe(process.stdout)
+      await build
+    } catch(err) {
+        process.exitCode = 1
+    }
+
   },
 
   serve: async (options = {}) => {

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -83,13 +83,18 @@ export default {
     if (options.dryRun) command.push('--dryrun')
     if (options.debug) env.CHALK_LEVEL_LOG = 'DEBUG'
     env.ELEVENTY_ENV = 'production'
+    
+    const build = execa('node', command, {
+      all:true, 
+      cwd: projectRoot,
+      env,
+      nodePath: process.stdout
+    }).all.pipe(process.stdout)
+    
+    await build;
 
-    try {
-      const build = execa('node', command, { all: true, cwd: projectRoot, env })
-      build.all.pipe(process.stdout)
-      await build
-    } catch(err) {
-      process.exit(1)
+    if (build.exitCode !== 0) {
+      process.exit(build.exitCode);
     }
 
   },
@@ -106,16 +111,11 @@ export default {
 
     env.ELEVENTY_ENV = 'development'
 
-    try {
-      
-      await execa('node', command, {
-        all: true,
-        cwd: projectRoot,
-        env
-      }).all.pipe(process.stdout)
-
-    } catch (err) {
-      process.exit(1);
-    }
+    await execa('node', command, {
+      all: true,
+      cwd: projectRoot,
+      env, 
+      nodePath: process.execPath
+    }).all.pipe(process.stdout)
   }
 }

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -81,20 +81,15 @@ export default {
     const { command, env } = factory(options)
 
     if (options.dryRun) command.push('--dryrun')
-
+    if (options.debug) env.QUIRE_DEBUG_LOG = 'DEBUG'
     env.ELEVENTY_ENV = 'production'
 
-    const build = execa('node', command, {
-      all: true,
-      cwd: projectRoot,
-      env,
-      nodePath: process.execPath
-    })
-    build.all.pipe(process.stdout)
-    await build
-
-    if (build.exitCode !== 0) {
-      process.exit(build.exitCode)
+    try {
+      const build = execa('node', command, { all: true, cwd: projectRoot, env })
+      build.all.pipe(process.stdout)
+      await build
+    } catch (err) {
+      throw new Error('Build failed', { cause: err })
     }
   },
 

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -105,12 +105,17 @@ export default {
     if (options.debug) env.QUIRE_DEBUG_LOG = 'DEBUG'
 
     env.ELEVENTY_ENV = 'development'
-    
-    await execa('node', command, {
-      all: true,
-      cwd: projectRoot,
-      env
-    }).all.pipe(process.stdout)
 
+    try {
+      
+      await execa('node', command, {
+        all: true,
+        cwd: projectRoot,
+        env
+      }).all.pipe(process.stdout)
+
+    } catch (err) {
+      process.exit(1);
+    }
   }
 }

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -89,7 +89,7 @@ export default {
       build.all.pipe(process.stdout)
       await build
     } catch(err) {
-        process.exitCode = 1
+      process.exit(1)
     }
 
   },

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -81,16 +81,12 @@ export default {
     const { command, env } = factory(options)
 
     if (options.dryRun) command.push('--dryrun')
-    if (options.debug) env.QUIRE_DEBUG_LOG = 'DEBUG'
+    if (options.debug) env.CHALK_LEVEL_LOG = 'DEBUG'
     env.ELEVENTY_ENV = 'production'
 
-    try {
-      const build = execa('node', command, { all: true, cwd: projectRoot, env })
-      build.all.pipe(process.stdout)
-      await build
-    } catch (err) {
-      throw new Error('Build failed', { cause: err })
-    }
+    const build = execa('node', command, { all: true, cwd: projectRoot, env })
+    build.all.pipe(process.stdout)
+    await build
   },
 
   serve: async (options = {}) => {
@@ -101,14 +97,15 @@ export default {
     command.push('--serve')
 
     if (options.port) command.push(`--port=${options.port}`)
+    if (options.debug) env.QUIRE_DEBUG_LOG = 'DEBUG'
 
     env.ELEVENTY_ENV = 'development'
-
+    
     await execa('node', command, {
       all: true,
       cwd: projectRoot,
-      env,
-      nodePath: process.execPath
+      env
     }).all.pipe(process.stdout)
+
   }
 }

--- a/packages/cli/src/lib/11ty/cli.js
+++ b/packages/cli/src/lib/11ty/cli.js
@@ -88,9 +88,9 @@ export default {
       all:true, 
       cwd: projectRoot,
       env,
-      nodePath: process.stdout
-    }).all.pipe(process.stdout)
-    
+      nodePath: process.execPath
+    })
+    build.all.pipe(process.stdout)
     await build;
 
     if (build.exitCode !== 0) {
@@ -111,11 +111,13 @@ export default {
 
     env.ELEVENTY_ENV = 'development'
 
-    await execa('node', command, {
+    const serve = execa('node', command, {
       all: true,
       cwd: projectRoot,
       env, 
       nodePath: process.execPath
-    }).all.pipe(process.stdout)
+    })
+    serve.all.pipe(process.stdout)
+    await serve
   }
 }


### PR DESCRIPTION
Thank you for contributing to Quire! Please complete the form below to submit your pull request for review. 

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Fix, Feature, Docs, or Chore. Issue-# is only needed if this pull request addresses an [existing issue](https://github.com/thegetty/quire/issues).*

**Before submitting your PR, make sure that you can run the following commands: `quire preview`, `quire build`, `quire pdf`, and `quire epub`. If any of those core quire commands throw errors/yield unexpected behavior, we will NOT review the PR!**

### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
Capturing issues with similar pain points

https://github.com/thegetty/quire/issues/933
```
quire build
[CLI] running eleventy using lib/11ty cli
[CLI:11ty] running eleventy build
[quire] ERROR    [plugins:globalData]           Error: references.yaml: "entries" contains an entry with no "id".
```

https://github.com/thegetty/quire/issues/1115
```
quire build
[CLI] running eleventy using lib/11ty cli
[CLI:11ty] running eleventy build
[quire] ERROR    Figures:Annotation             Error creating annotation URI. Either the output directory (iiif/mother-variants), filename (undefined) or base URI (http://localhost:8080/) are invalid to form a fully qualified URI.
[quire] ERROR    Figures:FigureMedia            Could not read metadata for figure mother-variants: Error: Invalid input!

Note: The issue asks if we can remove [11ty]. I haven't found documentation that would allow us to suppress that. We could filter the error message to manually remove it?
```

https://github.com/thegetty/quire/issues/1116
```
CLI] running eleventy using lib/11ty cli
[CLI:11ty] running eleventy build
[quire] ERROR    [plugins:globalData]           Error: figures.yaml: "figure_list" contains duplicate ids: fig-1, fig-1, fig-1.

Note: What is the expected output for duplicates?
```

https://github.com/thegetty/quire/issues/845
```
[CLI:11ty] running eleventy build
[quire] ERROR    Figures:FigureMedia            Could not read metadata for figure fig-2: Error: Input file is missing: /Users/andyair/Desktop/code/quire/template/myproj/content/_assets/images/figures/evans-sons.jpg!

Note: Build still succeeds, process exit would be okay here.
```

### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.
Build and preview fail spectacularly in printing the whole stack trace to the cli. This makes it difficult to understand the root cause of the error. By throwing/catching appropriately and leveraging the chalk factory for logging, we can reduce the chatter printed to the cli. 

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.
- Remove hardcoded `DEBUG` from chalkfactory. Restores functionality to --debug option.
- Refactor globalData to check for missing ids. Will fail build immediately on missing or duplicate ids. (Though maybe it should only console.error and not exit?)
- `action` and `cli.build`, added async and await where appropriate.

### Does this pull request necessitate changes to Quire's documentation?
No

### Include screenshots of before/after if applicable.



### Additional Comments
Left notes with each output as they relate to the original issues and its ask. 


### Test Terminal output
npx ava _tests/plugins/globalData.spec.js                         

  ✔ Validate Figures added to eleventyConfig.globalData
  ✔ Validate Figures throws missing id error
  ─

  2 tests passed

