### PR TITLE
Refactor figures plugin to handle annex images (contributors, logos, etc)

### DIFF
--- a/_tests/publication.spec.js
+++ b/_tests/publication.spec.js
@@ -76,7 +76,7 @@ const checkAllImgsOK = async (page) => {
   const imgLoc = page.locator('img')
   const imgs = await imgLoc.all()  
 
-  // Get all the src attributes and root them to localhost:8080 if they aren't valid URLs
+  // Collect the src attributes and root them to localhost:8080 if they aren't valid URLs
   const imgHrefs = await Promise.all(imgs.map( async (img) => await img.getAttribute('src') ))
   const imgUrls = imgHrefs.map( (href) => {
     let url
@@ -90,35 +90,14 @@ const checkAllImgsOK = async (page) => {
     return url
   })
 
+  // Append og:image value to urls (if it is not a valid URL it's an error)
+  const ogLoc = page.locator('meta[property="og:image"]')
+  const ogElement = ogLoc.first()
+  const ogUrl = await ogElement.getAttribute('content')
+
+  imgUrls.push(ogUrl)
+
   await Promise.all( imgUrls.map( (u) => checkUrl(u,page) ) )
-}
-
-/**
- * @function checkLightboxSlides
- * 
- * @argument {Page} page
- * 
- * Checks that src attrs of all lightbox slide images work
- * 
- **/ 
-const checkLightboxSlides = async (page) => {
-  // Find each figure image on the page, click it
-  // TODO: Drill shadowRoots
-  const modal = await page.locator('q-modal').first()
-  const lightbox = await modal.locator('q-lightbox').first()
-
-  for ( const slideImg of await lightbox.locator('.q-lightbox-slides__element--image > img').all() ) {
-    const src = await slideImg.getAttribute('src')
-
-    let url
-    try {
-      url = new URL(src)
-    } catch {
-      url = new URL(src,'http://localhost:8080/')
-    }
-    console.log(url.href)
-    await checkUrl(url.href, page)
-  }
 }
 
 /**
@@ -160,6 +139,5 @@ for (const url of siteURLs) {
     await expect.soft(page).toHaveTitle(/.{1,}/)
     await checkAllImgsOK(page)
     await checkCanvasPanelCanvasDims(page)
-    // await checkLightboxSlides(page)
   })  
 }

--- a/_tests/publication.spec.js
+++ b/_tests/publication.spec.js
@@ -92,10 +92,12 @@ const checkAllImgsOK = async (page) => {
 
   // Append og:image value to urls (if it is not a valid URL it's an error)
   const ogLoc = page.locator('meta[property="og:image"]')
-  const ogElement = ogLoc.first()
-  const ogUrl = await ogElement.getAttribute('content')
+  const ogElements = await ogLoc.all()
 
-  imgUrls.push(ogUrl)
+  if (ogElements.length > 0) {
+    const ogUrl = await ogElements.at(0).getAttribute('content')
+    imgUrls.push(ogUrl)
+  }
 
   await Promise.all( imgUrls.map( (u) => checkUrl(u,page) ) )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16942,7 +16942,7 @@
     },
     "packages/11ty": {
       "name": "@thegetty/quire-11ty",
-      "version": "1.0.0",
+      "version": "1.0.1-rc.1",
       "license": "SEE LICENSE IN https://github.com/thegetty/quire/blob/main/LICENSE",
       "dependencies": {
         "@iiif/helpers": "^1.3.1",

--- a/packages/11ty/_includes/components/contributor/bio.js
+++ b/packages/11ty/_includes/components/contributor/bio.js
@@ -40,9 +40,17 @@ export default function (eleventyConfig) {
     let contributorImage = ''
     if (image) {
       const figure = getFigureMedia(`contributor-${id}`)
+      const media = figure.derivatives.full
+
+      const { internal: imagePath } = media.paths
+      const { height, width } = media.dimensions
+
+      const heightAttr = height ? `height="${height}"` : ''
+      const widthAttr = width ? `width="${width}"` : ''
+
       contributorImage = html`
           <div class="media-left">
-            <img class="image quire-contributor__pic" src="${figure.derivatives.full.paths.internal}" alt="Picture of ${escape(name)}">
+            <img class="image quire-contributor__pic" ${heightAttr} ${widthAttr} src="${imagePath}" alt="Picture of ${escape(name)}">
           </div>`
     }
 

--- a/packages/11ty/_includes/components/contributor/bio.js
+++ b/packages/11ty/_includes/components/contributor/bio.js
@@ -1,6 +1,5 @@
 import escape from 'html-escape'
 import { html } from '#lib/common-tags/index.js'
-import path from 'node:path'
 
 /**
  * Contributor bio subcomponent
@@ -14,12 +13,12 @@ import path from 'node:path'
  */
 export default function (eleventyConfig) {
   const fullname = eleventyConfig.getFilter('fullname')
+  const getFigureMedia = eleventyConfig.getFilter('getFigureMedia')
   const icon = eleventyConfig.getFilter('icon')
   const link = eleventyConfig.getFilter('link')
   const markdownify = eleventyConfig.getFilter('markdownify')
   const pageTitle = eleventyConfig.getFilter('pageTitle')
   const slugify = eleventyConfig.getFilter('slugify')
-  const { config } = eleventyConfig.globalData
 
   /**
    * @param  {Object} params
@@ -30,7 +29,7 @@ export default function (eleventyConfig) {
    * @property {String} URL Contributor URL
    */
   return function (params) {
-    const { bio, image, pages = [], url } = params
+    const { bio, id, image, pages = [], url } = params
 
     const name = fullname(params)
 
@@ -38,13 +37,14 @@ export default function (eleventyConfig) {
       ? link({ classes: ['quire-contributor__url'], name: icon({ type: 'link', description: '' }), url })
       : ''
 
-    const contributorImage = image
-      ? html`
+    let contributorImage = ''
+    if (image) {
+      const figure = getFigureMedia(`contributor-${id}`)
+      contributorImage = html`
           <div class="media-left">
-            <img class="image quire-contributor__pic" src="${path.join(config.figures.imageDir, image).replaceAll(path.sep, '/')}" alt="Picture of ${escape(name)}">
-          </div>
-      `
-      : ''
+            <img class="image quire-contributor__pic" src="${figure.derivatives.full.paths.internal}" alt="Picture of ${escape(name)}">
+          </div>`
+    }
 
     const contributorBio = bio
       ? html`

--- a/packages/11ty/_includes/components/copyright/index.js
+++ b/packages/11ty/_includes/components/copyright/index.js
@@ -24,11 +24,15 @@ export default function (eleventyConfig) {
     const publisherImages = publication.publisher.flatMap(({ logo, name }) => {
       const logoFigure = getFigureMedia(`logo-${slugify(name)}`)
 
-      const imagePath = logo && logoFigure.derivatives.full.paths.internal
+      if (!logo || !logoFigure) return []
 
-      return imagePath
-        ? [`<img src="${imagePath}" class="copyright__publisher-logo" alt="${name}" />`]
-        : []
+      const media = logoFigure.derivatives?.full
+      if (!media) return []
+
+      const { internal: imagePath } = media.paths
+      if (!imagePath) return []
+
+      return [`<img src="${imagePath}" class="copyright__publisher-logo" alt="${name}" />`]
     })
 
     const { license } = publication

--- a/packages/11ty/_includes/components/copyright/index.js
+++ b/packages/11ty/_includes/components/copyright/index.js
@@ -1,5 +1,4 @@
 import { html } from '#lib/common-tags/index.js'
-import path from 'node:path'
 
 /**
  * Copyright info
@@ -12,18 +11,20 @@ export default function (eleventyConfig) {
   const { config, publication } = eleventyConfig.globalData
 
   const copyrightLicensing = eleventyConfig.getFilter('copyrightLicensing')
+  const getFigureMedia = eleventyConfig.getFilter('getFigureMedia')
   const licenseIcons = eleventyConfig.getFilter('licenseIcons')
   const markdownify = eleventyConfig.getFilter('markdownify')
+  const slugify = eleventyConfig.getFilter('slugify')
 
   return function (params) {
-    const { imageDir } = config.figures
-
     const copyright = publication.copyright
       ? `<p>${markdownify(publication.copyright)}</p>`
       : ''
 
     const publisherImages = publication.publisher.flatMap(({ logo, name }) => {
-      const imagePath = logo && path.posix.join(imageDir, logo)
+      const logoFigure = getFigureMedia(`logo-${slugify(name)}`)
+
+      const imagePath = logo && logoFigure.derivatives.full.paths.internal
 
       return imagePath
         ? [`<img src="${imagePath}" class="copyright__publisher-logo" alt="${name}" />`]

--- a/packages/11ty/_includes/components/head-tags/jsonld.js
+++ b/packages/11ty/_includes/components/head-tags/jsonld.js
@@ -11,6 +11,7 @@ import path from 'node:path'
  * @return     {String}  An HTML script element with JSON-LD
  */
 export default function (eleventyConfig) {
+  const getFigureMedia = eleventyConfig.getFilter('getFigureMedia')
   const { config, publication } = eleventyConfig.globalData
   const { imageDir } = config.figures
 
@@ -106,6 +107,7 @@ export default function (eleventyConfig) {
       identifier: publication.publisher.url
     }
 
+    const promoFigure = getFigureMedia('promo-image')
     const Article = {
       '@type': 'Article',
       author: [...pageContributors],
@@ -118,7 +120,7 @@ export default function (eleventyConfig) {
         author: [...publicationContributors],
         datePublished: publication.pub_date,
         dateModified: publication.revision_history.date,
-        image: publication.promo_image && path.join(imageDir, publication.promo_image),
+        image: promoFigure.derivatives.full.paths.uri,
         license: publication.license.url,
         keywords: publication.subject
           .filter(({ type }) => type === 'keyword')

--- a/packages/11ty/_includes/components/head-tags/opengraph.js
+++ b/packages/11ty/_includes/components/head-tags/opengraph.js
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase */
 import escape from 'html-escape'
+import path from 'node:path'
+
 /**
  * Renders <head> <meta> data tags for Open Graph protocol data
  *
@@ -9,11 +11,15 @@ import escape from 'html-escape'
  * @return     {String}  HTML meta and link elements
  */
 export default function (eleventyConfig) {
-  const { publication } = eleventyConfig.globalData
+  const getFigureMedia = eleventyConfig.getFilter('getFigureMedia')
+  const { config, publication } = eleventyConfig.globalData
 
   return function ({ page }) {
-    const { description, identifier, promo_image, pub_date, pub_type, url } = publication
+    const { description, identifier, pub_date, pub_type } = publication
     const pageType = page && page.type
+
+    const promoFigure = getFigureMedia('promo-image')
+    const coverImage = page.cover ? path.posix.join(config.imageDir, page.cover) : undefined
 
     const meta = [
       {
@@ -22,13 +28,13 @@ export default function (eleventyConfig) {
       },
       {
         property: 'og:url',
-        content: new URL(page.url, url).toString()
+        content: page.canonicalURL
       },
       {
         property: 'og:image',
         content: pageType !== 'essay'
-          ? promo_image
-          : page.cover || promo_image
+          ? promoFigure.derivatives.full.paths.uri
+          : coverImage || promoFigure.derivatives.full.paths.uri
       },
       {
         property: 'og:description',

--- a/packages/11ty/_includes/components/head-tags/twitter-card.js
+++ b/packages/11ty/_includes/components/head-tags/twitter-card.js
@@ -11,18 +11,19 @@ import path from 'node:path'
  * @return     {String}  HTML meta and link elements
  */
 export default function (eleventyConfig) {
+  const getFigureMedia = eleventyConfig.getFilter('getFigureMedia')
   const { config, publication } = eleventyConfig.globalData
-  const { description, promo_image } = publication
+  const { description } = publication
   const { imageDir } = config.figures
 
   return function ({ abstract, cover, layout }) {
+    const promoFigure = getFigureMedia('promo-image')
     const imagePath = () => {
       if (!publication.url) return
-      if (layout !== 'essay') {
-        return promo_image && path.join(imageDir, promo_image)
+      if (layout !== 'essay' || !cover) {
+        return promoFigure.derivatives.full.paths.internal
       } else {
-        const image = cover || promo_image
-        return image && path.join(imageDir, image)
+        return path.posix.join(imageDir, cover)
       }
     }
 

--- a/packages/11ty/_plugins/figures/README.md
+++ b/packages/11ty/_plugins/figures/README.md
@@ -1,16 +1,24 @@
+## Figures Plugin
+
+The figures plugin provides media metadata, asset paths, and tiling or scaling for images in quire publications. The processed images are consumed by components and template code using the `figureMedia` global object and a `getFigureMedia(<id-as-string>)` 11ty filter.
+
+## Overview
+
+Before each publication build, the plugin uses the global figure data added by the globalData plugin from `figures.yaml`, `config.yaml`, and `publication.yaml`.
+
+For each entry in `figures_list`, the plugin uses `FigureFactory` to create a `figureMedia` object. Internally, the factory triggers dimensions metadata inspection, image tile and scaled derivative generation, IIIF manifest creation, and path calculations.
+
+In addition, `epub.defaultCoverImage` from `config.yaml` and `promo_image`, `contributor[].image`, and `publisher[].logo` from `publication.yaml` are made available using the `getFigureMedia` interface.
+
 ## IIIF Processing
 
-Quire's IIIF processing provides methods to prepare images to IIIF 3.0 specification for use with [`canvas-panel`](https://iiif-canvas-panel.netlify.app/docs/components/cp) and [`image-service`](https://iiif-canvas-panel.netlify.app/docs/components/single-image-service) web components.
+For figures with `zoom` set to true, the plugin provides tiled image directory hierarchies and an IIIF 3.0 Presentation API manifest for use with [`canvas-panel`](https://iiif-canvas-panel.netlify.app/docs/components/cp) and its [`image-service`](https://iiif-canvas-panel.netlify.app/docs/components/single-image-service) web components.
 
-Processing iterates over the data in `figures.yaml`, passing each figure entry to an instance of `FigureFactory` to create a `figure` on which a method can be called to generate image tiles, write IIIF manifest JSON files, and perform image transformations.
-
-### Setup
+### Setup and Configuration
 
 The `baseURI` property set in [`config.yaml`](/content/_data/config.yaml) will be used to generate IIIF `@id` properties.
 
 When running the Eleventy development server the `baseURI` is set to `localhost`.
-
-### Config
 
 IIIF configuration options can be found in [`_plugins/figures/iiif/config.js`](iiif/config.js).
 

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -513,7 +513,6 @@ export default class FigureMedia {
       }
 
       case this.mediaType === 'annex-image': {
-        console.log(pathname, imagesDir, this.src)
         const absolute = path.posix.join(pathname, imagesDir, this.src)
         const internal = path.posix.join(imagesDir, this.src)
         const uri = new URL(absolute, baseURI).href

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -409,7 +409,7 @@ export default class FigureMedia {
   /**
    * @function processFigure
    *
-   * Processes figure metadata and asset files into servable assets
+   * Coordinates figure metadata generation and asset file handling
    *
    * @return {Object}
    * @property {Array} errors
@@ -418,23 +418,34 @@ export default class FigureMedia {
   async processFigure () {
     this.errors = []
 
-    if (this.mediaType !== 'image') return {}
+    switch (this.mediaType) {
+      case 'annex-image':
+        // Store dimensions and return
+        await this.calculateDimensions()
+        this.storeDerivativeMetadata('full', { height: this.height, width: this.width })
 
-    await this.calculateDimensions()
+        return { errors: this.errors }
 
-    if (this.isSequence) {
-      await this.processSequenceMedia()
-    } else {
-      await this.processImageMedia()
+      case 'image':
+        await this.calculateDimensions()
+
+        if (this.isSequence) {
+          await this.processSequenceMedia()
+        } else {
+          await this.processImageMedia()
+        }
+
+        await this.processAnnotationsMedia()
+
+        if (this.isCanvas) {
+          await this.createManifest()
+        }
+
+        return { errors: this.errors }
+
+      default:
+        return {}
     }
-
-    await this.processAnnotationsMedia()
-
-    if (this.isCanvas) {
-      await this.createManifest()
-    }
-
-    return { errors: this.errors }
   }
 
   /**
@@ -487,6 +498,7 @@ export default class FigureMedia {
    **/
   storeDerivativeMetadata (name, metadata, outputFilename = null) {
     const { baseURI } = this.iiifConfig
+    const { imagesDir } = this.iiifConfig.dirs
     const { pathname } = new URL(baseURI)
 
     const { height, width } = metadata
@@ -497,6 +509,20 @@ export default class FigureMedia {
       // External resources should pass their URLs unmutated
       case this.isExternalResource: {
         paths = { absolute: this.src, internal: this.src, uri: this.src }
+        break
+      }
+
+      case this.mediaType === 'annex-image': {
+        console.log(pathname, imagesDir, this.src)
+        const absolute = path.posix.join(pathname, imagesDir, this.src)
+        const internal = path.posix.join(imagesDir, this.src)
+        const uri = new URL(absolute, baseURI).href
+
+        paths = {
+          absolute,
+          internal,
+          uri
+        }
         break
       }
 

--- a/packages/11ty/_plugins/figures/iiif/config.js
+++ b/packages/11ty/_plugins/figures/iiif/config.js
@@ -7,6 +7,7 @@ const logger = chalkFactory('Figures:IIIF:Config', 'DEBUG')
 export default (eleventyConfig) => {
   const { url } = eleventyConfig.globalData.publication
   const { inputDir, outputDir, publicDir } = eleventyConfig.globalData.directoryConfig
+  const { imageDir } = eleventyConfig.globalData.config.figures
   const { port = 8080 } = eleventyConfig.serverOptions
 
   const projectRoot = path.resolve(inputDir, '..')
@@ -36,7 +37,7 @@ export default (eleventyConfig) => {
       /**
        * Image file directory relative to `inputRoot`
        */
-      imagesDir: path.join('_assets', 'images'),
+      imagesDir: imageDir,
       /**
        * Root directory for input images
        */

--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -1,8 +1,61 @@
 import FigureMediaFactory from './figureMedia/factory.js'
 import chalkFactory from '#lib/chalk/index.js'
 import iiifConfig from './iiif/config.js'
+import slugify from '@sindresorhus/slugify'
 
 const logger = chalkFactory('Figures', 'DEBUG')
+
+/**
+ * @function prepareAnnexImages
+ *
+ * @param {Object} eleventyConfig - config from which to extract annex images
+ *
+ * @returns {Array}
+ *
+ * Returns annex images from the eleventyConfig mapped to the figure model.
+ * for use with the figureMedia factory.
+ *
+ **/
+const prepareAnnexImages = (eleventyConfig) => {
+  const { defaultCoverImage } = eleventyConfig.globalData.config.epub
+  const { contributor, promo_image: promoImageData, publisher } = eleventyConfig.globalData.publication
+
+  let annexes = []
+  if (promoImageData) {
+    annexes.push({
+      id: 'promo-image',
+      media_type: 'annex-image',
+      src: promoImageData
+    })
+  }
+
+  if (defaultCoverImage) {
+    annexes.push({
+      id: 'epub-default',
+      media_type: 'annex-image',
+      src: defaultCoverImage
+    })
+  }
+
+  const contributorAvatars = (contributor ?? []).filter((contrib) => Boolean(contrib.image)).map((contrib) => {
+    return {
+      id: `contributor-${contrib.id}`,
+      media_type: 'annex-image',
+      src: contrib.image
+    }
+  })
+
+  const publisherLogos = (publisher ?? []).filter((publish) => Boolean(publish.logo)).map((publish) => {
+    return {
+      id: `logo-${slugify(publish.name)}`,
+      media_type: 'annex-image',
+      src: publish.logo
+    }
+  })
+
+  annexes = annexes.concat(contributorAvatars, publisherLogos)
+  return annexes
+}
 
 /**
  * Figures Plugin
@@ -14,14 +67,29 @@ export default function (eleventyConfig, options) {
     const config = iiifConfig(eleventyConfig)
     const figureFactory = new FigureMediaFactory({ ...config, ...options })
 
+    /**
+     * Unwrap figure list and annex image data (eg, contributor and promo images)
+     **/
     const { figure_list: figureList } = eleventyConfig.globalData.figures
 
+    // Run annex assets through the figure factory
+    const annexes = prepareAnnexImages(eleventyConfig)
+    const annexFigures = await Promise.all(
+      annexes.map((data) => {
+        return figureFactory.create(data)
+      })
+    )
+
+    // Run figures through figure factory
     const figures = await Promise.all(
       figureList.map((data) => {
         return figureFactory.create(data)
       })
     )
-    const errors = figureList.filter(({ errors }) => errors && !!errors.length)
+
+    // Combine the lists and check errors
+    const allFigures = annexFigures.concat(figures)
+    const errors = allFigures.filter(({ errors }) => errors && !!errors.length)
 
     if (errors.length) {
       logger.error('There were errors processing the following images:')
@@ -37,7 +105,7 @@ export default function (eleventyConfig, options) {
      * Add IIIFConfig and processed figureMedia to global data
      */
     eleventyConfig.addGlobalData('iiifConfig', config)
-    eleventyConfig.addGlobalData('figureMedia', figures.map(({ figure }) => figure.media()))
+    eleventyConfig.addGlobalData('figureMedia', allFigures.map(({ figure }) => figure.media()))
 
     logger.info('Processing complete')
   })

--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -12,6 +12,7 @@ const logger = chalkFactory('_plugins:epub:manifest')
  * @return {Object}
  */
 export default (eleventyConfig) => {
+  const getFigureMedia = eleventyConfig.getFilter('getFigureMedia')
   const removeHTML = eleventyConfig.getFilter('removeHTML')
   const sortByKeys = eleventyConfig.getFilter('sortByKeys')
 
@@ -23,14 +24,13 @@ export default (eleventyConfig) => {
     description,
     isbn,
     language,
-    promo_image: promoImage,
     pub_date: pubDate,
     publishers,
     readingLine,
     subtitle,
     title
   } = eleventyConfig.globalData.publication
-  const { accessibilityMetadata, epub, figures: { imageDir } } = eleventyConfig.globalData.config
+  const { accessibilityMetadata } = eleventyConfig.globalData.config
 
   /**
    * Contributor name, filtered by type
@@ -55,15 +55,19 @@ export default (eleventyConfig) => {
   }
 
   const cover = () => {
-    const image = promoImage || epub.defaultCoverImage
-    if (!image) {
+    const promoFigure = getFigureMedia('promo-image')
+    const epubDefaultImage = getFigureMedia('epub-default')
+
+    // Use the internal path to align disk file paths correctly
+    const coverPath = promoFigure ? promoFigure.derivatives.full.paths.internal : epubDefaultImage.derivatives.full.paths.internal
+    if (!coverPath) {
       logger.error('Epub requires a cover image defined in publication.promo_image or config.epub.defaultCoverImage.')
       return
     }
 
-    // Remove leading absolute pathing
-    const realtiveImageDir = imageDir.startsWith('/') ? imageDir.slice(1) : imageDir
-    return path.posix.join(realtiveImageDir, image)
+    // Remove leading absolute pathing so it works correctly in epub package
+    const relative = path.posix.relative('/', coverPath)
+    return relative
   }
 
   /**

--- a/packages/11ty/_tests/helpers/index.js
+++ b/packages/11ty/_tests/helpers/index.js
@@ -20,7 +20,9 @@ const stubGlobalData = (stubData, finalizer) => {
         copyButton: {}
       },
       epub: {},
-      figures: { }
+      figures: {
+        imageDir: ''
+      }
     }
     let publication = {}
     const figures = { figure_list: [] }
@@ -78,7 +80,7 @@ const minimalBuildingData = {
       outputDir: '_epub'
     },
     figures: {
-      imageDir: '_assets/images/figures'
+      imageDir: '/_assets/images'
     },
     pageTitle: {
       labelDivider: '. '

--- a/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
+++ b/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
@@ -1,7 +1,7 @@
 /**
- * figures.spec.js
+ * figuresMediaFactory.spec.js
  *
- * Tests for the `figures` plugin
+ * Tests for the figures plugin's `FigureMediaFactory`
  *
  **/
 import esmock from 'esmock'
@@ -11,7 +11,7 @@ import path from 'path'
 import sinon from 'sinon'
 import test from 'ava'
 
-const iiifConfigPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../_plugins/figures/test/__fixtures__/iiif-config.json')
+const iiifConfigPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../_plugins/figures/test/__fixtures__/iiif-config.json')
 
 /**
  * @function MockFigureMediaFactory

--- a/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
+++ b/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
@@ -157,3 +157,7 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
   t.is(height, 1000)
   t.is(width, 1000)
 })
+
+// test('TODO: Any tests specific to the figure media factory to verify behaviors of bare data like that', (t) => {
+//   t.fail('Are there any figure media factory tests for bare data or the poster-style data?')
+// })

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -23,7 +23,7 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
       id,
       figure: {
         id,
-        media: () => { return { id } }        
+        media: () => { return { id } }
       }
     }
   })

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -16,11 +16,11 @@ test.before('', async (t) => {
 
   // Inspectable factory `create` member and eleventyConfig `addGlobalData` members
   const create = sandbox.fake(({ id }) => {
-    //  `media()` gets called at the end of figures plugin init so must exist 
     return {
       id,
       figure: {
         id,
+        // `media()` is called by figures plugin so must exist 
         media: () => { return { id } }
       }
     }

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -17,20 +17,30 @@ test.before('', async (t) => {
 test('Annex publication images (logos, avatars, etc) should be added to figuresMedia globalData', async (t) => {
   const { sandbox } = t.context
 
-  // addGlobalData() and create() functions for testing whether the factory was passed the figure
-  const addGlobalData = sandbox.fake.returns({})
-  const create = sandbox.fake.returns({
-    media: () => { return {} }
+  // fake functions for tracking calls on the factory mock and global data
+  const create = sandbox.fake(({ id }) => {
+    return {
+      id,
+      figure: {
+        id,
+        media: () => { return { id } }        
+      }
+    }
   })
+  const addGlobalData = sandbox.fake()
 
   // Initialize the plugin against a config that auto-runs the plugin's event hook
   const pluginInit = await esmock('#plugins/figures/index.js', {
-    '#plugins/figures/figureMedia/factory.js': { create }
+    '#plugins/figures/figureMedia/factory.js': sandbox.stub().returns({ create })
   })
-  // TODO: Stub globalData with our test figures
+
+  // Stub globalData with our test figures
   const eleventyConfig = {
     addGlobalData,
     globalData: {
+      directoryConfig: {
+        inputDir: 'content', publicDir: 'public'
+      },
       epub: {
         defaultCoverImage: 'test-default-cover.jpg'
       },
@@ -38,27 +48,56 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
         contributor: [
           { id: 'test-contributor', image: 'test-contributor-avatar.jpg' }
         ],
+        promo_image: 'test-promo-image.jpg',
         publisher: [
-          { id: 'test-publisher', logo: 'test-publisher-logo.jpg' }
-        ]
+          { name: 'Test Publisher', logo: 'test-publisher-logo.jpg' }
+        ],
+        url: new URL('http://localhost:8080')
       },
       figures: {
         figure_list: []
       }
     },
-    on: (eventKey, hook) => hook()
+    on: async (eventKey, hook) => {
+      await hook()
+    },
+    serverOptions: {
+      port: 8080
+    }
   }
+
   pluginInit(eleventyConfig, {})
+  console.log('suppers', addGlobalData.notCalled)
+  t.true(create.calledWithMatch(sinon.match({ id: 'promo-image', src: 'test-promo-image.jpg' })),
+    'Figures plugin should process promo image for derivatives')
+  // TODO: Test that addGlobalData was called for this figure
+  // t.true(
+  //   addGlobalData.calledWithMatch(
+  //     sinon.match('figureMedia'),
+  //     sinon.match.has('id', 'promo-image')
+  //   ),
+  //   'globalData should be added for promo image')
 
-  t.true('Figures plugin should process promo image for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
-  t.true('globalData should be added for promo image', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+  t.true(create.calledWithMatch(sinon.match({ id: 'epub-default', src: 'test-default-cover.jpg' })),
+    'Figures plugin should process epub default cover for derivatives')
+  // TODO: Test that addGlobalData was called for this figure
+  // t.true(
+  //   addGlobalData.calledWithMatch(
+  //     sinon.match('figureMedia'),
+  //     sinon.match.has('id', 'promo-image')
+  //   ),
+  //   'globalData should be added for epub default cover'
+  // )
 
-  t.true('Figures plugin should process epub default cover for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
-  t.true('globalData should be added for epub default cover', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+  t.true(create.calledWithMatch(sinon.match({ id: 'logo-test-publisher', src: 'test-publisher-logo.jpg' })),
+    'Figures plugin should process logos for derivatives')
+  // TODO
+  // t.true(addGlobalData.calledWithMatch(sinon.match({ id: '' })),
+  //   'globalData should be added for logos')
 
-  t.true('Figures plugin should process logos for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
-  t.true('globalData should be added for logos', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
-
-  t.true('Figures plugin should process contributor avatars for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
-  t.true('globalData should be added for contributor avatars', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+  t.true(create.calledWithMatch(sinon.match({ id: 'contributor-test-contributor', src: 'test-contributor-avatar.jpg' })),
+    'Figures plugin should process contributor avatars for derivatives')
+  // TODO
+  // t.true(addGlobalData.calledWithMatch(sinon.match({ id: '' })),
+  //   'globalData should be added for contributor avatars')
 })

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -38,11 +38,16 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
   const eleventyConfig = {
     addGlobalData,
     globalData: {
+      config: {
+        epub: {
+          defaultCoverImage: 'test-default-cover.jpg'
+        },
+        figures: {
+          imageDir: '/_assets/images'
+        }
+      },
       directoryConfig: {
         inputDir: 'content', publicDir: 'public'
-      },
-      epub: {
-        defaultCoverImage: 'test-default-cover.jpg'
       },
       publication: {
         contributor: [

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -8,17 +8,15 @@ import test from 'ava'
 import esmock from 'esmock'
 import sinon from 'sinon'
 
+/**
+ * Sets up a sandbox and fake functions for using FigureMediaFactory and globalData
+ **/
 test.before('', async (t) => {
   const sandbox = sinon.createSandbox()
 
-  t.context.sandbox = sandbox
-})
-
-test('Annex publication images (logos, avatars, etc) should be added to figuresMedia globalData', async (t) => {
-  const { sandbox } = t.context
-
-  // fake functions for tracking calls on the factory mock and global data
+  // Inspectable factory `create` member and eleventyConfig `addGlobalData` members
   const create = sandbox.fake(({ id }) => {
+    //  `media()` gets called at the end of figures plugin init so must exist 
     return {
       id,
       figure: {
@@ -29,12 +27,25 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
   })
   const addGlobalData = sandbox.fake()
 
-  // Initialize the plugin against a config that auto-runs the plugin's event hook
+  t.context.sandbox = sandbox
+  t.context.create = create
+  t.context.addGlobalData = addGlobalData
+})
+
+test('Annex publication images (logos, avatars, etc) should be added to figuresMedia globalData', async (t) => {
+  const { addGlobalData, create, sandbox } = t.context
+
+  // Import the plugin with our test function injected as a member
   const pluginInit = await esmock('#plugins/figures/index.js', {
     '#plugins/figures/figureMedia/factory.js': sandbox.stub().returns({ create })
   })
 
-  // Stub globalData with our test figures and fake `addGlobalData`
+  /**
+   * Stub configuration with the test function injected, useable input values,
+   * and a minimal event loop that runs the initialized hooks.
+   *
+   * NB: `on` handlers are called synchronously so `runHooks()` executes the stack
+   **/
   const eleventyConfig = {
     addGlobalData,
     globalData: {
@@ -63,19 +74,19 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
         figure_list: []
       }
     },
-    // `on` and `hooks` mock eleventy's event loop,
-    //  which must be executed on its own to be properly `await`ed
+    _hooks: [],
     on: (eventKey, asyncHook) => {
-      eleventyConfig.hooks.push(asyncHook)
+      eleventyConfig._hooks.push(asyncHook)
     },
-    hooks: [],
+    runHooks: async () => await Promise.all(eleventyConfig._hooks.map((h) => h())),
     serverOptions: {
       port: 8080
     }
   }
 
+  // Initialize the plugin and run the hooks
   pluginInit(eleventyConfig, {})
-  await Promise.all(eleventyConfig.hooks.map((h) => h()))
+  await eleventyConfig.runHooks()
 
   t.true(create.calledWithMatch(sinon.match({ id: 'promo-image', src: 'test-promo-image.jpg' })),
     'Figures plugin should process promo image for derivatives')

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -34,7 +34,7 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
     '#plugins/figures/figureMedia/factory.js': sandbox.stub().returns({ create })
   })
 
-  // Stub globalData with our test figures
+  // Stub globalData with our test figures and fake `addGlobalData`
   const eleventyConfig = {
     addGlobalData,
     globalData: {
@@ -58,46 +58,57 @@ test('Annex publication images (logos, avatars, etc) should be added to figuresM
         figure_list: []
       }
     },
-    on: async (eventKey, hook) => {
-      await hook()
+    // `on` and `hooks` mock eleventy's event loop,
+    //  which must be executed on its own to be properly `await`ed
+    on: (eventKey, asyncHook) => {
+      eleventyConfig.hooks.push(asyncHook)
     },
+    hooks: [],
     serverOptions: {
       port: 8080
     }
   }
 
   pluginInit(eleventyConfig, {})
-  console.log('suppers', addGlobalData.notCalled)
+  await Promise.all(eleventyConfig.hooks.map((h) => h()))
+
   t.true(create.calledWithMatch(sinon.match({ id: 'promo-image', src: 'test-promo-image.jpg' })),
     'Figures plugin should process promo image for derivatives')
-  // TODO: Test that addGlobalData was called for this figure
-  // t.true(
-  //   addGlobalData.calledWithMatch(
-  //     sinon.match('figureMedia'),
-  //     sinon.match.has('id', 'promo-image')
-  //   ),
-  //   'globalData should be added for promo image')
+  t.true(
+    addGlobalData.calledWithMatch(
+      sinon.match('figureMedia'), sinon.match((value) => {
+        return Array.isArray(value) && value.some(d => d.id === 'promo-image')
+      })),
+    'globalData should be added for promo image'
+  )
 
   t.true(create.calledWithMatch(sinon.match({ id: 'epub-default', src: 'test-default-cover.jpg' })),
     'Figures plugin should process epub default cover for derivatives')
-  // TODO: Test that addGlobalData was called for this figure
-  // t.true(
-  //   addGlobalData.calledWithMatch(
-  //     sinon.match('figureMedia'),
-  //     sinon.match.has('id', 'promo-image')
-  //   ),
-  //   'globalData should be added for epub default cover'
-  // )
+  t.true(
+    addGlobalData.calledWithMatch(
+      sinon.match('figureMedia'), sinon.match((value) => {
+        return Array.isArray(value) && value.some(d => d.id === 'epub-default')
+      })),
+    'globalData should be added for epub default cover'
+  )
 
   t.true(create.calledWithMatch(sinon.match({ id: 'logo-test-publisher', src: 'test-publisher-logo.jpg' })),
     'Figures plugin should process logos for derivatives')
-  // TODO
-  // t.true(addGlobalData.calledWithMatch(sinon.match({ id: '' })),
-  //   'globalData should be added for logos')
+  t.true(
+    addGlobalData.calledWithMatch(
+      sinon.match('figureMedia'), sinon.match((value) => {
+        return Array.isArray(value) && value.some(d => d.id === 'logo-test-publisher')
+      })
+    ),
+    'globalData should be added for logos')
 
   t.true(create.calledWithMatch(sinon.match({ id: 'contributor-test-contributor', src: 'test-contributor-avatar.jpg' })),
     'Figures plugin should process contributor avatars for derivatives')
-  // TODO
-  // t.true(addGlobalData.calledWithMatch(sinon.match({ id: '' })),
-  //   'globalData should be added for contributor avatars')
+  t.true(
+    addGlobalData.calledWithMatch(
+      sinon.match('figureMedia'), sinon.match((value) => {
+        return Array.isArray(value) && value.some(d => d.id === 'contributor-test-contributor')
+      })
+    ),
+    'globalData should be added for contributor avatars')
 })

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -20,7 +20,7 @@ test.before('', async (t) => {
       id,
       figure: {
         id,
-        // `media()` is called by figures plugin so must exist 
+        // `media()` is called by figures plugin so must exist
         media: () => { return { id } }
       }
     }

--- a/packages/11ty/_tests/plugins/figures/index.spec.js
+++ b/packages/11ty/_tests/plugins/figures/index.spec.js
@@ -1,0 +1,64 @@
+/**
+ * figures.spec.js
+ *
+ * Tests for the `figures` plugin
+ *
+ **/
+import test from 'ava'
+import esmock from 'esmock'
+import sinon from 'sinon'
+
+test.before('', async (t) => {
+  const sandbox = sinon.createSandbox()
+
+  t.context.sandbox = sandbox
+})
+
+test('Annex publication images (logos, avatars, etc) should be added to figuresMedia globalData', async (t) => {
+  const { sandbox } = t.context
+
+  // addGlobalData() and create() functions for testing whether the factory was passed the figure
+  const addGlobalData = sandbox.fake.returns({})
+  const create = sandbox.fake.returns({
+    media: () => { return {} }
+  })
+
+  // Initialize the plugin against a config that auto-runs the plugin's event hook
+  const pluginInit = await esmock('#plugins/figures/index.js', {
+    '#plugins/figures/figureMedia/factory.js': { create }
+  })
+  // TODO: Stub globalData with our test figures
+  const eleventyConfig = {
+    addGlobalData,
+    globalData: {
+      epub: {
+        defaultCoverImage: 'test-default-cover.jpg'
+      },
+      publication: {
+        contributor: [
+          { id: 'test-contributor', image: 'test-contributor-avatar.jpg' }
+        ],
+        publisher: [
+          { id: 'test-publisher', logo: 'test-publisher-logo.jpg' }
+        ]
+      },
+      figures: {
+        figure_list: []
+      }
+    },
+    on: (eventKey, hook) => hook()
+  }
+  pluginInit(eleventyConfig, {})
+
+  t.true('Figures plugin should process promo image for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
+  t.true('globalData should be added for promo image', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+
+  t.true('Figures plugin should process epub default cover for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
+  t.true('globalData should be added for epub default cover', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+
+  t.true('Figures plugin should process logos for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
+  t.true('globalData should be added for logos', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+
+  t.true('Figures plugin should process contributor avatars for derivatives', create.calledWithMatch(sinon.match({ id: '', src: '' })))
+  t.true('globalData should be added for contributor avatars', addGlobalData.calledWithMatch(sinon.match({ id: '' })))
+})

--- a/packages/11ty/_tests/search.spec.js
+++ b/packages/11ty/_tests/search.spec.js
@@ -14,22 +14,24 @@ const stubData = {
       pagePDF: true
     },
     figures: {
-      imageDir,
-      figure_list: [
-        {
-          id: 'fig1',
-          label: 'Figure 1',
-          caption: 'This is a test figure.',
-          src: 'figure1.jpg',
-          alt: 'A photo of a tree',
-          credit: 'John Doe',
-          mediaType: 'image'
-        }
-      ]
+      imageDir
     },
     pageTitle: {
       labelDivider: '|'
     }
+  },
+  figures: {
+    figure_list: [
+      {
+        id: 'fig1',
+        label: 'Figure 1',
+        caption: 'This is a test figure.',
+        src: 'figure1.jpg',
+        alt: 'A photo of a tree',
+        credit: 'John Doe',
+        mediaType: 'image'
+      }
+    ]
   },
   publication: {
     title: 'Test Publication',
@@ -68,7 +70,7 @@ const collections = {
         canonicalURL: 'https://example.com/test-publication/page1/index.html',
         page: {
           figures: [
-            stubData.config.figures.figure_list[0]
+            stubData.figures.figure_list[0]
           ]
         },
         title: 'Test Page 1',
@@ -92,7 +94,7 @@ const collections = {
         page: {
           canonicalURL: 'https://example.com/test-publication/page3/index.html',
           figures: [
-            stubData.config.figures.figure_list[0]
+            stubData.figures.figure_list[0]
           ]
         },
         title: 'Test Page 2',

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-11ty",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "description": "Quire 11ty static site generator",
   "keywords": [
     "11ty",


### PR DESCRIPTION
This PR refactors the figures plugin to process dimensions metadata and paths about "annex" images from the quire configuration -- epub cover images, promo images, contributor images, and publisher logos. This better aligns plugin functions that share image media dimension checking and asset path calculation requirements and lifts those functions away from front-end components.

This PR is released to `npm` and github releases as `@thegetty/quire-11ty@1.0.1-rc.1`.

This code is responsive to one half of #1197. Some specific implementation / review notes:
  - These changes retain `vite`'s role in bundling these assets for the site's bundle so most of the components affected (exception: `meta` tags) still emit publication-internal paths.
  - Partially handles an issue (#1280) with `og:image` and `twitter:image` tags where assets were either nonexistent or emitted as absolute filepaths.
  - Refactors a few `package/11ty` test harness functions and bootstrap data to better represent actual values.
  - Adds tests and refactors `figures` plugin to better generalize its metadata and path functions for other types of figures, introduces the switching dispatch over `mediaType` that enables the latter half of #1197.
  - Adds an integration test ensuring that og:image tags return assets that will be served in the site bundle.
  - Adds `height` and `width` to contributor avatar images. Adding intrinsic dimensions to the publisher footer images distorted the default layout so are not included here.