### PR TITLE
Update figures plugin to handle poster images and self-hosted video media

### DIFF
--- a/packages/11ty/_includes/components/figure/image/element.js
+++ b/packages/11ty/_includes/components/figure/image/element.js
@@ -44,7 +44,7 @@ export default function (eleventyConfig) {
       case isImageService && !interactive && staticInlineFigureImage:
       case !lightbox && Boolean(staticInlineFigureImage): {
         const { paths, dimensions } = derivatives.staticInlineFigureImage
-        const { height, width } = dimensions
+        const { height, width } = dimensions ?? {}
 
         // Choose media path based on whether path will be loaded as-is or processed by 11ty
         const src = lightbox ? paths.absolute : paths.internal

--- a/packages/11ty/_includes/components/figure/image/print.js
+++ b/packages/11ty/_includes/components/figure/image/print.js
@@ -28,18 +28,20 @@ export default function (eleventyConfig) {
     if (printImage === undefined) return ''
 
     const { paths, dimensions } = printImage
-    const { height, width } = dimensions
+    const { height, width } = dimensions ?? {}
 
     if (!paths.internal) return ''
 
     const labelElement = figureLabel({ caption, id, label })
+    const heightAttr = height ? `height="${height}"` : ''
+    const widthAttr = width ? `width="${width}"` : ''
 
     return html`
       <img alt="${escape(alt)}"
            class="q-figure__image"
-           height="${height}"
-           src="${paths.internal}"
-           width="${width}"/>
+           ${heightAttr}
+           ${widthAttr}
+           src="${paths.internal}" />
       ${figureCaption({ caption, content: labelElement, credit })}
     `
   }

--- a/packages/11ty/_includes/components/figure/video/element.js
+++ b/packages/11ty/_includes/components/figure/video/element.js
@@ -23,13 +23,14 @@ export default function (eleventyConfig) {
   const { imageDir } = eleventyConfig.globalData.config.figures
   const figureMediaEmbedUrl = eleventyConfig.getFilter('figureMediaEmbedUrl')
   const videoElements = {
-    video ({ id, poster = '', src }) {
-      if (!src) {
+    video ({ derivatives, id }) {
+      const { media, staticInlineFigureImage } = derivatives
+      if (!media) {
         logger.error(`Cannot render Video without 'src'. Check that figures data for id: ${id} has a valid 'src'`)
         return ''
       }
 
-      if (!poster) {
+      if (!staticInlineFigureImage) {
         logger.warn(`Figure '${id}' does not have a 'poster' property. A poster image for id: ${id} will not be rendered`)
       }
 
@@ -38,9 +39,9 @@ export default function (eleventyConfig) {
         <video
           class="q-figure-video-element"
           controls
-          poster="${poster}"
+          poster="${staticInlineFigureImage?.paths?.internal}"
         >
-          <source src="${src}" type="video/mp4"/>
+          <source src="${media.paths.internal}" type="video/mp4"/>
           ${unsupported}
         </video>
       `

--- a/packages/11ty/_includes/components/figure/video/print.js
+++ b/packages/11ty/_includes/components/figure/video/print.js
@@ -1,6 +1,5 @@
 import { html } from '#lib/common-tags/index.js'
 import chalkFactory from '#lib/chalk/index.js'
-import path from 'node:path'
 
 const logger = chalkFactory('Figure Video')
 
@@ -16,25 +15,22 @@ export default function (eleventyConfig) {
   const figureCaption = eleventyConfig.getFilter('figureCaption')
   const figureLabel = eleventyConfig.getFilter('figureLabel')
 
-  const { imageDir } = eleventyConfig.globalData.config.figures
-
   return function ({
     aspect_ratio: aspectRatio,
     caption,
     credit,
+    derivatives,
     id,
     label,
     mediaId,
-    mediaType,
-    poster = ''
+    mediaType
   }) {
-    if (!poster) {
+    const { printImage } = derivatives
+    if (!printImage) {
       logger.warn(`Figure '${id}' does not have a 'poster' property. Print media will not render a fallback image for id: ${id}`)
     }
 
-    const posterSrc = poster.startsWith('http')
-      ? poster
-      : path.posix.join(imageDir, poster)
+    const posterSrc = printImage.paths.internal
     const labelElement = figureLabel({ caption, id, label })
     const captionElement = figureCaption({ caption, content: labelElement, credit, mediaId, mediaType })
 

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -111,6 +111,7 @@ export default class FigureMedia {
       label,
       media_id: mediaId,
       media_type: mediaType,
+      poster,
       src,
       zoom
     } = data
@@ -147,6 +148,7 @@ export default class FigureMedia {
     this.outputDir = outputDir
     this.outputPathname = outputPathname
     this.outputFormat = format && format.output
+    this.poster = poster
     this.processImage = imageProcessor
     this.src = src
 
@@ -379,27 +381,49 @@ export default class FigureMedia {
   async calculateDimensions () {
     let height, width
 
-    // Fetch dimensions from IIIF via `Fetch` or the disk via `sharp`
-    if (this.iiifImage) {
-      try {
-        const terminatedUrl = this.iiifImage.endsWith('/') ? this.iiifImage : this.iiifImage + '/'
+    // Fetch dimensions depending on the figure's details 
+    switch (true) {
+      // Get metadata details directly from IIIF via `Fetch`
+      case (this.iiifImage): {
+        try {
+          const terminatedUrl = this.iiifImage.endsWith('/') ? this.iiifImage : this.iiifImage + '/'
 
-        const infoUrl = new URL('info.json', terminatedUrl)
-        const info = await Fetch(infoUrl.href, { type: 'json' })
+          const infoUrl = new URL('info.json', terminatedUrl)
+          const info = await Fetch(infoUrl.href, { type: 'json' })
 
-        height = info.height
-        width = info.width
-      } catch (error) {
-        logger.error(`Could not fetch metadata for figure ${this.id} with error ${error}!`)
-        return
+          height = info.height
+          width = info.width
+        } catch (error) {
+          logger.error(`Could not fetch metadata for figure ${this.id} with error ${error}!`)
+          return
+        }
+
+        break      
       }
-    } else {
-      try {
-        ({ height, width } = await sharp(this.imageFilePath).metadata())
-      } catch (error) {
-        logger.error(`Could not read metadata for figure ${this.id}: ${error}!`)
-        return
-      }
+
+      // Only handle image dimensions from media embeds with posters
+      case 'video':
+      case 'soundcloud':
+      case 'youtube':
+      case 'vimeo':
+        if (!this.poster) return
+
+        try {
+          ({ height, width } = await sharp(this.imageFilePath).metadata())
+        } catch (error) {
+          logger.error(`Could not read metadata for poster ${this.id}: ${error}!`)
+          return
+        }
+        break
+
+      // By default use `sharp` and the image on disk
+      default:
+        try {
+          ({ height, width } = await sharp(this.imageFilePath).metadata())
+        } catch (error) {
+          logger.error(`Could not read metadata for figure ${this.id}: ${error}!`)
+          return
+        }
     }
 
     this.height = height
@@ -558,7 +582,7 @@ export default class FigureMedia {
       case ['video', 'soundcloud', 'youtube', 'audio'].includes(this.mediaType): {
         // NB: Transformed derivatives are stored in a directory with the name of the transform and a filename of <name>.<format>
         outputFilename ??= `${name}.jpg`
-        const directory = this.iiifImage ? slugify(this.iiifImage) : path.parse(this.data.poster).name
+        const directory = this.iiifImage ? slugify(this.iiifImage) : path.parse(this.poster).name
 
         // `internal` is used without a leading slash for path math
         // then made absolutely internal, relative to the publication root
@@ -627,7 +651,7 @@ export default class FigureMedia {
    *
    */
   async processImageMedia () {
-    if (!(this.src || this.iiifImage || this.data.poster)) return
+    if (!(this.src || this.iiifImage || this.poster)) return
 
     const { transformations } = this.iiifConfig
 
@@ -658,7 +682,7 @@ export default class FigureMedia {
       case 'youtube':
       case 'vimeo':
       case 'soundcloud':
-        imageSrc = this.data.poster
+        imageSrc = this.poster
         break
 
       default:

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -402,10 +402,10 @@ export default class FigureMedia {
       }
 
       // Only handle image dimensions from media embeds with posters
-      case 'video':
-      case 'soundcloud':
-      case 'youtube':
-      case 'vimeo':
+      case (this.mediaType === 'video'):
+      case (this.mediaType === 'soundcloud'):
+      case (this.mediaType === 'youtube'):
+      case (this.mediaType === 'vimeo'):
         if (!this.poster) return
 
         try {

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -223,7 +223,7 @@ export default class FigureMedia {
       return path.join(firstSequenceItemDirname, firstSequenceItemFilename)
     }
 
-    const imagePath = this.src || firstChoiceSrc() || firstSequenceItemSrc()
+    const imagePath = this.src || this.poster || firstChoiceSrc() || firstSequenceItemSrc()
     if (!imagePath) {
       this.errors.push(`Invalid figure ID "${this.id}". Figures with annotations must have "choice" annotations or a "src" property.`)
       return
@@ -443,6 +443,36 @@ export default class FigureMedia {
 
         return { errors: this.errors }
 
+      case 'youtube':
+      case 'vimeo':
+      case 'video':
+      case 'soundcloud': {
+        // Handle poster image if it exists
+        await this.calculateDimensions()
+        await this.processImageMedia()
+
+        // Handle media URL, assigning a pure URL if the video is hosted externally
+        if (this.mediaType === 'video') {
+          const { baseURI } = this.iiifConfig
+          const { imagesDir } = this.iiifConfig.dirs
+          const { pathname } = new URL(baseURI)
+
+          const internal = !this.isExternalResource ? path.posix.join(imagesDir, this.src) : this.src
+          const absolute = !this.isExternalResource ? path.posix.join(pathname, internal) : this.src
+          const uri = !this.isExternalResource ? urlPathJoin(baseURI, internal) : this.src
+
+          this.derivatives.media = {
+            paths: {
+              absolute,
+              internal,
+              uri
+            }
+          }
+        }
+
+        return { errors: this.errors }
+      }
+
       default:
         return {}
     }
@@ -525,6 +555,24 @@ export default class FigureMedia {
         break
       }
 
+      case ['video', 'soundcloud', 'youtube', 'audio'].includes(this.mediaType): {
+        // NB: Transformed derivatives are stored in a directory with the name of the transform and a filename of <name>.<format>
+        outputFilename ??= `${name}.jpg`
+        const directory = this.iiifImage ? slugify(this.iiifImage) : path.parse(this.data.poster).name
+
+        // `internal` is used without a leading slash for path math
+        // then made absolutely internal, relative to the publication root
+        const internal = path.posix.join(this.outputPathname, directory, outputFilename)
+        const absolute = path.posix.join(pathname, internal)
+        const uri = urlPathJoin(baseURI, internal)
+
+        paths = {
+          absolute,
+          internal: path.posix.join('/', internal),
+          uri
+        }
+        break
+      }
       default: {
         // NB: Transformed derivatives are stored in a directory with the name of the transform and a filename of <name>.<format>
         outputFilename ??= `${name}.jpg`
@@ -561,11 +609,14 @@ export default class FigureMedia {
     }
 
     this.derivatives[property] = {
-      dimensions: {
+      paths
+    }
+
+    if (height && width) {
+      this.derivatives[property].dimensions = {
         height,
         width
-      },
-      paths
+      }
     }
   }
 
@@ -576,7 +627,7 @@ export default class FigureMedia {
    *
    */
   async processImageMedia () {
-    if (!(this.src || this.iiifImage)) return
+    if (!(this.src || this.iiifImage || this.data.poster)) return
 
     const { transformations } = this.iiifConfig
 
@@ -601,8 +652,20 @@ export default class FigureMedia {
       options.tile = true
     }
 
-    const { errors, metadata } = await this.processImage(this.src ?? this.iiifImage, this.outputDir, options)
+    let imageSrc
+    switch (this.mediaType) {
+      case 'video':
+      case 'youtube':
+      case 'vimeo':
+      case 'soundcloud':
+        imageSrc = this.data.poster
+        break
 
+      default:
+        imageSrc = this.src ?? this.iiifImage
+    }
+
+    const { errors, metadata } = await this.processImage(imageSrc, this.outputDir, options)
     if (errors) this.errors = this.errors.concat(errors)
 
     // Store path and dimensions data for each transformation

--- a/packages/11ty/_plugins/figures/figureMedia/index.js
+++ b/packages/11ty/_plugins/figures/figureMedia/index.js
@@ -381,7 +381,7 @@ export default class FigureMedia {
   async calculateDimensions () {
     let height, width
 
-    // Fetch dimensions depending on the figure's details 
+    // Fetch dimensions depending on the figure's details
     switch (true) {
       // Get metadata details directly from IIIF via `Fetch`
       case (this.iiifImage): {
@@ -398,7 +398,7 @@ export default class FigureMedia {
           return
         }
 
-        break      
+        break
       }
 
       // Only handle image dimensions from media embeds with posters

--- a/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
+++ b/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
@@ -158,3 +158,29 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
   t.is(height, 1000)
   t.is(width, 1000)
 })
+
+test('Media factory should correctly handle metadata and posters for video figures', async (t) => {
+  // Set up a figure to be transformed
+  const { iiifConfig, sandbox } = t.context
+  const figure = {
+    id: 'video-figure',
+    src: 'cat-1-video.mp4',
+    poster: 'cat-1-video-poster.jpg',
+    mediaType: 'video'
+  }
+
+  // Fake processor for checking in on media derivative operations
+  const processor = sandbox.fake.returns({ errors: [], metadata: { full: { height: 1000, width: 1000 } } })
+  const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, processor)
+  await factoryRoot.create(figure)
+
+  // Test that video poster is transformed
+  t.truthy(
+    processor.calledWith(
+      sinon.match('cat-1-video-poster.jpg'),
+      sinon.match('iiif/video-figure'),
+      sinon.match((val) => ('transformations' in val && val.transformations.length > 0) && !('tile' in val))
+    ),
+    'Videos and audios with poster images should have their posters transformed'
+  )
+})

--- a/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
+++ b/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
@@ -166,7 +166,7 @@ test('Media factory should correctly handle metadata and posters for video figur
     id: 'video-figure',
     src: 'cat-1-video.mp4',
     poster: 'cat-1-video-poster.jpg',
-    mediaType: 'video'
+    media_type: 'video'
   }
 
   // Fake processor for checking in on media derivative operations
@@ -185,12 +185,12 @@ test('Media factory should correctly handle metadata and posters for video figur
   )
 
   // Check output paths and dimensions are correct
-  const { printImage, media } = figureMedia.derivatives
+  const { full, media } = figureMedia.derivatives
 
-  t.truthy(printImage.paths.internal === '/iiif/video-figure/print.jpg',
+  t.truthy(full.paths.internal === '/iiif/video-figure/cat-1-video-poster/full.jpg',
     'Video printImage from poster should have paths')
-  t.truthy(printImage.dimensions.height > 0 && printImage.dimensions.width > 0,
+  t.truthy(full.dimensions.height > 0 && full.dimensions.width > 0,
     'Video printImage from poster should have dimensions')
-  t.truthy(media.paths.internal === '/_assets/images/cat-1-video.mp4',
+  t.truthy(media.paths.internal === '_assets/images/cat-1-video.mp4',
     'Video media should have paths')
 })

--- a/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
+++ b/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
@@ -172,9 +172,9 @@ test('Media factory should correctly handle metadata and posters for video figur
   // Fake processor for checking in on media derivative operations
   const processor = sandbox.fake.returns({ errors: [], metadata: { full: { height: 1000, width: 1000 } } })
   const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, processor)
-  await factoryRoot.create(figure)
+  const { figure: figureMedia } = await factoryRoot.create(figure)
 
-  // Test that video poster is transformed
+  // Test that the poster is transformed but not tiled
   t.truthy(
     processor.calledWith(
       sinon.match('cat-1-video-poster.jpg'),
@@ -183,4 +183,14 @@ test('Media factory should correctly handle metadata and posters for video figur
     ),
     'Videos and audios with poster images should have their posters transformed'
   )
+
+  // Check output paths and dimensions are correct
+  const { printImage, media } = figureMedia.derivatives
+
+  t.truthy(printImage.paths.internal === '/iiif/video-figure/print.jpg',
+    'Video printImage from poster should have paths')
+  t.truthy(printImage.dimensions.height > 0 && printImage.dimensions.width > 0,
+    'Video printImage from poster should have dimensions')
+  t.truthy(media.paths.internal === '/_assets/images/cat-1-video.mp4',
+    'Video media should have paths')
 })

--- a/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
+++ b/packages/11ty/_tests/plugins/figures/figureMediaFactory.spec.js
@@ -60,15 +60,17 @@ test('FigureMediaFactory should use unmutated `src` properties for figure images
   }
 
   // Test that src will be passed unmutated to the paths on figureMedia
-  const noopProcessor = async (path, _, options) => {
-    return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
-  }
+  const processor = sandbox.fake.returns({ errors: [], metadata: { full: { height: 1000, width: 1000 } } })
+  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, processor)
 
-  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, noopProcessor)
   const { figure: figureModel } = await factory.create(figure)
   const figureMedia = figureModel.media()
 
   const { derivatives } = figureMedia
+
+  // Check that the processor was not called?
+  t.falsy(processor.callCount,
+    'The figures processor should not be called on URL sources')
 
   // Check that the paths of each transformation are unmutated
   for (const [name, derivative] of Object.entries(derivatives)) {
@@ -92,20 +94,19 @@ test('FigureMediaFactory should create derivatives for zoomable figures', async 
   }
 
   // Check whether the figure will be processed as zoomed and tiled
-  let passed = false
-  const zoomedAndTiled = async (path, _, options) => {
-    passed = options.transformations?.length > 0 && options.tile && !options.iiifEndpoint
-    return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
-  }
-
-  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, zoomedAndTiled)
+  const processor = sandbox.fake.returns({ errors: [], metadata: { full: { height: 1000, width: 1000 } } })
+  const factory = await MockFigureMediaFactory(sandbox, iiifConfig, processor)
   await factory.create(figure)
 
-  if (passed) {
-    t.pass()
-  } else {
-    t.fail()
-  }
+  // Check if processor was called with at least one transformation and tile=true
+  t.truthy(
+    processor.calledWith(
+      sinon.match('iiif-figure.jpg'),
+      sinon.match('iiif/iiif-figure'),
+      sinon.match.has('transformations', sinon.match.some(sinon.match.defined)).and(sinon.match.has('tile', sinon.match.truthy))
+    ),
+    'IIIF figures should be processed for transformations and tiling'
+  )
 })
 
 test('FigureMediaFactory should create a staticInlineFigureImage for static figures', async (t) => {
@@ -116,22 +117,22 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
     src: 'static-figure.jpg'
   }
 
-  // Set up a mock processor that checks whether the right options are passed in
-  let passed = false
-  const transformedNotTiled = async (path, _, options) => {
-    passed = options.transformations?.length > 0 && !options.tile && !options.iiifEndpoint
-    return { errors: [], metadata: { full: { height: 1000, width: 1000 } } }
-  }
-
-  const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, transformedNotTiled)
+  // Fake processor for checking in on media derivative operations
+  const processor = sandbox.fake.returns({ errors: [], metadata: { full: { height: 1000, width: 1000 } } })
+  const factoryRoot = await MockFigureMediaFactory(sandbox, iiifConfig, processor)
   await factoryRoot.create(figure)
 
-  if (!passed) {
-    t.fail()
-  }
+  t.truthy(
+    processor.calledWith(
+      sinon.match('static-figure.jpg'),
+      sinon.match('iiif/static-figure'),
+      sinon.match((val) => ('transformations' in val && val.transformations.length > 0) && !('tile' in val))
+    ),
+    'Image figures without zoom should be transformed but not tiled'
+  )
 
   iiifConfig.baseURI = new URL('subpath', iiifConfig.baseURI).href
-  const factorySubpath = await MockFigureMediaFactory(sandbox, iiifConfig, transformedNotTiled)
+  const factorySubpath = await MockFigureMediaFactory(sandbox, iiifConfig, processor)
   const { figure: subpathFigureMedia } = await factorySubpath.create(figure)
 
   const { paths, dimensions } = subpathFigureMedia.derivatives.full
@@ -157,7 +158,3 @@ test('FigureMediaFactory should create a staticInlineFigureImage for static figu
   t.is(height, 1000)
   t.is(width, 1000)
 })
-
-// test('TODO: Any tests specific to the figure media factory to verify behaviors of bare data like that', (t) => {
-//   t.fail('Are there any figure media factory tests for bare data or the poster-style data?')
-// })


### PR DESCRIPTION
This PR refactors the figures plugin so it manages derivatives for video and audio figures that use `poster` images and lifts the concern for poster image and media asset pathing out of the component. This is the second and final part of #1197, where all path calculations and derivative handling is now located in the figures plugin and emitted as data for direct consumption by page components. It is based on #1279 and should be reviewed after that PR.

Review notes and implementation details:
- Refactors existing figure media factory tests to better use sinon’s `fake` and `match` APIs for less test code repetition and complexity.
- Adds test paths ensuring that poster images for video and audio figures are processed, and that calculated paths for self-hosted video files are included in figure media objects. 
- Adds conditionals to `processImageMedia()` to have the factory use the figure’s `poster` value as the source for the print, static inline, etc images.
- Refactors existing figure audio, video components to use pre-calculated paths for poster and print images and self-hosted video asset paths.
- Fixes a regression from #1279 where missing image dimensions cause builds to fail.